### PR TITLE
added tokudb_status

### DIFF
--- a/bin/pt-stalk
+++ b/bin/pt-stalk
@@ -838,6 +838,7 @@ collect() {
       local mutex="SHOW MUTEX STATUS"
    fi
    innodb_status 1
+   tokudb_status 1
    $CMD_MYSQL $EXT_ARGV -e "$mutex" >> "$d/$p-mutex-status1" &
    open_tables                      >> "$d/$p-opentables1"   &
 
@@ -988,6 +989,7 @@ collect() {
    fi
 
    innodb_status 2
+   tokudb_status 2
    $CMD_MYSQL $EXT_ARGV -e "$mutex" >> "$d/$p-mutex-status2" &
    open_tables                      >> "$d/$p-opentables2"   &
 
@@ -1055,13 +1057,20 @@ transactions() {
    $CMD_MYSQL $EXT_ARGV -e "SELECT SQL_NO_CACHE * FROM INFORMATION_SCHEMA.INNODB_LOCK_WAITS\G"
 }
 
+tokudb_status() {
+    local n=$1
+
+    $CMD_MYSQL $EXT_ARGV -e "SHOW ENGINE TOKUDB STATUS\G" \
+      >> "$d/$p-tokudbstatus$n" || rm -f "$d/$p-tokudbstatus$n"
+}
+
 innodb_status() {
    local n=$1
 
    local innostat=""
 
    $CMD_MYSQL $EXT_ARGV -e "SHOW /*!40100 ENGINE*/ INNODB STATUS\G" \
-      >> "$d/$p-innodbstatus$n"
+      >> "$d/$p-innodbstatus$n" || rm -f $d/$p-tokudbstatus$n
    grep "END OF INNODB" "$d/$p-innodbstatus$n" >/dev/null || {
       if [ -d /proc -a -d /proc/$mysqld_pid ]; then
          for fd in /proc/$mysqld_pid/fd/*; do

--- a/bin/pt-stalk
+++ b/bin/pt-stalk
@@ -1070,7 +1070,7 @@ innodb_status() {
    local innostat=""
 
    $CMD_MYSQL $EXT_ARGV -e "SHOW /*!40100 ENGINE*/ INNODB STATUS\G" \
-      >> "$d/$p-innodbstatus$n" || rm -f $d/$p-tokudbstatus$n
+      >> "$d/$p-innodbstatus$n"
    grep "END OF INNODB" "$d/$p-innodbstatus$n" >/dev/null || {
       if [ -d /proc -a -d /proc/$mysqld_pid ]; then
          for fd in /proc/$mysqld_pid/fd/*; do


### PR DESCRIPTION
Frank: This adds a simple tokudb_status function copied from the existing innodb_status one, that does not create the files if the client returns an error (as that would imply the engine is unknown to the server). 
I did minimal testing on an instance with and without tokudb and it behaved as expected. 