### PR TITLE
pt-osc chunk-size-limit=0 skips tables - lp1441928

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -9068,7 +9068,7 @@ sub main {
                   tbl   => $tbl,
                );
                PTDEBUG && _d('Table on',$slave->name(),'has', $n_rows, 'rows');
-               if ( $n_rows && $n_rows > ($tbl->{chunk_size} * $limit) ) {
+               if ( $limit && $n_rows && $n_rows > ($tbl->{chunk_size} * $limit) ) {
                   PTDEBUG && _d('Table too large on', $slave->name());
                   push @too_large, [$slave->name(), $n_rows || 0];
                }

--- a/t/pt-online-schema-change/basics.t
+++ b/t/pt-online-schema-change/basics.t
@@ -716,6 +716,25 @@ ok(
 ) or diag($test_diff);
 
 # #############################################################################
+#  --chunk-size-limit=0  must not skip tables that would be chunked 
+#  in one nibble
+#  https://bugs.launchpad.net/percona-toolkit/+bug/1441928
+# #############################################################################
+
+($output, $exit) = full_output(
+   sub { pt_online_schema_change::main(@args,
+      "$dsn,D=sakila,t=actor", qw(--chunk-size-limit 0 --alter-foreign-keys-method drop_swap --execute --alter ENGINE=InnoDB)) },
+   stderr => 1,
+);
+
+like(
+      $output,
+      qr/Successfully altered/i,
+      "--chunk-size-limit=0  doesn't skip tables - lp1441928"
+);
+
+
+# #############################################################################
 # --default-engine
 # #############################################################################
 


### PR DESCRIPTION
Background: 
a) The option --chunk-size-limit is meant to put an upper limit to the size of a chunk that pt-osc will copy to the new, altered table. (otherwise it bails)
b) It also plays a role in deciding if a table can be copied in one chunk and if the table in the slave can also be copied in one chunk (otherwise it bails)

Problem:
Setting --chunk-size-limit=0 is supposed to suppress checking for a chunk size limit.
This is true for (a), but it fails in the case of (b) ... i.e , It always bails in the case of a single chunk copy.

Solution:
Simply skip checking chunk size for case (b) if chunk-size-limit=0

Added test case 
