### PR TITLE
fix lp:1581752 5.7 compatibility for pt-query-digest, slow log time format

### DIFF
--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -4993,7 +4993,7 @@ sub new {
    return bless $self, $class;
 }
 
-my $slow_log_ts_line = qr/^# Time: ([0-9: ]{15})/;
+my $slow_log_ts_line = qr/^# Time: ((?:[0-9: ]{15})|(?:[-0-9: T]{19}))/;
 my $slow_log_uh_line = qr/# User\@Host: ([^\[]+|\[[^[]+\]).*?@ (\S*) \[(.*)\]\s*(?:Id:\s*(\d+))?/;
 my $slow_log_hd_line = qr{
       ^(?:

--- a/lib/SlowLogParser.pm
+++ b/lib/SlowLogParser.pm
@@ -41,7 +41,7 @@ sub new {
    return bless $self, $class;
 }
 
-my $slow_log_ts_line = qr/^# Time: ([0-9: ]{15})/;
+my $slow_log_ts_line = qr/^# Time: ((?:[0-9: ]{15})|(?:[-0-9: T]{19}))/;
 my $slow_log_uh_line = qr/# User\@Host: ([^\[]+|\[[^[]+\]).*?@ (\S*) \[(.*)\]\s*(?:Id:\s*(\d+))?/;
 # These can appear in the log file when it's opened -- for example, when someone
 # runs FLUSH LOGS or the server starts.


### PR DESCRIPTION
https://bugs.launchpad.net/percona-toolkit/+bug/1581752

Time field in slow log in 5.7 has new format:
"Time: 2016-05-14T05:28:50.060335Z"

Thus --since and --until pt-query-digest options producing empty result.