### PR TITLE
enable support for RDS in pt-kill

### DIFF
--- a/bin/pt-kill
+++ b/bin/pt-kill
@@ -7642,6 +7642,13 @@ Note that this is a digest (or hash) of the query's "fingerprint",
 so queries of the same form but with different values will have the same ID.
 See pt-query-digest for more information.
 
+=item --rds
+Denotes the instance in question is on Amazon RDS. By default pt-kill runs
+the MySQL command "kill" for L<"--kill"> and "kill query" L<"--kill-query">.
+On RDS these two commands are not available and are replaced by function calls.
+This option modifies L<"--kill"> to use "CALL mysql.rds_kill(thread-id)" instead
+and L<"--kill-query"> to use "CALL mysql.rds_kill_query(thread-id)"
+
 =item --run-time
 
 type: time

--- a/bin/pt-kill
+++ b/bin/pt-kill
@@ -6709,7 +6709,13 @@ sub main {
    my $proc_sth;
    my $kill;          # callback to KILL
    my $kill_sth;
-   my $kill_sql = $o->get('kill-query') ? 'KILL QUERY ?' : 'KILL ?';
+   my $kill_sql;
+   if ( $o->get('rds') ){
+       $kill_sql = $o->get('kill-query') ? 'CALL mysql.rds_kill_query(?)' : 'CALL mysql.rds_kill(?)';
+   }
+   else{
+       $kill_sql = $o->get('kill-query') ? 'KILL QUERY ?' : 'KILL ?';
+   }
    my $files;
    if ( $files = $o->get('test-matching') ) {
       PTDEBUG && _d('Getting processlist from files:', @$files);
@@ -7643,6 +7649,7 @@ so queries of the same form but with different values will have the same ID.
 See pt-query-digest for more information.
 
 =item --rds
+
 Denotes the instance in question is on Amazon RDS. By default pt-kill runs
 the MySQL command "kill" for L<"--kill"> and "kill query" L<"--kill-query">.
 On RDS these two commands are not available and are replaced by function calls.


### PR DESCRIPTION
The standard way to kill a query in MySQL is to run the command "kill query [thread-id]" and the way to kill a connection is the command "kill [thread-id]". The script pt-kill uses the earlier if you specify --kill-query and the later if you specify --kill in the options.

Unfortunately due to limited privileges, we are not able to run these commands in RDS. RDS provides stored procedure analogous to those two commands for us to use. These procedures run using a system similar to setuid to run the commands as a more privileged user. The procedure for "kill [thread-id]" is "CALL mysql.rds_kill( [thread-id] )" and "CALL mysql.rds_kill_query( [thread-id] )" for "kill query [thread-id]".

http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.MySQL.CommonDBATasks.html

This patch enables RDS support for pt-kill. It adds a new flag ```--rds``` which makes the pt-kill script use the RDS procedure calls instead.