### PR TITLE
pt-slave-restart fix for MariaDB 10.0 and above

### DIFF
--- a/bin/pt-slave-restart
+++ b/bin/pt-slave-restart
@@ -5004,7 +5004,7 @@ sub watch_server {
    # transaction is not possible with SQL_SLAVE_SKIP_COUNTER
    my $skip_event;
    my $have_gtid = 0;
-   if ( VersionParser->new($dbh) >= '5.6.5' ) {
+   if ( VersionParser->new($dbh) >= '5.6.5' && VersionParser->new($dbh) <= '10.0.0' ) {
       my $row = $dbh->selectrow_arrayref('SELECT @@GLOBAL.gtid_mode');
       PTDEBUG && _d('@@GLOBAL.gtid_mode:', $row->[0]);
       if ( $row && $row->[0] eq 'ON' ) {


### PR DESCRIPTION
pt-slave-restart is broken on MariaDB 10.0 and above, because VersionParser only checks if the version number is superior to 5.6.5. By checking as well that version number is also inferior to 10.0.0, that allows pt-slave-restart to function with MariaDB 10.0 and above, given that GTID replication errors can be skipped safely using the Sql_slave_skip_counter method.