### PR TITLE
pt-osc: added --sleep option. Useful when load or lag checking is not…

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -9260,6 +9260,12 @@ sub main {
          $sys_load_pr->start() if $sys_load_pr;
          $sys_load->wait(Progress => $sys_load_pr);
 
+         # sleep between chunks to avoid overloading PXC nodes
+         my $sleep = $args{NibbleIterator}->{OptionParser}->get('sleep');
+         if ( $sleep ) {
+            sleep $sleep;
+         }
+
          return;
       },
       done => sub {
@@ -11494,6 +11500,15 @@ example, specifying C<--set-vars wait_timeout=500> overrides the default
 value of C<10000>.
 
 The tool prints a warning and continues if a variable cannot be set.
+
+=item --sleep
+
+type: float; default: 0
+
+How long to sleep (in seconds) after copying each chunk. This option is useful 
+when throttling by L<"--max-lag"> and L<"--max-load"> are not possible. 
+A small, sub-second value should be used, like 0.1, else the tool could take 
+a very long time to copy large tables.
 
 =item --socket
 


### PR DESCRIPTION
The --sleep option specifies a time in seconds to wait after inserting each chunk of rows in the new table.
This is a palliative measure for when lag or load checking is not possible.
Note: The value is float, so you can specify fractions of a second.