### PR TITLE
pt-archiver purge and no-delete are mutually exclusive - lp1452914

### DIFF
--- a/bin/pt-archiver
+++ b/bin/pt-archiver
@@ -5559,6 +5559,9 @@ sub main {
       if ( $bulk_del && $limit < 2 ) {
          $o->save_error("--bulk-delete is meaningless with --limit 1");
       }
+      if ( $o->got('purge') && $o->got('no-delete') ) {
+         $o->save_error("--purge and --no-delete are mutually exclusive");
+      }
    }
 
    if ( $bulk_del || $o->get('bulk-insert') ) {


### PR DESCRIPTION
Makes --no-delete and --purge options (which are incompatible) mutually exclusive