### PR TITLE
pt-query-digest changed default attribute-value-limit to disabled

### DIFF
--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -15262,14 +15262,14 @@ be report lines for both db and Schema.
 
 =item --attribute-value-limit
 
-type: int; default: 4294967296
+type: int; default: 0 
 
 A sanity limit for attribute values.
 
 This option deals with bugs in slow logging functionality that causes large
 values for attributes.  If the attribute's value is bigger than this, the
 last-seen value for that class of query is used instead.
-The default is 4G (2^32). To disable (set no upper limit) set value to 0.
+Disabled by default.
 
 =item --charset
 

--- a/t/pt-query-digest/mysql_analyses.t
+++ b/t/pt-query-digest/mysql_analyses.t
@@ -105,7 +105,7 @@ ok(
       sub { pt_query_digest::main(@args, $sample.'tcpdump-1402776.txt',
          '--report-format', 'header,query_report,profile',
          qw(--watch-server 127.0.0.1:13000)) },
-         "t/pt-query-digest/samples/tcpdump-1402776_report.txt"
+         "t/pt-query-digest/samples/tcpdump-1402776_report.txt", 
    ),
    'Analysis for tcpdump-1402776 with connection error (bug 1402776)'
 );


### PR DESCRIPTION
changed default attribute-value-limit to disabled, since some values are now exceeding de previous default 4G
e.g. number of rows returned