### PR TITLE
die on DBI error such as a failure to update heartbeat table

### DIFF
--- a/bin/pt-heartbeat
+++ b/bin/pt-heartbeat
@@ -5351,6 +5351,7 @@ sub main {
          my ( $err ) = $EVAL_ERROR =~ m/^(?:DBI|DBD).*failed: (.*?)\s*at \S+ line .*/;
          if ( $err ) {
             warn "$err\n";
+            die $err;
          }
          else {
             die $EVAL_ERROR;


### PR DESCRIPTION
If you are running `pt-heartbeat` in daemon mode with `--update` and the
heartbeat table is removed (eg: mistakenly by an admin, or other) then
`pt-heartbeat` will continuously spin with an error such as:

```
Nov 13 01:06:02 hostname pt-heartbeat@1000.service[9519]: Table 'database._pt_heartbeat' doesn't exist [for Statement "UPDATE `pantheon`.`_pt_heartbeat` SET ts=?, file=?, position=?, relay_master_log_file=?, exec_master_log_pos=? WHERE server_id='2272608305'" with ParamValues: 0='2015-11-13T01:06:02.001110', 1='mysql-bin.000005', 2='366399508', 3=undef, 4=undef]
```

Instead, we would prefer that it exit()'d with error which would allow for the supervisor
to restart the process which would re-create the table if the `create-table` option was
specified.
