### PR TITLE
Bug-1592166 pt-kill leaks memory each time it kills a query

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,9 @@
 Changelog for Percona Toolkit
 
+v2.2.19
+
+ * Fixed bug 1592166:  pt-kill leaks memory
+
 v2.2.18 released 2016-06-24
 
  * Feature 1537416  :  pt-stalk now sorts the output of transactions by id

--- a/bin/pt-kill
+++ b/bin/pt-kill
@@ -3494,6 +3494,7 @@ sub find {
    my $ms  = $self->{MasterSlave};
 
    my @matches;
+   $self->{_reasons_for_matching} = undef;
    QUERY:
    foreach my $query ( @$proclist ) {
       PTDEBUG && _d('Checking query', Dumper($query));


### PR DESCRIPTION
The problem was the script was not cleaning up a structure where it holds the reasons that made the queries to match the rules.