### PR TITLE
pt-sift failed to download missing tools

### DIFF
--- a/bin/pt-sift
+++ b/bin/pt-sift
@@ -579,7 +579,7 @@ main() {
          eval "PR_$prog_base"="${BASEDIR}/$prog"
       elif which "curl" >/dev/null 2>&1; then
          echo "Fetching $prog" >&2
-         curl "http://www.percona.com/get/$prog" > "$prog" && chmod +x "$prog"
+         curl -L "https://www.percona.com/get/$prog" > "$prog" && chmod +x "$prog"
          eval "PR_$prog_base"="./$prog"
       else
          echo "Cannot find or fetch required program: $prog" >&2


### PR DESCRIPTION
pt-sift uses some other tools so it checks if they are present and downloads them using "curl" if missing.
This started to fail once percona.com website protocol changed to https.
Solved changing to http->https and also adding redirect option to curl "-L" for good measure.
 