### PR TITLE
add enum column type to is_char check so that values are properly quoted

### DIFF
--- a/bin/pt-table-sync
+++ b/bin/pt-table-sync
@@ -3537,7 +3537,7 @@ sub make_UPDATE {
    my $types = $self->{tbl_struct}->{type_for};
    return "UPDATE $self->{dst_db_tbl} SET "
       . join(', ', map {
-            my $is_char  = ($types->{$_} || '') =~ m/char|text/i;
+            my $is_char  = ($types->{$_} || '') =~ m/char|text|enum/i;
             my $is_float = ($types->{$_} || '') =~ m/float|double/i;
             $self->{Quoter}->quote($_)
             . '='
@@ -3586,7 +3586,7 @@ sub make_row {
       . ') VALUES ('
       . join(', ',
             map {
-               my $is_char  = ($type_for->{$_} || '') =~ m/char|text/i;
+               my $is_char  = ($type_for->{$_} || '') =~ m/char|text|enum/i;
                my $is_float = ($type_for->{$_} || '') =~ m/float|double/i;
                $q->quote_val(
                      $row->{$_},
@@ -3602,7 +3602,7 @@ sub make_where_clause {
    my @clauses = map {
       my $val = $row->{$_};
       my $sep = defined $val ? '=' : ' IS ';
-      my $is_char  = ($self->{tbl_struct}->{type_for}->{$_} || '') =~ m/char|text/i;
+      my $is_char  = ($self->{tbl_struct}->{type_for}->{$_} || '') =~ m/char|text|enum/i;
       my $is_float = ($self->{tbl_struct}->{type_for}->{$_} || '') =~ m/float|double/i;
       $self->{Quoter}->quote($_) . $sep . $self->{Quoter}->quote_val($val,
                                               is_char  => $is_char,

--- a/lib/ChangeHandler.pm
+++ b/lib/ChangeHandler.pm
@@ -326,7 +326,7 @@ sub make_UPDATE {
    my $types = $self->{tbl_struct}->{type_for};
    return "UPDATE $self->{dst_db_tbl} SET "
       . join(', ', map {
-            my $is_char  = ($types->{$_} || '') =~ m/char|text/i;
+            my $is_char  = ($types->{$_} || '') =~ m/char|text|enum/i;
             my $is_float = ($types->{$_} || '') =~ m/float|double/i;
             $self->{Quoter}->quote($_)
             . '='


### PR DESCRIPTION
My particular use case is that I have an enum value "0x0" which gets caught up in the hexadecimal check in https://github.com/percona/percona-toolkit/blob/2.2/bin/pt-table-sync#L1895 .  When this occurs, pt-table-sync treats the value as a hexadecimal value and bombs out when I get a "Data truncated for column" mysql error on insert/update.