### PR TITLE
DSN doc: need to escape commas in password

### DIFF
--- a/bin/pt-archiver
+++ b/bin/pt-archiver
@@ -7147,6 +7147,7 @@ TABLE.
 short form: -p; type: string
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item --pid
 
@@ -7616,6 +7617,7 @@ Plugin module name.
 dsn: password; copy: yes
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 

--- a/bin/pt-config-diff
+++ b/bin/pt-config-diff
@@ -5672,6 +5672,7 @@ Connect to host.
 dsn: password; copy: yes
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 

--- a/bin/pt-deadlock-logger
+++ b/bin/pt-deadlock-logger
@@ -5330,6 +5330,7 @@ Express IP addresses as integers.
 short form: -p; type: string
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item --pid
 
@@ -5457,6 +5458,7 @@ Connect to host.
 dsn: password; copy: yes
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 

--- a/bin/pt-duplicate-key-checker
+++ b/bin/pt-duplicate-key-checker
@@ -5367,6 +5367,7 @@ Check for duplicate f=foreign keys, k=keys or fk=both.
 short form: -p; type: string
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item --pid
 
@@ -5509,6 +5510,7 @@ Connect to host.
 dsn: password; copy: yes
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 

--- a/bin/pt-find
+++ b/bin/pt-find
@@ -4386,6 +4386,7 @@ complicated expressions with parentheses and mixtures of OR and AND.
 short form: -p; type: string
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item --pid
 
@@ -4879,6 +4880,7 @@ Connect to host.
 dsn: password; copy: yes
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 

--- a/bin/pt-fk-error-logger
+++ b/bin/pt-fk-error-logger
@@ -4322,6 +4322,7 @@ Print all output to this file when daemonized.
 short form: -p; type: string
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item --pid
 
@@ -4444,6 +4445,7 @@ Connect to host.
 dsn: password; copy: yes
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 

--- a/bin/pt-heartbeat
+++ b/bin/pt-heartbeat
@@ -5877,6 +5877,7 @@ L<"--frames">.  For example,
 short form: -p; type: string
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item --pid
 
@@ -6117,6 +6118,7 @@ Connect to host.
 dsn: password; copy: yes
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 

--- a/bin/pt-index-usage
+++ b/bin/pt-index-usage
@@ -7127,6 +7127,7 @@ Ignore tables whose names match the Perl regex.
 short form: -p; type: string
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item --port
 
@@ -7443,6 +7444,7 @@ Connect to host.
 dsn: password; copy: yes
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 

--- a/bin/pt-kill
+++ b/bin/pt-kill
@@ -7611,6 +7611,7 @@ MAGIC_create_log_table:
 short form: -p; type: string
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item --pid
 
@@ -8138,6 +8139,7 @@ Connect to host.
 dsn: password; copy: yes
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 

--- a/bin/pt-mysql-summary
+++ b/bin/pt-mysql-summary
@@ -2959,6 +2959,7 @@ Host to connect to.
 short form: -p; type: string
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item --port
 

--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -11378,6 +11378,7 @@ exist.
 short form: -p; type: string
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item --pid
 
@@ -11692,6 +11693,7 @@ Connect to host.
 dsn: password; copy: yes
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 

--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -15791,6 +15791,7 @@ so the data structure may change in future versions.
 short form: -p; type: string
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item --pid
 
@@ -16384,6 +16385,7 @@ Connect to host.
 dsn: password; copy: yes
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 

--- a/bin/pt-show-grants
+++ b/bin/pt-show-grants
@@ -2190,6 +2190,7 @@ Only show grants for this comma-separated list of users.
 short form: -p; type: string
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item --pid
 
@@ -2302,6 +2303,7 @@ Connect to host.
 dsn: password; copy: yes
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 

--- a/bin/pt-slave-delay
+++ b/bin/pt-slave-delay
@@ -4625,6 +4625,7 @@ Print all output to this file when daemonized.
 short form: -p; type: string
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item --pid
 
@@ -4764,6 +4765,7 @@ Connect to host.
 dsn: password; copy: yes
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 

--- a/bin/pt-slave-find
+++ b/bin/pt-slave-find
@@ -4089,6 +4089,7 @@ Connect to host.
 short form: -p; type: string
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item --pid
 
@@ -4264,6 +4265,7 @@ Connect to host.
 dsn: password; copy: yes
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 

--- a/bin/pt-slave-restart
+++ b/bin/pt-slave-restart
@@ -5567,6 +5567,7 @@ explicitly, L<"--stop"> will disable it.
 short form: -p; type: string
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item --pid
 
@@ -5832,6 +5833,7 @@ Connect to host.
 dsn: password; copy: yes
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 

--- a/bin/pt-stalk
+++ b/bin/pt-stalk
@@ -1893,6 +1893,7 @@ Send an email to these addresses for every L<"--collect">.
 short form: -p; type: string
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item --pid
 

--- a/bin/pt-table-checksum
+++ b/bin/pt-table-checksum
@@ -12236,6 +12236,7 @@ you notice queueing, it is best to decrease the chunk time.
 short form: -p; type: string; group: Connection
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item --pid
 
@@ -12694,6 +12695,7 @@ Connect to host.
 dsn: password; copy: yes
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 

--- a/bin/pt-table-sync
+++ b/bin/pt-table-sync
@@ -12317,6 +12317,7 @@ replication or the like.  Tables are locked with LOCK TABLES.
 short form: -p; type: string
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item --pid
 
@@ -12619,6 +12620,7 @@ Connect to host.
 dsn: password; copy: yes
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 

--- a/bin/pt-table-usage
+++ b/bin/pt-table-usage
@@ -7334,6 +7334,7 @@ Print all output to this file when daemonized.
 short form: -p; type: string
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item --pid
 
@@ -7460,6 +7461,7 @@ Connect to host.
 dsn: password; copy: yes
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 

--- a/bin/pt-upgrade
+++ b/bin/pt-upgrade
@@ -11191,6 +11191,7 @@ on by default.
 dsn: password; copy: yes
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 

--- a/bin/pt-variable-advisor
+++ b/bin/pt-variable-advisor
@@ -5906,6 +5906,7 @@ to ignore.
 short form: -p; type: string
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item --pid
 
@@ -6034,6 +6035,7 @@ Connect to host.
 dsn: password; copy: yes
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 

--- a/bin/pt-visual-explain
+++ b/bin/pt-visual-explain
@@ -3047,6 +3047,7 @@ Connect to host.
 short form: -p; type: string
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item --pid
 
@@ -3139,6 +3140,7 @@ Connect to host.
 dsn: password; copy: yes
 
 Password to use when connecting.
+If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 


### PR DESCRIPTION
Added to all tool docs the need to escape commas in the DSN spec
 