### PR TITLE
new var binlog_error_action caused bug in collect module

### DIFF
--- a/bin/pt-stalk
+++ b/bin/pt-stalk
@@ -816,7 +816,7 @@ collect() {
 
    local mysql_version="$(awk '/^version[^_]/{print substr($2,1,3)}' "$d/$p-variables")"
 
-   local mysql_error_log="$(awk '/log_error/{print $2}' "$d/$p-variables")"
+   local mysql_error_log="$(awk '/^log_error/{print $2}' "$d/$p-variables")"
    if [ -z "$mysql_error_log" -a "$mysqld_pid" ]; then
       mysql_error_log="$(ls -l /proc/$mysqld_pid/fd | awk '/ 2 ->/{print $NF}')"
    fi
@@ -871,7 +871,6 @@ collect() {
       $CMD_SYSCTL -a >> "$d/$p-sysctl" &
    fi
 
-   # collect dmesg events from 60 seconds ago until present
    if [ "$CMD_DMESG" ]; then
       local UPTIME=`cat /proc/uptime | awk '{ print $1 }'`
       local START_TIME=$(echo "$UPTIME 60" | awk '{print ($1 - $2)}')
@@ -891,7 +890,6 @@ collect() {
       $CMD_MPSTAT -P ALL $OPT_SLEEP_COLLECT $cnt >> "$d/$p-mpstat" &
       $CMD_MPSTAT -P ALL $OPT_RUN_TIME 1 >> "$d/$p-mpstat-overall" &
    fi
-
 
    $CMD_MYSQLADMIN $EXT_ARGV ext -i$OPT_SLEEP_COLLECT -c$cnt >>"$d/$p-mysqladmin" &
    local mysqladmin_pid=$!


### PR DESCRIPTION
The shell "collect" module confused the new mysql var: "binlog_error_action" with "log_error"
https://dev.mysql.com/doc/refman/5.7/en/replication-options-binary-log.html#sysvar_binlog_error_action

Also aligned many module diffs with the one contained in pt-stalk (only tool that uses it)