### PR TITLE
pt-archiver multple slave lag and OptionParser repeatable option

### DIFF
--- a/bin/pt-archiver
+++ b/bin/pt-archiver
@@ -784,6 +784,7 @@ sub new {
       'default'    => 1,
       'cumulative' => 1,
       'negatable'  => 1,
+      'repeatable' => 1,  # means it can be specified more than once
    );
 
    my $self = {
@@ -974,6 +975,7 @@ sub _pod_to_specs {
             desc  => $para
                . (defined $attribs{default} ? " (default $attribs{default})" : ''),
             group => ($attribs{'group'} ? $attribs{'group'} : 'default'),
+            attributes => \%attribs
          };
       }
       while ( $para = <$fh> ) {
@@ -1027,6 +1029,7 @@ sub _parse_specs {
 
          $opt->{is_negatable}  = $opt->{spec} =~ m/!/        ? 1 : 0;
          $opt->{is_cumulative} = $opt->{spec} =~ m/\+/       ? 1 : 0;
+         $opt->{is_repeatable} = $opt->{attributes}->{repeatable} ? 1 : 0;
          $opt->{is_required}   = $opt->{desc} =~ m/required/ ? 1 : 0;
 
          $opt->{group} ||= 'default';
@@ -1170,11 +1173,21 @@ sub _set_option {
          return;
       }
       else {
-         $opt->{value} = $val;
+         if ($opt->{is_repeatable}) {
+            push @{$opt->{value}} , $val;
+         }
+         else {
+            $opt->{value} = $val;
+         }
       }
    }
    else {
-      $opt->{value} = $val;
+      if ($opt->{is_repeatable}) {
+         push @{$opt->{value}} , $val;
+      }
+      else {
+         $opt->{value} = $val;
+      }
    }
    $opt->{got} = 1;
    PTDEBUG && _d('Got option', $long, '=', $val);
@@ -1628,6 +1641,14 @@ sub _read_config_file {
          $parse  = 0;
          next LINE;
       }
+
+      if (  $parse
+            && !$self->has('version-check')
+            && $line =~ /version-check/
+      ) {
+         next LINE;
+      }
+
       if ( $parse
          && (my($opt, $arg) = $line =~ m/^\s*([^=\s]+?)(?:\s*=\s*(.*?)\s*)?$/)
       ) {
@@ -5713,17 +5734,23 @@ sub main {
    # ########################################################################
    # Get lag dbh.
    # ########################################################################
-   my $lag_dbh;
+   my @lag_dbh;
    my $ms;
    if ( $o->get('check-slave-lag') ) {
       my $dsn_defaults = $dp->parse_options($o);
-      my $dsn  = $dp->parse($o->get('check-slave-lag'), $dsn_defaults);
-      $lag_dbh = $dp->get_dbh($dp->get_cxn_params($dsn), { AutoCommit => 1 });
-      $ms      = new MasterSlave(
+      my $lag_slaves_dsn = $o->get('check-slave-lag');
+      $ms = new MasterSlave(
          OptionParser => $o,
          DSNParser    => $dp,
          Quoter       => $q,
       );
+      # we get each slave's connection handler (and its id, for debug and reporting)
+      for my $slave (@$lag_slaves_dsn) {
+         my $dsn                 = $dp->parse($slave, $dsn_defaults);
+         my $lag_dbh             = $dp->get_dbh($dp->get_cxn_params($dsn), { AutoCommit => 1 });
+         my $lag_id              = $ms->short_host($dsn);
+         push @lag_dbh , {'dbh' => $lag_dbh, 'id' => $lag_id}
+      }
    }
 
    # ########################################################################
@@ -6305,12 +6332,19 @@ sub main {
       }
 
       # Check slave lag and wait if slave is too far behind.
-      if ( $lag_dbh ) {
-         my $lag = $ms->get_slave_lag($lag_dbh);
-         while ( !defined $lag || $lag > $o->get('max-lag') ) {
-            PTDEBUG && _d('Sleeping: slave lag is', $lag);
-            sleep($o->get('check-interval'));
-            $lag = $ms->get_slave_lag($lag_dbh);
+      foreach my $lag_server (@lag_dbh) {
+         my $lag_dbh = $lag_server->{'dbh'};
+         my $id      = $lag_server->{'id'};
+         if ( $lag_dbh ) {
+            my $lag = $ms->get_slave_lag($lag_dbh);
+            while ( !defined $lag || $lag > $o->get('max-lag') ) {
+               PTDEBUG && _d("Sleeping: slave lag for server '$id' is", $lag);
+               if ($o->got('progress')) {
+                  _d("Sleeping: slave lag for server '$id' is", $lag);
+               }  
+               sleep($o->get('check-interval'));
+               $lag = $ms->get_slave_lag($lag_dbh);
+            }
          }
       }
    }  # ROW 
@@ -6883,9 +6917,10 @@ How often to check for slave lag if L<"--check-slave-lag"> is given.
 
 =item --check-slave-lag
 
-type: string
+type: string; repeatable: yes
 
 Pause archiving until the specified DSN's slave lag is less than L<"--max-lag">.
+This option can be specified multiple times for checking more than one slave.
 
 =item --columns
 


### PR DESCRIPTION
Added the the possibility to mark an option as "repeatable" in OptionParser module.
This allows for options to be specified multiple time to create an array, instead of overwriting the previous definition.
This was then used in pt-archiver to be able to define multiple --check-slave-lag options and to check those slaves in a loop. (separating multiple DSNs by a comma was not practical due to regex limitations and the DSN format)
Note that this does not affect previous behaviour of tools because only options marked as "repeatable" are affected, and this was used only in pt-archiver for the --check-slave-lag option, and handled specially for it.
The ability to mark an option as repeatable may be used later on for other options (e.g --set-vars) 
 