### PR TITLE
pt-qd clarify attribute-value-limit in docs

### DIFF
--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -15243,6 +15243,7 @@ A sanity limit for attribute values.
 This option deals with bugs in slow logging functionality that causes large
 values for attributes.  If the attribute's value is bigger than this, the
 last-seen value for that class of query is used instead.
+The default is 4G (2^32). To disable (set no upper limit) set value to 0.
 
 =item --charset
 


### PR DESCRIPTION
clarify the way to disable --attribute-value-limit in the docs