### PR TITLE
pt-show-grants - order output of column privileges - lp1523730

### DIFF
--- a/bin/pt-show-grants
+++ b/bin/pt-show-grants
@@ -1998,6 +1998,11 @@ sub split_grants {
             )
             (?:,\s)?    # Separted from the next grant, if any, by a comma
       /xg;
+      # sort columns in column-level permissions (bug lp-1523730)
+      @grants = map {
+        $_ =~ s/(INSERT|SELECT|UPDATE)\s\((.+?)\)/"$1 (" . join(', ',sort(split(', ',$2))) . ')'/me;
+        $_;
+      } @grants;
    }
    else {
       PTDEBUG && _d('Splitting grants on comma:', $grants);

--- a/t/pt-show-grants/basics.t
+++ b/t/pt-show-grants/basics.t
@@ -108,6 +108,7 @@ ok(
    "Column-level grants (bug 866075)"
 );
 
+
 ok(
    no_diff(
       sub { pt_show_grants::main('-F', $cnf, qw(--only sally --no-header),

--- a/t/pt-show-grants/samples/column-grants-combined.txt
+++ b/t/pt-show-grants/samples/column-grants-combined.txt
@@ -1,4 +1,4 @@
 -- Grants for 'sally'@'%'
 GRANT INSERT (city), SELECT, SELECT (city_id) ON `sakila`.`city` TO 'sally'@'%';
-GRANT SELECT (SANumber, DateCreated, PaymentStat, PckPrice) ON `test`.`t` TO 'sally'@'%';
+GRANT SELECT (DateCreated, PaymentStat, PckPrice, SANumber) ON `test`.`t` TO 'sally'@'%';
 GRANT USAGE ON *.* TO 'sally'@'%';

--- a/t/pt-show-grants/samples/column-grants-separate-revoke.txt
+++ b/t/pt-show-grants/samples/column-grants-separate-revoke.txt
@@ -1,10 +1,10 @@
 -- Revoke statements for 'sally'@'%'
 REVOKE INSERT (city) ON `sakila`.`city` FROM 'sally'@'%';
-REVOKE SELECT (SANumber, DateCreated, PaymentStat, PckPrice) ON `test`.`t` FROM 'sally'@'%';
+REVOKE SELECT (DateCreated, PaymentStat, PckPrice, SANumber) ON `test`.`t` FROM 'sally'@'%';
 REVOKE SELECT (city_id) ON `sakila`.`city` FROM 'sally'@'%';
 REVOKE USAGE ON *.* FROM 'sally'@'%';
 -- Grants for 'sally'@'%'
 GRANT INSERT (city) ON `sakila`.`city` TO 'sally'@'%';
-GRANT SELECT (SANumber, DateCreated, PaymentStat, PckPrice) ON `test`.`t` TO 'sally'@'%';
+GRANT SELECT (DateCreated, PaymentStat, PckPrice, SANumber) ON `test`.`t` TO 'sally'@'%';
 GRANT SELECT (city_id) ON `sakila`.`city` TO 'sally'@'%';
 GRANT USAGE ON *.* TO 'sally'@'%';

--- a/t/pt-show-grants/samples/column-grants-separate.txt
+++ b/t/pt-show-grants/samples/column-grants-separate.txt
@@ -1,5 +1,5 @@
 -- Grants for 'sally'@'%'
 GRANT INSERT (city) ON `sakila`.`city` TO 'sally'@'%';
-GRANT SELECT (SANumber, DateCreated, PaymentStat, PckPrice) ON `test`.`t` TO 'sally'@'%';
+GRANT SELECT (DateCreated, PaymentStat, PckPrice, SANumber) ON `test`.`t` TO 'sally'@'%';
 GRANT SELECT (city_id) ON `sakila`.`city` TO 'sally'@'%';
 GRANT USAGE ON *.* TO 'sally'@'%';

--- a/t/pt-show-grants/samples/column-grants.txt
+++ b/t/pt-show-grants/samples/column-grants.txt
@@ -1,4 +1,4 @@
 -- Grants for 'sally'@'%'
 GRANT INSERT (city), SELECT (city_id) ON `sakila`.`city` TO 'sally'@'%';
-GRANT SELECT (SANumber, DateCreated, PaymentStat, PckPrice) ON `test`.`t` TO 'sally'@'%';
+GRANT SELECT (DateCreated, PaymentStat, PckPrice, SANumber) ON `test`.`t` TO 'sally'@'%';
 GRANT USAGE ON *.* TO 'sally'@'%';


### PR DESCRIPTION
pt-show-grants column-level privileges output resulted in different sorting order between
mysql and the mysql compatible AWS Aurora.
Solution. Simply sort the columns alphabetically.
Modified a few tests to accommodate for the change.
