### PR TITLE
calrified pt-slave-restart --verbose doc

### DIFF
--- a/bin/pt-slave-restart
+++ b/bin/pt-slave-restart
@@ -5384,8 +5384,11 @@ unexpectedly, you should identify and fix the root cause.
 
 =head1 OUTPUT
 
-If you specify L<"--verbose">, pt-slave-restart prints a line every time it sees
-the slave has an error.  See L<"--verbose"> for details.
+pt-slave-restart prints a line every time it sees the slave has an error.
+By default this line is: a timestamp, connection information, relay_log_file, 
+relay_log_pos, and last_errno.
+You can add more information using the L<"--verbose"> option.
+You can supress all output using the L<"--quiet"> option.
 
 =head1 SLEEP
 
@@ -5788,10 +5791,13 @@ User for login if not current user.
 
 short form: -v; cumulative: yes; default: 1
 
-Be verbose; can specify multiple times.  Verbosity 1 outputs connection
-information, a timestamp, relay_log_file, relay_log_pos, and last_errno.
-Verbosity 2 adds last_error.  See also L<"--error-length">.  Verbosity 3 prints
-the current sleep time each time pt-slave-restart sleeps.
+Adds more information to the default output. 
+This flag can be specified multiple times. e.g. -v -v OR -vv.
+By default (no verbose flag) the tool outputs connection information, a timestamp, 
+relay_log_file, relay_log_pos, and last_errno.
+One flag (-v) adds last_error.  See also L<"--error-length">.  
+Two flags (-vv) prints the current sleep time each time pt-slave-restart sleeps.
+To supress all output use the L<"--quiet"> option. 
 
 =item --version
 


### PR DESCRIPTION
verbose option documentation in pt-slave-restart might lead to believe it required an integer as a parameter, instead of being a flag.