### PR TITLE
Add option "--[no]vertical-format"

### DIFF
--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -14353,7 +14353,7 @@ sub print_reports {
             explain_why  => $explain_why,
             files        => $args{files},
             log_type     => $o->get('type')->[0],
-            no_v_format  => 0,
+            no_v_format  => !$o->get('vertical-format'),
             variations   => $o->get('variations'),
             group        => { map { $_=>1 } qw(rusage date hostname files header) },
             resume       => $resume,
@@ -16350,6 +16350,15 @@ output.  This feature should never interfere with the normal operation of the
 tool.  
 
 For more information, visit L<https://www.percona.com/version-check>.
+
+=item --[no]vertical-format
+
+default: yes
+
+Output a trailing "\G" in the reported SQL queries.
+
+This makes the mysql client to display the result using vertical format.
+Non-native MySQL clients like phpMyAdmin do not support this.
 
 =item --watch-server
 

--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -6965,14 +6965,14 @@ sub query_report {
 
          PTDEBUG && _d("Fingerprint\n#    $vals->{item}\n");
 
-         $report .= $self->tables_report(@{$vals->{tables}});
+         $report .= $self->tables_report($vals->{tables}, \%args);
 
          if ( $vals->{crc} ) {
             $report.= "# CRC " . ($vals->{crc} % 1_000) . "\n";
          }
 
          my $log_type = $args{log_type} || '';
-         my $mark     = '\G';
+         my $mark     = $args{no_v_format} ? '' : '\G';
 
          if ( $item =~ m/^(?:[\(\s]*select|insert|replace)/ ) {
             if ( $item =~ m/^(?:insert|replace)/ ) { # No EXPLAIN
@@ -6995,7 +6995,7 @@ sub query_report {
       else {
          if ( $groupby eq 'tables' ) {
             my ( $db, $tbl ) = $self->Quoter->split_unquote($item);
-            $report .= $self->tables_report([$db, $tbl]);
+            $report .= $self->tables_report([ [$db, $tbl] ], \%args);
          }
          $report .= "$item\n";
       }
@@ -7654,18 +7654,19 @@ sub pref_sort {
 }
 
 sub tables_report {
-   my ( $self, @tables ) = @_;
-   return '' unless @tables;
+   my ( $self, $tables_ref, $args_ref ) = @_;
+   return '' unless @$tables_ref;
    my $q      = $self->Quoter();
    my $tables = "";
-   foreach my $db_tbl ( @tables ) {
+   my $mark   = $args_ref->{no_v_format} ? '' : '\G';
+   foreach my $db_tbl ( @$tables_ref ) {
       my ( $db, $tbl ) = @$db_tbl;
       $tables .= '#    SHOW TABLE STATUS'
                . ($db ? " FROM `$db`" : '')
-               . " LIKE '$tbl'\\G\n";
+               . " LIKE '$tbl'${mark}\n";
       $tables .= "#    SHOW CREATE TABLE "
                . $q->quote(grep { $_ } @$db_tbl)
-               . "\\G\n";
+               . "${mark}\n";
    }
    return $tables ? "# Tables\n$tables" : "# No tables\n";
 }
@@ -8037,16 +8038,17 @@ override query_report => sub {
             default_db => $default_db,
             Quoter     => $q,
          );
+         my $mark = $args{no_v_format} ? '' : '\G';
          foreach my $db_tbl ( @table_names ) {
             my ( $db, $tbl ) = @$db_tbl;
             my $status
                = 'SHOW TABLE STATUS'
                . ($db ? " FROM `$db`" : '')
-               . " LIKE '$tbl'\\G";
+               . " LIKE '$tbl'${mark}";
             my $create
                = "SHOW CREATE TABLE "
                . $q->quote(grep { $_ } @$db_tbl)
-               . "\\G";
+               . ${mark};
             push @tables, { status => $status, create => $create };
          }
 
@@ -14350,6 +14352,7 @@ sub print_reports {
             explain_why  => $explain_why,
             files        => $args{files},
             log_type     => $o->get('type')->[0],
+            no_v_format  => 0,
             variations   => $o->get('variations'),
             group        => { map { $_=>1 } qw(rusage date hostname files header) },
             resume       => $resume,

--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -8039,6 +8039,7 @@ override query_report => sub {
             Quoter     => $q,
          );
          my $mark = $args{no_v_format} ? '' : '\G';
+
          foreach my $db_tbl ( @table_names ) {
             my ( $db, $tbl ) = @$db_tbl;
             my $status

--- a/lib/JSONReportFormatter.pm
+++ b/lib/JSONReportFormatter.pm
@@ -350,6 +350,7 @@ override query_report => sub {
             Quoter     => $q,
          );
          my $mark = $args{no_v_format} ? '' : '\G';
+
          foreach my $db_tbl ( @table_names ) {
             my ( $db, $tbl ) = @$db_tbl;
             my $status

--- a/lib/JSONReportFormatter.pm
+++ b/lib/JSONReportFormatter.pm
@@ -349,16 +349,17 @@ override query_report => sub {
             default_db => $default_db,
             Quoter     => $q,
          );
+         my $mark = $args{no_v_format} ? '' : '\G';
          foreach my $db_tbl ( @table_names ) {
             my ( $db, $tbl ) = @$db_tbl;
             my $status
                = 'SHOW TABLE STATUS'
                . ($db ? " FROM `$db`" : '')
-               . " LIKE '$tbl'\\G";
+               . " LIKE '$tbl'${mark}";
             my $create
                = "SHOW CREATE TABLE "
                . $q->quote(grep { $_ } @$db_tbl)
-               . "\\G";
+               . ${mark};
             push @tables, { status => $status, create => $create };
          }
 

--- a/lib/QueryReportFormatter.pm
+++ b/lib/QueryReportFormatter.pm
@@ -472,7 +472,7 @@ sub query_report {
          PTDEBUG && _d("Fingerprint\n#    $vals->{item}\n");
 
          # Print tables used by query.
-         $report .= $self->tables_report(@{$vals->{tables}});
+         $report .= $self->tables_report($vals->{tables}, \%args);
 
          # Print sample (worst) query's CRC % 1_000.  We mod 1_000 because
          # that's actually the value stored in the ea, not the full checksum.
@@ -484,7 +484,7 @@ sub query_report {
          }
 
          my $log_type = $args{log_type} || '';
-         my $mark     = '\G';
+         my $mark     = $args{no_v_format} ? '' : '\G';
 
          if ( $item =~ m/^(?:[\(\s]*select|insert|replace)/ ) {
             if ( $item =~ m/^(?:insert|replace)/ ) { # No EXPLAIN
@@ -508,7 +508,7 @@ sub query_report {
       else {
          if ( $groupby eq 'tables' ) {
             my ( $db, $tbl ) = $self->Quoter->split_unquote($item);
-            $report .= $self->tables_report([$db, $tbl]);
+            $report .= $self->tables_report([ [$db, $tbl] ], \%args);
          }
          $report .= "$item\n";
       }
@@ -1262,20 +1262,21 @@ sub pref_sort {
    }
 }
 
-# Gets a default database and a list of arrayrefs of [db, tbl] to print out
+# Gets an arrayref of [db, tbl] arrayrefs pairs to print out
 sub tables_report {
-   my ( $self, @tables ) = @_;
-   return '' unless @tables;
+   my ( $self, $tables_ref, $args_ref ) = @_;
+   return '' unless @$tables_ref;
    my $q      = $self->Quoter();
    my $tables = "";
-   foreach my $db_tbl ( @tables ) {
+   my $mark   = $args_ref->{no_v_format} ? '' : '\G';
+   foreach my $db_tbl ( @$tables_ref ) {
       my ( $db, $tbl ) = @$db_tbl;
       $tables .= '#    SHOW TABLE STATUS'
                . ($db ? " FROM `$db`" : '')
-               . " LIKE '$tbl'\\G\n";
+               . " LIKE '$tbl'${mark}\n";
       $tables .= "#    SHOW CREATE TABLE "
                . $q->quote(grep { $_ } @$db_tbl)
-               . "\\G\n";
+               . "${mark}\n";
    }
    return $tables ? "# Tables\n$tables" : "# No tables\n";
 }

--- a/t/pt-query-digest/json.t
+++ b/t/pt-query-digest/json.t
@@ -38,6 +38,15 @@ ok(
    ),
    'json output for slow002'
 ) or diag($test_diff);
+ok(
+   no_diff(
+      sub { pt_query_digest::main(qw(--no-vertical-format), @args,
+                                  "$sample/slowlogs/slow002.txt") },
+      "$results/slow002_no_vertical.txt",
+      sed => [ qq/'s!$trunk!TRUNK!'/ ],
+   ),
+   'json output for slow002 with --no-vertical-format'
+) or diag($test_diff);
 
 ok(
    no_diff(
@@ -47,6 +56,15 @@ ok(
       sed => [ qq/'s!$trunk!TRUNK!'/ ],
    ),
    'json-anon output for slow002'
+) or diag($test_diff);
+ok(
+   no_diff(
+      sub { pt_query_digest::main(qw(--output json-anon --no-vertical-format),
+         "$sample/slowlogs/slow002.txt") },
+      "$results/slow002-anon_no_vertical.txt",
+      sed => [ qq/'s!$trunk!TRUNK!'/ ],
+   ),
+   'json-anon output for slow002 with --no-vertical-format'
 ) or diag($test_diff);
 
 # --type tcpdump

--- a/t/pt-query-digest/samples/json/slow002-anon_no_vertical.txt
+++ b/t/pt-query-digest/samples/json/slow002-anon_no_vertical.txt
@@ -1,0 +1,269 @@
+
+{
+   "classes" : [
+      {
+         "attribute" : "fingerprint",
+         "checksum" : "66825DDC008FFA89",
+         "distillate" : "UPDATE db?.tuningdetail_?_? db?.gonzo",
+         "fingerprint" : "update d?tuningdetail_?_? n inner join d?gonzo a using(gonzo) set n.column? = a.column?, n.word? = a.word?",
+         "histograms" : {
+            "Query_time" : [
+               0,
+               0,
+               0,
+               0,
+               0,
+               1,
+               0,
+               0
+            ]
+         },
+         "metrics" : {
+            "Filesort" : {
+               "yes" : "0"
+            },
+            "Filesort_on_disk" : {
+               "yes" : "0"
+            },
+            "Full_join" : {
+               "yes" : "0"
+            },
+            "Full_scan" : {
+               "yes" : "1"
+            },
+            "Lock_time" : {
+               "avg" : "0.000091",
+               "max" : "0.000091",
+               "median" : "0.000091",
+               "min" : "0.000091",
+               "pct" : "0.125000",
+               "pct_95" : "0.000091",
+               "stddev" : "0.000000",
+               "sum" : "0.000091"
+            },
+            "Merge_passes" : {
+               "avg" : "0",
+               "max" : "0",
+               "median" : "0",
+               "min" : "0",
+               "pct" : "0",
+               "pct_95" : "0",
+               "stddev" : "0",
+               "sum" : "0"
+            },
+            "QC_Hit" : {
+               "yes" : "0"
+            },
+            "Query_length" : {
+               "avg" : "129",
+               "max" : "129",
+               "median" : "129",
+               "min" : "129",
+               "pct" : "0",
+               "pct_95" : "129",
+               "stddev" : "0",
+               "sum" : "129"
+            },
+            "Query_time" : {
+               "avg" : "0.726052",
+               "max" : "0.726052",
+               "median" : "0.726052",
+               "min" : "0.726052",
+               "pct" : "0.125000",
+               "pct_95" : "0.726052",
+               "stddev" : "0.000000",
+               "sum" : "0.726052"
+            },
+            "Rows_examined" : {
+               "avg" : "62951",
+               "max" : "62951",
+               "median" : "62951",
+               "min" : "62951",
+               "pct" : "0",
+               "pct_95" : "62951",
+               "stddev" : "0",
+               "sum" : "62951"
+            },
+            "Rows_sent" : {
+               "avg" : "0",
+               "max" : "0",
+               "median" : "0",
+               "min" : "0",
+               "pct" : "0",
+               "pct_95" : "0",
+               "stddev" : "0",
+               "sum" : "0"
+            },
+            "Tmp_table" : {
+               "yes" : "0"
+            },
+            "Tmp_table_on_disk" : {
+               "yes" : "0"
+            },
+            "db" : {
+               "value" : "db1"
+            },
+            "host" : {
+               "value" : ""
+            },
+            "user" : {
+               "value" : "[SQL_SLAVE]"
+            }
+         },
+         "query_count" : 1,
+         "tables" : [
+            {
+               "create" : "SHOW CREATE TABLE `db2`.`tuningdetail_21_265507`",
+               "status" : "SHOW TABLE STATUS FROM `db2` LIKE 'tuningdetail_21_265507'"
+            },
+            {
+               "create" : "SHOW CREATE TABLE `db1`.`gonzo`",
+               "status" : "SHOW TABLE STATUS FROM `db1` LIKE 'gonzo'"
+            }
+         ],
+         "ts_max" : "2007-12-18 11:48:27",
+         "ts_min" : "2007-12-18 11:48:27"
+      }
+   ],
+   "global" : {
+      "files" : [
+         {
+            "name" : "TRUNK/t/lib/samples/slowlogs/slow002.txt",
+            "size" : 3841
+         }
+      ],
+      "metrics" : {
+         "Filesort" : {
+            "cnt" : "0"
+         },
+         "Filesort_on_disk" : {
+            "cnt" : "0"
+         },
+         "Full_join" : {
+            "cnt" : "0"
+         },
+         "Full_scan" : {
+            "cnt" : "1"
+         },
+         "InnoDB_IO_r_bytes" : {
+            "avg" : "0",
+            "max" : "0",
+            "median" : "0",
+            "min" : "0",
+            "pct_95" : "0",
+            "stddev" : "0",
+            "sum" : "0"
+         },
+         "InnoDB_IO_r_ops" : {
+            "avg" : "0",
+            "max" : "0",
+            "median" : "0",
+            "min" : "0",
+            "pct_95" : "0",
+            "stddev" : "0",
+            "sum" : "0"
+         },
+         "InnoDB_IO_r_wait" : {
+            "avg" : "0.000000",
+            "max" : "0.000000",
+            "median" : "0.000000",
+            "min" : "0.000000",
+            "pct_95" : "0.000000",
+            "stddev" : "0.000000",
+            "sum" : "0.000000"
+         },
+         "InnoDB_pages_distinct" : {
+            "avg" : "17",
+            "max" : "24",
+            "median" : "17",
+            "min" : "11",
+            "pct_95" : "23",
+            "stddev" : "3",
+            "sum" : "107"
+         },
+         "InnoDB_queue_wait" : {
+            "avg" : "0.000000",
+            "max" : "0.000000",
+            "median" : "0.000000",
+            "min" : "0.000000",
+            "pct_95" : "0.000000",
+            "stddev" : "0.000000",
+            "sum" : "0.000000"
+         },
+         "InnoDB_rec_lock_wait" : {
+            "avg" : "0.000000",
+            "max" : "0.000000",
+            "median" : "0.000000",
+            "min" : "0.000000",
+            "pct_95" : "0.000000",
+            "stddev" : "0.000000",
+            "sum" : "0.000000"
+         },
+         "Lock_time" : {
+            "avg" : "0.000038",
+            "max" : "0.000091",
+            "median" : "0.000026",
+            "min" : "0.000000",
+            "pct_95" : "0.000089",
+            "stddev" : "0.000028",
+            "sum" : "0.000304"
+         },
+         "Merge_passes" : {
+            "avg" : "0",
+            "max" : "0",
+            "median" : "0",
+            "min" : "0",
+            "pct_95" : "0",
+            "stddev" : "0",
+            "sum" : "0"
+         },
+         "QC_Hit" : {
+            "cnt" : "0"
+         },
+         "Query_length" : {
+            "avg" : "62",
+            "max" : "129",
+            "median" : "62",
+            "min" : "5",
+            "pct_95" : "124",
+            "stddev" : "34",
+            "sum" : "502"
+         },
+         "Query_time" : {
+            "avg" : "0.095260",
+            "max" : "0.726052",
+            "median" : "0.000516",
+            "min" : "0.000012",
+            "pct_95" : "0.705093",
+            "stddev" : "0.231765",
+            "sum" : "0.762080"
+         },
+         "Rows_examined" : {
+            "avg" : "7868",
+            "max" : "62951",
+            "median" : "0",
+            "min" : "0",
+            "pct_95" : "61003",
+            "stddev" : "20174",
+            "sum" : "62951"
+         },
+         "Rows_sent" : {
+            "avg" : "0",
+            "max" : "0",
+            "median" : "0",
+            "min" : "0",
+            "pct_95" : "0",
+            "stddev" : "0",
+            "sum" : "0"
+         },
+         "Tmp_table" : {
+            "cnt" : "0"
+         },
+         "Tmp_table_on_disk" : {
+            "cnt" : "0"
+         }
+      },
+      "query_count" : 8,
+      "unique_query_count" : 7
+   }
+}

--- a/t/pt-query-digest/samples/json/slow002_no_vertical.txt
+++ b/t/pt-query-digest/samples/json/slow002_no_vertical.txt
@@ -1,0 +1,275 @@
+
+{
+   "classes" : [
+      {
+         "attribute" : "fingerprint",
+         "checksum" : "66825DDC008FFA89",
+         "distillate" : "UPDATE db?.tuningdetail_?_? db?.gonzo",
+         "example" : {
+            "Query_time" : "0.726052",
+            "as_select" : "select  n.column1 = a.column1, n.word3 = a.word3 from db2.tuningdetail_21_265507 n\n      inner join db1.gonzo a using(gonzo) ",
+            "query" : "update db2.tuningdetail_21_265507 n\n      inner join db1.gonzo a using(gonzo) \n      set n.column1 = a.column1, n.word3 = a.word3",
+            "ts" : "2007-12-18 11:48:27"
+         },
+         "fingerprint" : "update d?tuningdetail_?_? n inner join d?gonzo a using(gonzo) set n.column? = a.column?, n.word? = a.word?",
+         "histograms" : {
+            "Query_time" : [
+               0,
+               0,
+               0,
+               0,
+               0,
+               1,
+               0,
+               0
+            ]
+         },
+         "metrics" : {
+            "Filesort" : {
+               "yes" : "0"
+            },
+            "Filesort_on_disk" : {
+               "yes" : "0"
+            },
+            "Full_join" : {
+               "yes" : "0"
+            },
+            "Full_scan" : {
+               "yes" : "1"
+            },
+            "Lock_time" : {
+               "avg" : "0.000091",
+               "max" : "0.000091",
+               "median" : "0.000091",
+               "min" : "0.000091",
+               "pct" : "0.125000",
+               "pct_95" : "0.000091",
+               "stddev" : "0.000000",
+               "sum" : "0.000091"
+            },
+            "Merge_passes" : {
+               "avg" : "0",
+               "max" : "0",
+               "median" : "0",
+               "min" : "0",
+               "pct" : "0",
+               "pct_95" : "0",
+               "stddev" : "0",
+               "sum" : "0"
+            },
+            "QC_Hit" : {
+               "yes" : "0"
+            },
+            "Query_length" : {
+               "avg" : "129",
+               "max" : "129",
+               "median" : "129",
+               "min" : "129",
+               "pct" : "0",
+               "pct_95" : "129",
+               "stddev" : "0",
+               "sum" : "129"
+            },
+            "Query_time" : {
+               "avg" : "0.726052",
+               "max" : "0.726052",
+               "median" : "0.726052",
+               "min" : "0.726052",
+               "pct" : "0.125000",
+               "pct_95" : "0.726052",
+               "stddev" : "0.000000",
+               "sum" : "0.726052"
+            },
+            "Rows_examined" : {
+               "avg" : "62951",
+               "max" : "62951",
+               "median" : "62951",
+               "min" : "62951",
+               "pct" : "0",
+               "pct_95" : "62951",
+               "stddev" : "0",
+               "sum" : "62951"
+            },
+            "Rows_sent" : {
+               "avg" : "0",
+               "max" : "0",
+               "median" : "0",
+               "min" : "0",
+               "pct" : "0",
+               "pct_95" : "0",
+               "stddev" : "0",
+               "sum" : "0"
+            },
+            "Tmp_table" : {
+               "yes" : "0"
+            },
+            "Tmp_table_on_disk" : {
+               "yes" : "0"
+            },
+            "db" : {
+               "value" : "db1"
+            },
+            "host" : {
+               "value" : ""
+            },
+            "user" : {
+               "value" : "[SQL_SLAVE]"
+            }
+         },
+         "query_count" : 1,
+         "tables" : [
+            {
+               "create" : "SHOW CREATE TABLE `db2`.`tuningdetail_21_265507`",
+               "status" : "SHOW TABLE STATUS FROM `db2` LIKE 'tuningdetail_21_265507'"
+            },
+            {
+               "create" : "SHOW CREATE TABLE `db1`.`gonzo`",
+               "status" : "SHOW TABLE STATUS FROM `db1` LIKE 'gonzo'"
+            }
+         ],
+         "ts_max" : "2007-12-18 11:48:27",
+         "ts_min" : "2007-12-18 11:48:27"
+      }
+   ],
+   "global" : {
+      "files" : [
+         {
+            "name" : "TRUNK/t/lib/samples/slowlogs/slow002.txt",
+            "size" : 3841
+         }
+      ],
+      "metrics" : {
+         "Filesort" : {
+            "cnt" : "0"
+         },
+         "Filesort_on_disk" : {
+            "cnt" : "0"
+         },
+         "Full_join" : {
+            "cnt" : "0"
+         },
+         "Full_scan" : {
+            "cnt" : "1"
+         },
+         "InnoDB_IO_r_bytes" : {
+            "avg" : "0",
+            "max" : "0",
+            "median" : "0",
+            "min" : "0",
+            "pct_95" : "0",
+            "stddev" : "0",
+            "sum" : "0"
+         },
+         "InnoDB_IO_r_ops" : {
+            "avg" : "0",
+            "max" : "0",
+            "median" : "0",
+            "min" : "0",
+            "pct_95" : "0",
+            "stddev" : "0",
+            "sum" : "0"
+         },
+         "InnoDB_IO_r_wait" : {
+            "avg" : "0.000000",
+            "max" : "0.000000",
+            "median" : "0.000000",
+            "min" : "0.000000",
+            "pct_95" : "0.000000",
+            "stddev" : "0.000000",
+            "sum" : "0.000000"
+         },
+         "InnoDB_pages_distinct" : {
+            "avg" : "17",
+            "max" : "24",
+            "median" : "17",
+            "min" : "11",
+            "pct_95" : "23",
+            "stddev" : "3",
+            "sum" : "107"
+         },
+         "InnoDB_queue_wait" : {
+            "avg" : "0.000000",
+            "max" : "0.000000",
+            "median" : "0.000000",
+            "min" : "0.000000",
+            "pct_95" : "0.000000",
+            "stddev" : "0.000000",
+            "sum" : "0.000000"
+         },
+         "InnoDB_rec_lock_wait" : {
+            "avg" : "0.000000",
+            "max" : "0.000000",
+            "median" : "0.000000",
+            "min" : "0.000000",
+            "pct_95" : "0.000000",
+            "stddev" : "0.000000",
+            "sum" : "0.000000"
+         },
+         "Lock_time" : {
+            "avg" : "0.000038",
+            "max" : "0.000091",
+            "median" : "0.000026",
+            "min" : "0.000000",
+            "pct_95" : "0.000089",
+            "stddev" : "0.000028",
+            "sum" : "0.000304"
+         },
+         "Merge_passes" : {
+            "avg" : "0",
+            "max" : "0",
+            "median" : "0",
+            "min" : "0",
+            "pct_95" : "0",
+            "stddev" : "0",
+            "sum" : "0"
+         },
+         "QC_Hit" : {
+            "cnt" : "0"
+         },
+         "Query_length" : {
+            "avg" : "62",
+            "max" : "129",
+            "median" : "62",
+            "min" : "5",
+            "pct_95" : "124",
+            "stddev" : "34",
+            "sum" : "502"
+         },
+         "Query_time" : {
+            "avg" : "0.095260",
+            "max" : "0.726052",
+            "median" : "0.000516",
+            "min" : "0.000012",
+            "pct_95" : "0.705093",
+            "stddev" : "0.231765",
+            "sum" : "0.762080"
+         },
+         "Rows_examined" : {
+            "avg" : "7868",
+            "max" : "62951",
+            "median" : "0",
+            "min" : "0",
+            "pct_95" : "61003",
+            "stddev" : "20174",
+            "sum" : "62951"
+         },
+         "Rows_sent" : {
+            "avg" : "0",
+            "max" : "0",
+            "median" : "0",
+            "min" : "0",
+            "pct_95" : "0",
+            "stddev" : "0",
+            "sum" : "0"
+         },
+         "Tmp_table" : {
+            "cnt" : "0"
+         },
+         "Tmp_table_on_disk" : {
+            "cnt" : "0"
+         }
+      },
+      "query_count" : 8,
+      "unique_query_count" : 7
+   }
+}

--- a/t/pt-query-digest/samples/slow001_tablesreport_no_vertical.txt
+++ b/t/pt-query-digest/samples/slow001_tablesreport_no_vertical.txt
@@ -1,0 +1,34 @@
+
+# ########################################################################
+# Report grouped by tables
+# ########################################################################
+
+# Item 1: 0.03 QPS, 0.05x concurrency, ID 0x1161D7068EB79526 at byte 0 ___
+# This item is included in the report because it matches --limit.
+# Scores: V/M = 0.00
+# Time range: 2007-10-15 21:43:52 to 21:45:10
+# Attribute    pct   total     min     max     avg     95%  stddev  median
+# ============ === ======= ======= ======= ======= ======= ======= =======
+# Count        100       2
+# Exec time    100      4s      2s      2s      2s      2s       0      2s
+# Lock time      0       0       0       0       0       0       0       0
+# Rows sent    100       2       1       1       1       1       0       1
+# Rows examine   0       0       0       0       0       0       0       0
+# Query size   100      49      22      27   24.50      27    3.54   24.50
+# String:
+# Databases    sakila (1/50%), test (1/50%)
+# Hosts        localhost
+# Users        root
+# Query_time distribution
+#   1us
+#  10us
+# 100us
+#   1ms
+#  10ms
+# 100ms
+#    1s  ################################################################
+#  10s+
+# Tables
+#    SHOW TABLE STATUS FROM `test` LIKE 'n'
+#    SHOW CREATE TABLE `test`.`n`
+test.n

--- a/t/pt-query-digest/samples/slow002_report_no_vertical.txt
+++ b/t/pt-query-digest/samples/slow002_report_no_vertical.txt
@@ -1,0 +1,267 @@
+
+# Query 1: 0 QPS, 0x concurrency, ID 0x66825DDC008FFA89 at byte 338 ______
+# Scores: V/M = 0.00
+# Time range: all events occurred at 2007-12-18 11:48:27
+# Attribute    pct   total     min     max     avg     95%  stddev  median
+# ============ === ======= ======= ======= ======= ======= ======= =======
+# Count         12       1
+# Exec time     95   726ms   726ms   726ms   726ms   726ms       0   726ms
+# Lock time     29    91us    91us    91us    91us    91us       0    91us
+# Rows sent      0       0       0       0       0       0       0       0
+# Rows examine 100  61.48k  61.48k  61.48k  61.48k  61.48k       0  61.48k
+# Merge passes   0       0       0       0       0       0       0       0
+# Query size    25     129     129     129     129     129       0     129
+# Boolean:
+# Full scan    100% yes,   0% no
+# String:
+# Databases    db1
+# Hosts
+# Users        [SQL_SLAVE]
+# Query_time distribution
+#   1us
+#  10us
+# 100us
+#   1ms
+#  10ms
+# 100ms  ################################################################
+#    1s
+#  10s+
+# Tables
+#    SHOW TABLE STATUS FROM `db2` LIKE 'tuningdetail_21_265507'
+#    SHOW CREATE TABLE `db2`.`tuningdetail_21_265507`
+#    SHOW TABLE STATUS FROM `db1` LIKE 'gonzo'
+#    SHOW CREATE TABLE `db1`.`gonzo`
+update db2.tuningdetail_21_265507 n
+      inner join db1.gonzo a using(gonzo) 
+      set n.column1 = a.column1, n.word3 = a.word3
+# Converted for EXPLAIN
+# EXPLAIN /*!50100 PARTITIONS*/
+select  n.column1 = a.column1, n.word3 = a.word3 from db2.tuningdetail_21_265507 n
+      inner join db1.gonzo a using(gonzo) 
+
+# Query 2: 0 QPS, 0x concurrency, ID 0x0FFE94ABA6A2A9E8 at byte 1334 _____
+# Scores: V/M = 0.00
+# Time range: all events occurred at 2007-12-18 11:48:27
+# Attribute    pct   total     min     max     avg     95%  stddev  median
+# ============ === ======= ======= ======= ======= ======= ======= =======
+# Count         12       1
+# Exec time      4    33ms    33ms    33ms    33ms    33ms       0    33ms
+# Lock time      9    28us    28us    28us    28us    28us       0    28us
+# Rows sent      0       0       0       0       0       0       0       0
+# Rows examine   0       0       0       0       0       0       0       0
+# Merge passes   0       0       0       0       0       0       0       0
+# Query size    20     103     103     103     103     103       0     103
+# InnoDB:
+# IO r bytes     0       0       0       0       0       0       0       0
+# IO r ops       0       0       0       0       0       0       0       0
+# IO r wait      0       0       0       0       0       0       0       0
+# pages distin  10      11      11      11      11      11       0      11
+# queue wait     0       0       0       0       0       0       0       0
+# rec lock wai   0       0       0       0       0       0       0       0
+# String:
+# Databases    db1
+# Hosts
+# Users        [SQL_SLAVE]
+# Query_time distribution
+#   1us
+#  10us
+# 100us
+#   1ms
+#  10ms  ################################################################
+# 100ms
+#    1s
+#  10s+
+# Tables
+#    SHOW TABLE STATUS FROM `db4` LIKE 'vab3concept1upload'
+#    SHOW CREATE TABLE `db4`.`vab3concept1upload`
+UPDATE db4.vab3concept1upload
+SET    vab3concept1id = '91848182522'
+WHERE  vab3concept1upload='6994465'
+# Converted for EXPLAIN
+# EXPLAIN /*!50100 PARTITIONS*/
+select     vab3concept1id = '91848182522' from db4.vab3concept1upload where   vab3concept1upload='6994465'
+
+# Query 3: 0 QPS, 0x concurrency, ID 0xB211BA2B8D6D065C at byte 3374 _____
+# Scores: V/M = 0.00
+# Time range: all events occurred at 2007-12-18 11:48:27
+# Attribute    pct   total     min     max     avg     95%  stddev  median
+# ============ === ======= ======= ======= ======= ======= ======= =======
+# Count         25       2
+# Exec time      0     1ms   530us   530us   530us   530us       0   530us
+# Lock time     17    54us    27us    27us    27us    27us       0    27us
+# Rows sent      0       0       0       0       0       0       0       0
+# Rows examine   0       0       0       0       0       0       0       0
+# Merge passes   0       0       0       0       0       0       0       0
+# Query size    16      82      41      41      41      41       0      41
+# InnoDB:
+# IO r bytes     0       0       0       0       0       0       0       0
+# IO r ops       0       0       0       0       0       0       0       0
+# IO r wait      0       0       0       0       0       0       0       0
+# pages distin  33      36      18      18      18      18       0      18
+# queue wait     0       0       0       0       0       0       0       0
+# rec lock wai   0       0       0       0       0       0       0       0
+# String:
+# Databases    db1
+# Hosts
+# Users        [SQL_SLAVE]
+# Query_time distribution
+#   1us
+#  10us
+# 100us  ################################################################
+#   1ms
+#  10ms
+# 100ms
+#    1s
+#  10s+
+# Tables
+#    SHOW TABLE STATUS FROM `foo` LIKE 'bar'
+#    SHOW CREATE TABLE `foo`.`bar`
+UPDATE foo.bar
+SET    biz = '91848182522'
+# Converted for EXPLAIN
+# EXPLAIN /*!50100 PARTITIONS*/
+select     biz = '91848182522' from foo.bar 
+
+# Query 4: 0 QPS, 0x concurrency, ID 0x6969975466519B81 at byte 2861 _____
+# Scores: V/M = 0.00
+# Time range: all events occurred at 2007-12-18 11:48:27
+# Attribute    pct   total     min     max     avg     95%  stddev  median
+# ============ === ======= ======= ======= ======= ======= ======= =======
+# Count         12       1
+# Exec time      0   530us   530us   530us   530us   530us       0   530us
+# Lock time      8    27us    27us    27us    27us    27us       0    27us
+# Rows sent      0       0       0       0       0       0       0       0
+# Rows examine   0       0       0       0       0       0       0       0
+# Merge passes   0       0       0       0       0       0       0       0
+# Query size    11      60      60      60      60      60       0      60
+# InnoDB:
+# IO r bytes     0       0       0       0       0       0       0       0
+# IO r ops       0       0       0       0       0       0       0       0
+# IO r wait      0       0       0       0       0       0       0       0
+# pages distin  16      18      18      18      18      18       0      18
+# queue wait     0       0       0       0       0       0       0       0
+# rec lock wai   0       0       0       0       0       0       0       0
+# String:
+# Databases    db1
+# Hosts
+# Users        [SQL_SLAVE]
+# Query_time distribution
+#   1us
+#  10us
+# 100us  ################################################################
+#   1ms
+#  10ms
+# 100ms
+#    1s
+#  10s+
+# Tables
+#    SHOW TABLE STATUS FROM `bizzle` LIKE 'bat'
+#    SHOW CREATE TABLE `bizzle`.`bat`
+UPDATE bizzle.bat
+SET    boop='bop: 899'
+WHERE  fillze='899'
+# Converted for EXPLAIN
+# EXPLAIN /*!50100 PARTITIONS*/
+select     boop='bop: 899' from bizzle.bat where   fillze='899'
+
+# Query 5: 0 QPS, 0x concurrency, ID 0xC22D235B07D1D774 at byte 1864 _____
+# Scores: V/M = 0.00
+# Time range: all events occurred at 2007-12-18 11:48:27
+# Attribute    pct   total     min     max     avg     95%  stddev  median
+# ============ === ======= ======= ======= ======= ======= ======= =======
+# Count         12       1
+# Exec time      0   530us   530us   530us   530us   530us       0   530us
+# Lock time      8    27us    27us    27us    27us    27us       0    27us
+# Rows sent      0       0       0       0       0       0       0       0
+# Rows examine   0       0       0       0       0       0       0       0
+# Merge passes   0       0       0       0       0       0       0       0
+# Query size    11      57      57      57      57      57       0      57
+# InnoDB:
+# IO r bytes     0       0       0       0       0       0       0       0
+# IO r ops       0       0       0       0       0       0       0       0
+# IO r wait      0       0       0       0       0       0       0       0
+# pages distin  16      18      18      18      18      18       0      18
+# queue wait     0       0       0       0       0       0       0       0
+# rec lock wai   0       0       0       0       0       0       0       0
+# String:
+# Databases    db1
+# Hosts
+# Users        [SQL_SLAVE]
+# Query_time distribution
+#   1us
+#  10us
+# 100us  ################################################################
+#   1ms
+#  10ms
+# 100ms
+#    1s
+#  10s+
+# Tables
+#    SHOW TABLE STATUS FROM `db1` LIKE 'conch'
+#    SHOW CREATE TABLE `db1`.`conch`
+INSERT INTO db1.conch (word3, vid83)
+VALUES ('211', '18')
+
+# Query 6: 0 QPS, 0x concurrency, ID 0x7546F89214254F2F at byte 815 ______
+# Scores: V/M = 0.00
+# Time range: all events occurred at 2007-12-18 11:48:27
+# Attribute    pct   total     min     max     avg     95%  stddev  median
+# ============ === ======= ======= ======= ======= ======= ======= =======
+# Count         12       1
+# Exec time      0   512us   512us   512us   512us   512us       0   512us
+# Lock time     25    77us    77us    77us    77us    77us       0    77us
+# Rows sent      0       0       0       0       0       0       0       0
+# Rows examine   0       0       0       0       0       0       0       0
+# Merge passes   0       0       0       0       0       0       0       0
+# Query size    13      66      66      66      66      66       0      66
+# InnoDB:
+# IO r bytes     0       0       0       0       0       0       0       0
+# IO r ops       0       0       0       0       0       0       0       0
+# IO r wait      0       0       0       0       0       0       0       0
+# pages distin  22      24      24      24      24      24       0      24
+# queue wait     0       0       0       0       0       0       0       0
+# rec lock wai   0       0       0       0       0       0       0       0
+# String:
+# Databases    db1
+# Hosts
+# Users        [SQL_SLAVE]
+# Query_time distribution
+#   1us
+#  10us
+# 100us  ################################################################
+#   1ms
+#  10ms
+# 100ms
+#    1s
+#  10s+
+# Tables
+#    SHOW TABLE STATUS FROM `db3` LIKE 'vendor11gonzo'
+#    SHOW CREATE TABLE `db3`.`vendor11gonzo`
+INSERT INTO db3.vendor11gonzo (makef, bizzle)
+VALUES ('', 'Exact')
+
+# Query 7: 0 QPS, 0x concurrency, ID 0x85FFF5AA78E5FF6A at byte 0 ________
+# Scores: V/M = 0.00
+# Time range: all events occurred at 2007-12-18 11:48:27
+# Attribute    pct   total     min     max     avg     95%  stddev  median
+# ============ === ======= ======= ======= ======= ======= ======= =======
+# Count         12       1
+# Exec time      0    12us    12us    12us    12us    12us       0    12us
+# Lock time      0       0       0       0       0       0       0       0
+# Rows sent      0       0       0       0       0       0       0       0
+# Rows examine   0       0       0       0       0       0       0       0
+# Merge passes   0       0       0       0       0       0       0       0
+# Query size     0       5       5       5       5       5       0       5
+# String:
+# Hosts
+# Users        [SQL_SLAVE]
+# Query_time distribution
+#   1us
+#  10us  ################################################################
+# 100us
+#   1ms
+#  10ms
+# 100ms
+#    1s
+#  10s+
+BEGIN

--- a/t/pt-query-digest/slowlog_analyses.t
+++ b/t/pt-query-digest/slowlog_analyses.t
@@ -44,6 +44,14 @@ ok(
    ),
    'Analysis for slow001 with --group-by tables'
 );
+ok(
+   no_diff(
+      sub { pt_query_digest::main(@args, $sample.'slow001.txt',
+            qw(--group-by tables --no-vertical-format)) },
+      "t/pt-query-digest/samples/slow001_tablesreport_no_vertical.txt"
+   ),
+   'Analysis for slow001 with --group-by tables and --no-vertical-format'
+);
 
 ok(
    no_diff(
@@ -68,6 +76,13 @@ ok(
       "t/pt-query-digest/samples/slow002_report.txt"
    ),
    'Analysis for slow002'
+);
+ok(
+   no_diff(
+      sub { pt_query_digest::main(@args, $sample.'slow002.txt', qw(--no-vertical-format)) },
+      "t/pt-query-digest/samples/slow002_report_no_vertical.txt"
+   ),
+   'Analysis for slow002 with --no-vertical-format'
 );
 
 ok(


### PR DESCRIPTION
This PR adds option `--[no]vertical-format`: Output a trailing `\G` in the reported SQL queries (default: yes). Until now `\G` was always added. However, non-native MySQL clients like phpMyAdmin do not support this.

All local tests for `pt-query-digest` pass OK.

WARNING: The interface of `QueryReportFormatter::tables_report()` was changed but:
- `tables_report()` seems like a private helper function in `QueryReportFormatter.pm`; it is not referenced in any other files
- `JSONReportFormatter.pm` and `QueryReportFormatter.pm` are used only by `pt-query-digest`

The code changes are split into several commits for easier review.