### PR TITLE
BUG-1517155 Added --create-table-engine param to pt-heartbeat

### DIFF
--- a/bin/pt-heartbeat
+++ b/bin/pt-heartbeat
@@ -5821,7 +5821,16 @@ sub main {
       my $sql = $o->read_para_after(__FILE__, qr/MAGIC_create_heartbeat/);
       $sql =~ s/heartbeat/IF NOT EXISTS $db_tbl/;
       PTDEBUG && _d($sql);
-      $dbh->do($sql);
+      if ($o->get('create-table-engine')) {
+          my $engine = $o->get('create-table-engine');
+          $sql =~ s/;$/ ENGINE=$engine;/;
+          PTDEBUG && _d("Using engine $engine");
+          PTDEBUG && _d($sql);
+      }
+      eval { $dbh->do($sql); };
+      if ( $EVAL_ERROR ) {
+          die "Error creating heartbeat table:". $EVAL_ERROR;
+      }
      
       # Now we insert first row.
       # Some caveats:
@@ -6663,6 +6672,13 @@ or if using L<"--utc">:
 The tool automatically detects if the heartbeat table is legacy.
 
 See also L<"MULTI-SLAVE HIERARCHY">.
+
+=item --create-table-engine
+
+type: string
+
+Sets the engine to be used for the heartbeat table.
+The default storage engine is InnoDB as of MySQL 5.5.5.
 
 =item --daemonize
 

--- a/t/pt-heartbeat/basics.t
+++ b/t/pt-heartbeat/basics.t
@@ -166,6 +166,23 @@ is(
    '--create-table creates heartbeat table'
 ) or diag($output, Dumper($row));
 
+$master_dbh->do('drop table if exists test.heartbeat');
+$sb->wait_for_slaves;
+
+$output = output(
+   sub { pt_heartbeat::main('-F', $cnf,
+      qw(--update --run-time 1s --database test --table heartbeat),
+      qw(--create-table --create-table-engine MEMORY)) },
+   stderr => 1,
+);
+$master_dbh->do('use test');
+$row = $master_dbh->selectrow_hashref("SHOW TABLE STATUS LIKE 'heartbeat'");
+is(
+   uc($row->{engine}),
+   'MEMORY', 
+   '--create-table-engine creates heartbeat table using a non-default engine'
+) or diag($output, Dumper($row));
+
 # #############################################################################
 # Issue 352: Add port to mk-heartbeat --check output
 # #############################################################################


### PR DESCRIPTION
Now it is possible to set a stora engine for the heartbeat table, different than the DB default by using the `--create-table-engine` param.