### PR TITLE
Changes needed to build packages from git tree (BLD-271)

### DIFF
--- a/config/deb/control
+++ b/config/deb/control
@@ -6,8 +6,8 @@ Build-Depends: debhelper (>= 4.2)
 Build-Depends-Indep: perl (>= 5.6.0-16)
 Standards-Version: 3.7.2
 Homepage: http://www.percona.com/software/percona-toolkit/
-Vcs-Browser: http://bazaar.launchpad.net/~percona-toolkit-dev/percona-toolkit/0.9/files
-Vcs-Bzr: bzr+ssh://bazaar.launchpad.net/~percona-toolkit-ddev/percona-toolkit/0.9/
+Vcs-Browser: https://github.com/percona/percona-toolkit
+Vcs-Git: git://github.com/percona/percona-toolkit.git
 
 Package: percona-toolkit
 Architecture: all

--- a/util/build-packages
+++ b/util/build-packages
@@ -86,8 +86,8 @@ TAR=${TAR:-tar}
 
 check_branch() {
    echo -n "Checking branch... "
-   local clean_branch=$(bzr version-info --check-clean | grep -i 'clean: True')
-   if [ -z "$clean_branch" ]; then
+   local clean_branch=$(git status --porcelain|wc -l)
+   if [ "$clean_branch" -gt 0 ]; then
       die "The branch has uncommitted changes or unknown files"
    fi
    echo "OK"
@@ -491,9 +491,9 @@ if [ $BUILD -eq 1 ]; then
 Branch verified and updated; ready to build $PKG,
 but first you must:
 
-  1. bzr diff and review the changes (Changelog, percon-toolkit.pod, etc.)
-  2. bzr commit -m "Build $PKG"
-  3. bzr push
+  1. git diff and review the changes (Changelog, percon-toolkit.pod, etc.)
+  2. git commit -m "Build $PKG"
+  3. git push
 
 Press any key to continue... (or Ctrl-C to abort)
 MSG


### PR DESCRIPTION
Some minor changes in build-packages script to allow building packages from git source tree and also updated info in debian control file for github.

Here's how build looks:

**Build test when there are changes in the tree - staged and non-staged**
vagrant@t-ubuntu1204-64:/vagrant/percona-toolkit/util$ ./build-packages 2.2.14 ../../release_notes.rst                                                                                                                                 
Checking branch... The branch has uncommitted changes or unknown files

**Update files with new version**
vagrant@t-ubuntu1204-64:/vagrant/percona-toolkit/util$ ./build-packages 2.2.15 ../../release_notes.rst
Checking branch... OK
Checking new version 2.2.15... OK
Checking Changelog... OK
Checking release_notes.rst... OK
Updating version in tools... OK
Updating version in Makefile.PL... OK
Updating version in percona-toolkit.pod... OK
Updating version in sphinx-build/conf.py... OK
Updating copyright year in tools... OK
Updating copyright year in percona-toolkit.pod... OK
Updating MANIFEST... OK
Updating TOOLS section in percona-toolkit.pod... OK
Updating Changelog... OK
Updating Debian changelog... OK
Updating release_notes.rst... OK

**Build packages**
vagrant@t-ubuntu1204-64:/vagrant/percona-toolkit/util$ ./build-packages 2.2.15 ../../release_notes.rst

Branch verified and updated; ready to build percona-toolkit-2.2.15,
but first you must:

  1. git diff and review the changes (Changelog, percon-toolkit.pod, etc.)
  2. git commit -m "Build percona-toolkit-2.2.15"
  3. git push

Press any key to continue... (or Ctrl-C to abort)

Preparing release directory... OK
Building percona-toolkit-2.2.15.tar.gz... OK
Building percona-toolkit-2.2.15-1.noarch.rpm... OK
Building percona-toolkit_2.2.15-1_all.deb... OK
Done building percona-toolkit-2.2.15.  Packages are in /vagrant/percona-toolkit/release