### PR TITLE
Perl sprintf warnings lp1480719

### DIFF
--- a/bin/pt-diskstats
+++ b/bin/pt-diskstats
@@ -1306,8 +1306,8 @@ sub shorten {
    }
    return sprintf(
       $num =~ m/\./ || $n
-         ? "%.${p}f%s"
-         : '%d',
+         ? '%1$.'.$p.'f%2$s'
+         : '%1$d',
       $num, $units[$n]);
 }
 

--- a/bin/pt-fk-error-logger
+++ b/bin/pt-fk-error-logger
@@ -2328,8 +2328,8 @@ sub shorten {
    }
    return sprintf(
       $num =~ m/\./ || $n
-         ? "%.${p}f%s"
-         : '%d',
+         ? '%1$.'.$p.'f%2$s'
+         : '%1$d',
       $num, $units[$n]);
 }
 

--- a/bin/pt-heartbeat
+++ b/bin/pt-heartbeat
@@ -3967,8 +3967,8 @@ sub shorten {
    }
    return sprintf(
       $num =~ m/\./ || $n
-         ? "%.${p}f%s"
-         : '%d',
+         ? '%1$.'.$p.'f%2$s'
+         : '%1$d',
       $num, $units[$n]);
 }
 

--- a/bin/pt-heartbeat
+++ b/bin/pt-heartbeat
@@ -6140,10 +6140,16 @@ sub main {
    my $limit  = max(@$frames);
 
    # 2.00s [  0.05s,  0.01s,  0.00s ]
-   my $format = ($hires_ts ? '%.2f' : '%4d') . "s "
-              . "[ " . join(", ", map { "%5.2fs" } @$frames) . " ]"
-              . ($o->get('print-master-server-id') ? " %d" : '')
-              . "\n";
+   my $format = ($hires_ts ? '%1$.2f' : '%1$4d') . "s [ ";
+   my $findex = 2;
+   foreach (@$frames) {
+      $format .= $findex > 2 ? ', ' : '';
+      $format .= '%'.$findex.'$5.2fs';
+      $findex++;
+   }
+   $format .= " ]";
+   $format .= ($o->get('print-master-server-id') ? ' %'.$findex.'$d' : '')
+            . "\n";
 
    # ########################################################################
    # Monitor or update the heartbeat table.
@@ -6278,10 +6284,12 @@ sub check_delay {
       push @sths, [ $dsn, $sth ];
    }
 
-   my $format_delay = ($args{hires_ts} ? '%.2f' : '%d')
-                    . ($o->get('print-master-server-id') ? " %d" : "")
+   my $format_delay = ($args{hires_ts} ? '%1$.2f' : '%1$d')
+                    . ($o->get('print-master-server-id') ? ' %2$d' : "")
                     . "\n";
-   my $format_host  = "%-20s $format_delay";
+   my $format_host  = '%1$-20s '.($args{hires_ts} ? '%2$.2f' : '%2$d')
+                    . ($o->get('print-master-server-id') ? ' %3$d' : "")
+                    . "\n";
 
    # Before hi-res ts, we could check all slaves at one interval, assuming
    # the checks were fast, i.e. able to be done within one interval.  But

--- a/bin/pt-index-usage
+++ b/bin/pt-index-usage
@@ -3530,8 +3530,8 @@ sub shorten {
    }
    return sprintf(
       $num =~ m/\./ || $n
-         ? "%.${p}f%s"
-         : '%d',
+         ? '%1$.'.$p.'f%2$s'
+         : '%1$d',
       $num, $units[$n]);
 }
 
@@ -4918,11 +4918,10 @@ sub new {
       last_reported => $args{start},
       fraction      => 0,       # How complete the job is
       callback      => sub {
-         my ($fraction, $elapsed, $remaining, $eta) = @_;
+         my ($fraction, $elapsed, $remaining) = @_;
          printf STDERR "$name: %3d%% %s remain\n",
             $fraction * 100,
-            Transformers::secs_to_time($remaining),
-            Transformers::ts($eta);
+            Transformers::secs_to_time($remaining);
       },
       %args,
    };

--- a/bin/pt-kill
+++ b/bin/pt-kill
@@ -2589,8 +2589,8 @@ sub shorten {
    }
    return sprintf(
       $num =~ m/\./ || $n
-         ? "%.${p}f%s"
-         : '%d',
+         ? '%1$.'.$p.'f%2$s'
+         : '%1$d',
       $num, $units[$n]);
 }
 

--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -3591,11 +3591,10 @@ sub new {
       last_reported => $args{start},
       fraction      => 0,       # How complete the job is
       callback      => sub {
-         my ($fraction, $elapsed, $remaining, $eta) = @_;
+         my ($fraction, $elapsed, $remaining) = @_;
          printf STDERR "$name: %3d%% %s remain\n",
             $fraction * 100,
-            Transformers::secs_to_time($remaining),
-            Transformers::ts($eta);
+            Transformers::secs_to_time($remaining);
       },
       %args,
    };
@@ -6124,8 +6123,8 @@ sub shorten {
    }
    return sprintf(
       $num =~ m/\./ || $n
-         ? "%.${p}f%s"
-         : '%d',
+         ? '%1$.'.$p.'f%2$s'
+         : '%1$d',
       $num, $units[$n]);
 }
 

--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -2555,8 +2555,8 @@ sub shorten {
    }
    return sprintf(
       $num =~ m/\./ || $n
-         ? "%.${p}f%s"
-         : '%d',
+         ? '%1$.'.$p.'f%2$s'
+         : '%1$d',
       $num, $units[$n]);
 }
 
@@ -6674,9 +6674,9 @@ sub BUILDARGS {
          report_all       => $o->get('report-all'),
          report_histogram => $o->get('report-histogram'),
       },
-      num_format     => "# %-${label_width}s %3s %7s %7s %7s %7s %7s %7s %7s",
-      bool_format    => "# %-${label_width}s %3d%% yes, %3d%% no",
-      string_format  => "# %-${label_width}s %s",
+      num_format     => '# %1$-'.$label_width.'s %2$3s %3$7s %4$7s %5$7s %6$7s %7$7s %8$7s %9$7s',
+      bool_format    => '# %1$-'.$label_width.'s %2$3d%% yes, %3$3d%% no',
+      string_format  => '# %1$-'.$label_width.'s %2$s',
       hidden_attrib  => {   # Don't sort/print these attribs in the reports.
          arg         => 1, # They're usually handled specially, or not
          fingerprint => 1, # printed at all.
@@ -7139,7 +7139,11 @@ sub event_report {
       $val->{checksum},
       $val->{pos_in_log},
    );
-   $line .= ('_' x (LINE_LENGTH - length($line) + $self->label_width() - 12));
+   my $underscores = LINE_LENGTH - length($line) + $self->label_width() - 12;
+   if ( $underscores < 0 ) {
+      $underscores = 0;
+   }
+   $line .= ('_' x $underscores);
    push @result, $line;
 
    if ( $val->{reason} ) {
@@ -11112,11 +11116,10 @@ sub new {
       last_reported => $args{start},
       fraction      => 0,       # How complete the job is
       callback      => sub {
-         my ($fraction, $elapsed, $remaining, $eta) = @_;
+         my ($fraction, $elapsed, $remaining) = @_;
          printf STDERR "$name: %3d%% %s remain\n",
             $fraction * 100,
-            Transformers::secs_to_time($remaining),
-            Transformers::ts($eta);
+            Transformers::secs_to_time($remaining);
       },
       %args,
    };

--- a/bin/pt-slave-delay
+++ b/bin/pt-slave-delay
@@ -2582,8 +2582,8 @@ sub shorten {
    }
    return sprintf(
       $num =~ m/\./ || $n
-         ? "%.${p}f%s"
-         : '%d',
+         ? '%1$.'.$p.'f%2$s'
+         : '%1$d',
       $num, $units[$n]);
 }
 

--- a/bin/pt-slave-find
+++ b/bin/pt-slave-find
@@ -3455,8 +3455,8 @@ sub shorten {
    }
    return sprintf(
       $num =~ m/\./ || $n
-         ? "%.${p}f%s"
-         : '%d',
+         ? '%1$.'.$p.'f%2$s'
+         : '%1$d',
       $num, $units[$n]);
 }
 

--- a/bin/pt-table-checksum
+++ b/bin/pt-table-checksum
@@ -7930,8 +7930,8 @@ sub shorten {
    }
    return sprintf(
       $num =~ m/\./ || $n
-         ? "%.${p}f%s"
-         : '%d',
+         ? '%1$.'.$p.'f%2$s'
+         : '%1$d',
       $num, $units[$n]);
 }
 
@@ -8179,11 +8179,10 @@ sub new {
       last_reported => $args{start},
       fraction      => 0,       # How complete the job is
       callback      => sub {
-         my ($fraction, $elapsed, $remaining, $eta) = @_;
+         my ($fraction, $elapsed, $remaining) = @_;
          printf STDERR "$name: %3d%% %s remain\n",
             $fraction * 100,
-            Transformers::secs_to_time($remaining),
-            Transformers::ts($eta);
+            Transformers::secs_to_time($remaining);
       },
       %args,
    };

--- a/bin/pt-table-sync
+++ b/bin/pt-table-sync
@@ -8093,8 +8093,8 @@ sub shorten {
    }
    return sprintf(
       $num =~ m/\./ || $n
-         ? "%.${p}f%s"
-         : '%d',
+         ? '%1$.'.$p.'f%2$s'
+         : '%1$d',
       $num, $units[$n]);
 }
 

--- a/bin/pt-table-usage
+++ b/bin/pt-table-usage
@@ -2443,24 +2443,26 @@ use Time::Local qw(timegm timelocal);
 use Digest::MD5 qw(md5_hex);
 use B qw();
 
-require Exporter;
-our @ISA         = qw(Exporter);
-our %EXPORT_TAGS = ();
-our @EXPORT      = ();
-our @EXPORT_OK   = qw(
-   micro_t
-   percentage_of
-   secs_to_time
-   time_to_secs
-   shorten
-   ts
-   parse_timestamp
-   unix_timestamp
-   any_unix_timestamp
-   make_checksum
-   crc32
-   encode_json
-);
+BEGIN {
+   require Exporter;
+   our @ISA         = qw(Exporter);
+   our %EXPORT_TAGS = ();
+   our @EXPORT      = ();
+   our @EXPORT_OK   = qw(
+      micro_t
+      percentage_of
+      secs_to_time
+      time_to_secs
+      shorten
+      ts
+      parse_timestamp
+      unix_timestamp
+      any_unix_timestamp
+      make_checksum
+      crc32
+      encode_json
+   );
+}
 
 our $mysql_ts  = qr/(\d\d)(\d\d)(\d\d) +(\d+):(\d+):(\d+)(\.\d+)?/;
 our $proper_ts = qr/(\d\d\d\d)-(\d\d)-(\d\d)[T ](\d\d):(\d\d):(\d\d)(\.\d+)?/;
@@ -2562,8 +2564,8 @@ sub shorten {
    }
    return sprintf(
       $num =~ m/\./ || $n
-         ? "%.${p}f%s"
-         : '%d',
+         ? '%1$.'.$p.'f%2$s'
+         : '%1$d',
       $num, $units[$n]);
 }
 
@@ -2591,6 +2593,9 @@ sub parse_timestamp {
       return sprintf "%d-%02d-%02d %02d:%02d:"
                      . (defined $f ? '%09.6f' : '%02d'),
                      $y + 2000, $m, $d, $h, $i, (defined $f ? $s + $f : $s);
+   }
+   elsif ( $val =~ m/^$proper_ts$/ ) {
+      return $val;
    }
    return $val;
 }
@@ -6209,11 +6214,10 @@ sub new {
       last_reported => $args{start},
       fraction      => 0,       # How complete the job is
       callback      => sub {
-         my ($fraction, $elapsed, $remaining, $eta) = @_;
+         my ($fraction, $elapsed, $remaining) = @_;
          printf STDERR "$name: %3d%% %s remain\n",
             $fraction * 100,
-            Transformers::secs_to_time($remaining),
-            Transformers::ts($eta);
+            Transformers::secs_to_time($remaining);
       },
       %args,
    };

--- a/bin/pt-upgrade
+++ b/bin/pt-upgrade
@@ -2799,8 +2799,8 @@ sub shorten {
    }
    return sprintf(
       $num =~ m/\./ || $n
-         ? "%.${p}f%s"
-         : '%d',
+         ? '%1$.'.$p.'f%2$s'
+         : '%1$d',
       $num, $units[$n]);
 }
 
@@ -9123,11 +9123,10 @@ sub new {
       last_reported => $args{start},
       fraction      => 0,       # How complete the job is
       callback      => sub {
-         my ($fraction, $elapsed, $remaining, $eta) = @_;
+         my ($fraction, $elapsed, $remaining) = @_;
          printf STDERR "$name: %3d%% %s remain\n",
             $fraction * 100,
-            Transformers::secs_to_time($remaining),
-            Transformers::ts($eta);
+            Transformers::secs_to_time($remaining);
       },
       %args,
    };

--- a/lib/Progress.pm
+++ b/lib/Progress.pm
@@ -71,11 +71,10 @@ sub new {
       last_reported => $args{start},
       fraction      => 0,       # How complete the job is
       callback      => sub {
-         my ($fraction, $elapsed, $remaining, $eta) = @_;
+         my ($fraction, $elapsed, $remaining) = @_;
          printf STDERR "$name: %3d%% %s remain\n",
             $fraction * 100,
-            Transformers::secs_to_time($remaining),
-            Transformers::ts($eta);
+            Transformers::secs_to_time($remaining);
       },
       %args,
    };

--- a/lib/QueryReportFormatter.pm
+++ b/lib/QueryReportFormatter.pm
@@ -123,9 +123,9 @@ sub BUILDARGS {
          report_all       => $o->get('report-all'),
          report_histogram => $o->get('report-histogram'),
       },
-      num_format     => "# %-${label_width}s %3s %7s %7s %7s %7s %7s %7s %7s",
-      bool_format    => "# %-${label_width}s %3d%% yes, %3d%% no",
-      string_format  => "# %-${label_width}s %s",
+      num_format     => '# %1$-'.$label_width.'s %2$3s %3$7s %4$7s %5$7s %6$7s %7$7s %8$7s %9$7s',
+      bool_format    => '# %1$-'.$label_width.'s %2$3d%% yes, %3$3d%% no',
+      string_format  => '# %1$-'.$label_width.'s %2$s',
       hidden_attrib  => {   # Don't sort/print these attribs in the reports.
          arg         => 1, # They're usually handled specially, or not
          fingerprint => 1, # printed at all.
@@ -673,7 +673,11 @@ sub event_report {
       $val->{checksum},
       $val->{pos_in_log},
    );
-   $line .= ('_' x (LINE_LENGTH - length($line) + $self->label_width() - 12));
+   my $underscores = LINE_LENGTH - length($line) + $self->label_width() - 12;
+   if ( $underscores < 0 ) {
+      $underscores = 0;
+   }
+   $line .= ('_' x $underscores);
    push @result, $line;
 
    # Second line: reason why this class is being reported.

--- a/lib/Transformers.pm
+++ b/lib/Transformers.pm
@@ -159,10 +159,12 @@ sub shorten {
       $num /= $d;
       ++$n;
    }
+   # Added indexes 1$, 2$ to sprintf format to avoid 'redundant' warning
+   # https://bugs.launchpad.net/percona-toolkit/+bug/1480719
    return sprintf(
       $num =~ m/\./ || $n
-         ? "%.${p}f%s"
-         : '%d',
+         ? '%1$.'.$p.'f%2$s'
+         : '%1$d',
       $num, $units[$n]);
 }
 

--- a/t/pt-query-digest/issue_1186.t
+++ b/t/pt-query-digest/issue_1186.t
@@ -30,7 +30,7 @@ else {
 # Issue 1186: mk-query-digest --processlist --interval --filter ignores interval
 # #############################################################################
 
-my $output = `PTDEBUG=1 $trunk/bin/pt-query-digest --processlist h=127.1,P=12345,u=msandbox,p=msandbox --run-time 2 --port 12345 --interval .5 2>&1`;
+my $output = `PTDEBUG=1 $trunk/bin/pt-query-digest --processlist h=127.1,P=12345,u=msandbox,p=msandbox --run-time 2 --port 12345 --interval 0.5 2>&1`;
 
 my @times = $output =~ m/Current time: \S+/g;
 ok(
@@ -38,7 +38,7 @@ ok(
    "--interval limits number of processlist polls (issue 1186)"
 );
 
-$output = `PTDEBUG=1 $trunk/bin/pt-query-digest --processlist h=127.1,P=12345,u=msandbox,p=msandbox --run-time 2 --port 12345 --interval .5 --filter '(\$event->{arg} =~ /NEVER HAPPEN/)' 2>&1`;
+$output = `PTDEBUG=1 $trunk/bin/pt-query-digest --processlist h=127.1,P=12345,u=msandbox,p=msandbox --run-time 2 --port 12345 --interval 0.5 --filter '(\$event->{arg} =~ /NEVER HAPPEN/)' 2>&1`;
 
 @times = $output =~ m/Current time: \S+/g;
 ok(

--- a/t/pt-slave-restart/pt-slave-restart.t
+++ b/t/pt-slave-restart/pt-slave-restart.t
@@ -46,7 +46,7 @@ my $r = $slave_dbh->selectrow_hashref('show slave status');
 like($r->{last_error}, qr/Table 'test.t' doesn't exist'/, 'It is busted');
 
 # Start an instance
-diag(`$trunk/bin/pt-slave-restart --max-sleep .25 -h 127.0.0.1 -P 12346 -u msandbox -p msandbox --daemonize --pid /tmp/pt-slave-restart.pid --log /tmp/pt-slave-restart.log`);
+diag(`$trunk/bin/pt-slave-restart --max-sleep 0.25 -h 127.0.0.1 -P 12346 -u msandbox -p msandbox --daemonize --pid /tmp/pt-slave-restart.pid --log /tmp/pt-slave-restart.log`);
 my $output = `ps x | grep 'pt-slave-restart \-\-max\-sleep ' | grep -v grep | grep -v pt-slave-restart.t`;
 like($output, qr/pt-slave-restart --max/, 'It lives');
 
@@ -93,7 +93,7 @@ like(
 );
 
 # Start an instance
-$output = `$trunk/bin/pt-slave-restart --max-sleep .25 -h 127.0.0.1 -P 12346 -u msandbox -p msandbox --error-text "doesn't exist" --run-time 1s 2>&1`;
+$output = `$trunk/bin/pt-slave-restart --max-sleep 0.25 -h 127.0.0.1 -P 12346 -u msandbox -p msandbox --error-text "doesn't exist" --run-time 1s 2>&1`;
 unlike(
    $output,
    qr/Error does not match/,
@@ -104,7 +104,7 @@ unlike(
 # Issue 391: Add --pid option to all scripts
 # ###########################################################################
 `touch /tmp/pt-script.pid`;
-$output = `$trunk/bin/pt-slave-restart --max-sleep .25 -h 127.0.0.1 -P 12346 -u msandbox -p msandbox --pid /tmp/pt-script.pid 2>&1`;
+$output = `$trunk/bin/pt-slave-restart --max-sleep 0.25 -h 127.0.0.1 -P 12346 -u msandbox -p msandbox --pid /tmp/pt-script.pid 2>&1`;
 like(
    $output,
    qr{PID file /tmp/pt-script.pid already exists},

--- a/t/pt-table-checksum/basics.t
+++ b/t/pt-table-checksum/basics.t
@@ -357,7 +357,7 @@ like(
 $output = output(
    sub { $exit_status =  pt_table_checksum::main(
    qw(--user msandbox --pass msandbox),
-   qw(-S /tmp/12345/mysql_sandbox12345.sock --set-vars innodb_lock_wait_timeout=3 --run-time 5)) },
+   qw(-S /tmp/12345/mysql_sandbox12345.sock --set-vars innodb_lock_wait_timeout=3 --run-time 8)) },
    stderr => 1,
 );
 

--- a/t/pt-table-checksum/run_time.t
+++ b/t/pt-table-checksum/run_time.t
@@ -44,7 +44,7 @@ $exit_status = pt_table_checksum::main(@args,
 my $t  = time - $t0;
 
 ok(
-   $t >= 1.0 && $t <= 2.5 + $ENV{'PERCONA_SLOW_BOX'}*3,
+   $t >= 1.0 && $t <= ($ENV{PERCONA_SLOW_BOX} ? 5.5 : 2.5),
    "Ran in roughly --run-time 1 second"
 ) or diag("Actual run time: $t");
 


### PR DESCRIPTION
various fixes related to perl 5.22 

* printf/sprintf now emits a warning if receives more values than described in the format string.
Fixed by adding an index to each format symbol (no warnings are emitted if they have an index)

* The character multiplier function ( e.g: print "=" x $count ) now emits a warning if $count is negative.

* Unrelated to perl but to a CPAN module: GetOpt::Long has a few versions where it doesn't accept float values without the integer part (e.g.  .5 instead of 0.5 )
Just changed the tests in this case. 