### PR TITLE
added missing user dir in docs

### DIFF
--- a/docs/user/README
+++ b/docs/user/README
@@ -1,0 +1,1 @@
+directory used for user documentation


### PR DESCRIPTION
Added missing docs/user directory where all PT documentation is generated and saved
Perhaps it got lost during transition from Launchpad due to it being empty at the moment and GIT doesn't track empty dirs?
Anyway, added a simple README file to be able to track it from now on.
