### PR TITLE
pt-osc fixed recursion method dsn - lp1523685

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -4057,28 +4057,22 @@ use warnings FATAL => 'all';
 use English qw(-no_match_vars);
 use constant PTDEBUG => $ENV{PTDEBUG} || 0;
 
-sub check_recursion_method {
+sub check_recursion_method {                                                       
    my ($methods) = @_;
-
-   foreach my $method ( @$methods ) {
-      die "Invalid recursion method: " . ($method || 'undef') . "\n"
-         unless $method && $method =~ m/^(?:processlist$|hosts$|none$|cluster|dsn=)/i;
-   }
-
-   if ( @$methods > 1 ) {
-      if ( grep( { m/none/ } @$methods) && grep( {! m/none/ } @$methods) ) {
-            die "--recursion-method=none cannot be combined with other methods\n";
-      }
-      elsif ( grep({ !m/processlist|hosts/i } @$methods)
-            && $methods->[0] !~ /^dsn=/i )
-      {
-         die  "Invalid combination of recursion methods: "
-            . join(", ", map { defined($_) ? $_ : 'undef' } @$methods) . ". "
-            . "Only hosts and processlist may be combined.\n"
-      }
-   }
-
-   return;
+   if ( @$methods != 1 ) {                                                         
+      if ( grep({ !m/processlist|hosts/i } @$methods)                              
+            && $methods->[0] !~ /^dsn=/i ) 
+      {     
+         die  "Invalid combination of recursion methods: "                         
+            . join(", ", map { defined($_) ? $_ : 'undef' } @$methods) . ". "      
+            . "Only hosts and processlist may be combined.\n"                      
+      }                                                                            
+   }     
+   else {   
+      my ($method) = @$methods;
+      die "Invalid recursion method: " . ( $method || 'undef' )                    
+         unless $method && $method =~ m/^(?:processlist$|hosts$|none$|cluster$|dsn=)/i;     
+   }                                                                               
 }
 
 sub new {

--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -10356,28 +10356,22 @@ use warnings FATAL => 'all';
 use English qw(-no_match_vars);
 use constant PTDEBUG => $ENV{PTDEBUG} || 0;
 
-sub check_recursion_method {
+sub check_recursion_method {                                                       
    my ($methods) = @_;
-
-   foreach my $method ( @$methods ) {
-      die "Invalid recursion method: " . ($method || 'undef') . "\n"
-         unless $method && $method =~ m/^(?:processlist$|hosts$|none$|cluster|dsn=)/i;
-   }
-
-   if ( @$methods > 1 ) {
-      if ( grep( { m/none/ } @$methods) && grep( {! m/none/ } @$methods) ) {
-            die "--recursion-method=none cannot be combined with other methods\n";
-      }
-      elsif ( grep({ !m/processlist|hosts/i } @$methods)
-            && $methods->[0] !~ /^dsn=/i )
-      {
-         die  "Invalid combination of recursion methods: "
-            . join(", ", map { defined($_) ? $_ : 'undef' } @$methods) . ". "
-            . "Only hosts and processlist may be combined.\n"
-      }
-   }
-
-   return;
+   if ( @$methods != 1 ) {                                                         
+      if ( grep({ !m/processlist|hosts/i } @$methods)                              
+            && $methods->[0] !~ /^dsn=/i ) 
+      {     
+         die  "Invalid combination of recursion methods: "                         
+            . join(", ", map { defined($_) ? $_ : 'undef' } @$methods) . ". "      
+            . "Only hosts and processlist may be combined.\n"                      
+      }                                                                            
+   }     
+   else {   
+      my ($method) = @$methods;
+      die "Invalid recursion method: " . ( $method || 'undef' )                    
+         unless $method && $method =~ m/^(?:processlist$|hosts$|none$|cluster$|dsn=)/i;     
+   }                                                                               
 }
 
 sub new {

--- a/lib/MasterSlave.pm
+++ b/lib/MasterSlave.pm
@@ -29,30 +29,22 @@ use constant PTDEBUG => $ENV{PTDEBUG} || 0;
 
 # Sub: check_recursion_method
 #   Check that the arrayref of recursion methods passed in is valid
-sub check_recursion_method {
+sub check_recursion_method {                                                       
    my ($methods) = @_;
-
-   # Check that each method is valid.
-   foreach my $method ( @$methods ) {
-      die "Invalid recursion method: " . ($method || 'undef') . "\n"
-         unless $method && $method =~ m/^(?:processlist$|hosts$|none$|cluster|dsn=)/i;
-   }
-
-   # Check for invalid combination of methods.
-   if ( @$methods > 1 ) {
-      if ( grep( { m/none/ } @$methods) && grep( {! m/none/ } @$methods) ) {
-            die "--recursion-method=none cannot be combined with other methods\n";
-      }
-      elsif ( grep({ !m/processlist|hosts/i } @$methods)
-            && $methods->[0] !~ /^dsn=/i )
-      {
-         die  "Invalid combination of recursion methods: "
-            . join(", ", map { defined($_) ? $_ : 'undef' } @$methods) . ". "
-            . "Only hosts and processlist may be combined.\n"
-      }
-   }
-
-   return;
+   if ( @$methods != 1 ) {                                                         
+      if ( grep({ !m/processlist|hosts/i } @$methods)                              
+            && $methods->[0] !~ /^dsn=/i ) 
+      {     
+         die  "Invalid combination of recursion methods: "                         
+            . join(", ", map { defined($_) ? $_ : 'undef' } @$methods) . ". "      
+            . "Only hosts and processlist may be combined.\n"                      
+      }                                                                            
+   }     
+   else {   
+      my ($method) = @$methods;
+      die "Invalid recursion method: " . ( $method || 'undef' )                    
+         unless $method && $method =~ m/^(?:processlist$|hosts$|none$|cluster$|dsn=)/i;     
+   }                                                                               
 }
 
 sub new {

--- a/t/pt-online-schema-change/samples/create_dsns.sql
+++ b/t/pt-online-schema-change/samples/create_dsns.sql
@@ -1,0 +1,13 @@
+CREATE DATABASE IF NOT EXISTS test_recursion_method;
+USE test_recursion_method;
+DROP TABLE IF EXISTS `dsns`;
+CREATE TABLE `dsns` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `parent_id` int(11) DEFAULT NULL,
+  `dsn` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=latin1;
+
+INSERT INTO `dsns` VALUES (1, 12345, "D=test_recursion_method,t=dsns,P=12346,h=127.0.0.1,u=root,p=msandbox");
+INSERT INTO `dsns` VALUES (2, 12345, "D=test_recursion_method,t=dsns,P=12347,h=127.0.0.1,u=root,p=msandbox");
+


### PR DESCRIPTION
pt-osc recursion-method choked on dsn method.
Customized MasterSlave module was the culprit. Apparently It was customized for pt-osc (and pt-query-digest) and when tools were updated customization was overwritten.
Fixed by modifying the module with the enhancement and applying it to pt-osc (and pt-query-digest)
Created unit test for pt-osc for this.