### PR TITLE
pt-slave-restart now checks for MariaDB version

### DIFF
--- a/bin/pt-slave-restart
+++ b/bin/pt-slave-restart
@@ -5004,7 +5004,9 @@ sub watch_server {
    # transaction is not possible with SQL_SLAVE_SKIP_COUNTER
    my $skip_event;
    my $have_gtid = 0;
-   if ( VersionParser->new($dbh) >= '5.6.5' ) {
+   # We also check if version is lower than 10.0.0 because MariaDB has different 
+   # versioning system than MySQL 
+   if ( VersionParser->new($dbh) >= '5.6.5' && VersionParser->new($dbh) <= '10.0.0' ) {
       my $row = $dbh->selectrow_arrayref('SELECT @@GLOBAL.gtid_mode');
       PTDEBUG && _d('@@GLOBAL.gtid_mode:', $row->[0]);
       if ( $row && $row->[0] eq 'ON' ) {


### PR DESCRIPTION
background: pt-slave-restart checks for MySQL version and if gtid is enabled to handle skipping in a different way accordingly.
MariaDB uses a different versioning number system so this failed for that database.
We now simply check for both version numbers.
