### PR TITLE
Fix #1508401 Specify GPL Version in the RPm metadata

### DIFF
--- a/config/rpm/percona-toolkit.spec
+++ b/config/rpm/percona-toolkit.spec
@@ -3,7 +3,7 @@ Summary:   Advanced MySQL and system command-line tools
 Version:   %{version}
 Release:   %{release}
 Group:     Applications/Databases
-License:   GPL
+License:   GPLv2
 Vendor:    Percona
 URL:       http://www.percona.com/software/percona-toolkit/
 Source:    percona-toolkit-%{version}.tar.gz


### PR DESCRIPTION
The License field in the Percona-toolkit RPM is GPL. This does not tell
the version of GPL and might confuse tools and users that rely on this
field.

Best practice in the RPM world is to use "GPLv2" for the GPL 2.0
license.

The commit switches the license field of the RPM to GPLv2.