### PR TITLE
Changing default character set of the checksums table to utf8

### DIFF
--- a/bin/pt-table-checksum
+++ b/bin/pt-table-checksum
@@ -12491,7 +12491,7 @@ structure (MAGIC_create_replicate):
      ts             TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
      PRIMARY KEY (db, tbl, chunk),
      INDEX ts_db_tbl (ts, db, tbl)
-  ) ENGINE=InnoDB;
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 Note: lower_boundary and upper_boundary data type can be BLOB. See L<"--binary-index">.
 


### PR DESCRIPTION
Not setting explicitly the character set breaks the checksums
when using a default binary collation (the standard on all
Wikimedia sites). MySQL 5.5 and above has a system charset
of utf8 and it is not possible to change it without recompiling.

Bug: https://bugs.launchpad.net/percona-toolkit/+bug/1485195