### PR TITLE
Fix package name

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 
 WriteMakefile(
-    NAME      => 'percona-toolkit',
+    NAME      => 'Percona::Toolkit',
     VERSION   => '3.4.0',
     EXE_FILES => [ <bin/*> ],
     MAN1PODS  => {


### PR DESCRIPTION
The previous package name "percona-toolkit" is not a valid package name for
ExtUtils::MakeMaker:

> $ perl Makefile.PL
> Checking if your kit is complete...
> Looks good
> Warning: NAME must be a package name
> [...]

Let us use the same package name (Percona::Toolkit) various scripts in bin/
are already using.
