### PR TITLE
pt-archiver timeout when waiting for lag

### DIFF
--- a/bin/pt-archiver
+++ b/bin/pt-archiver
@@ -6311,6 +6311,8 @@ sub main {
             PTDEBUG && _d('Sleeping: slave lag is', $lag);
             sleep($o->get('check-interval'));
             $lag = $ms->get_slave_lag($lag_dbh);
+            $src->{dbh}->do("SELECT 'pt-archiver keepalive'") if $src;
+            $dst->{dbh}->do("SELECT 'pt-archiver keepalive'") if $dst;
          }
       }
    }  # ROW 


### PR DESCRIPTION
when innodb_kill_idle_transaction is set and waiting for slave lag exceeds that time, pt-archiver bails when slave catches up.

fixed by issuing a "keepalive" dummy query every slave lag check.
