### PR TITLE
Fix version check in pt-show-grants for MariaDB 10.0+

### DIFF
--- a/bin/pt-show-grants
+++ b/bin/pt-show-grants
@@ -1921,7 +1921,8 @@ sub main {
 
       # If MySQL 5.7.6+ then we need to use SHOW CREATE USER
       my @create_user;
-      if ( VersionCompare::cmp($version, '5.7.6') >= 0 ) {
+      if (( VersionCompare::cmp($version, '5.7.6') >= 0 ) &&
+          ( VersionCompare::cmp($version, '10.0.0') <= 0 )) {
          eval {
             @create_user = @{ $dbh->selectcol_arrayref("SHOW CREATE USER $user_host") };
          };


### PR DESCRIPTION
Fix pt-show-grants to run on MariaDB 10.0+

This was happening on 2.2.17:
```
$ sudo pt-show-grants
-- Grants dumped by pt-show-grants
-- Dumped from server Localhost via UNIX socket, MySQL 10.1.11-MariaDB-log at 2016-07-15 15:04:35
Use of uninitialized value $create in substitution (s///) at /usr/bin/pt-show-grants line 1923.
```