### PR TITLE
BUG-1581752-slow_log

### DIFF
--- a/bin/pt-index-usage
+++ b/bin/pt-index-usage
@@ -2799,7 +2799,7 @@ sub new {
    return bless $self, $class;
 }
 
-my $slow_log_ts_line = qr/^# Time: ([0-9: ]{15})/;
+my $slow_log_ts_line = qr/^# Time: ((?:[0-9: ]{15})|(?:[-0-9: T]{19}))/;
 my $slow_log_uh_line = qr/# User\@Host: ([^\[]+|\[[^[]+\]).*?@ (\S*) \[(.*)\]\s*(?:Id:\s*(\d+))?/;
 my $slow_log_hd_line = qr{
       ^(?:

--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -4993,7 +4993,7 @@ sub new {
    return bless $self, $class;
 }
 
-my $slow_log_ts_line = qr/^# Time: ([0-9: ]{15})/;
+my $slow_log_ts_line = qr/^# Time: ((?:[0-9: ]{15})|(?:[-0-9: T]{19}))/;
 my $slow_log_uh_line = qr/# User\@Host: ([^\[]+|\[[^[]+\]).*?@ (\S*) \[(.*)\]\s*(?:Id:\s*(\d+))?/;
 my $slow_log_hd_line = qr{
       ^(?:

--- a/bin/pt-table-usage
+++ b/bin/pt-table-usage
@@ -2239,7 +2239,7 @@ sub new {
    return bless $self, $class;
 }
 
-my $slow_log_ts_line = qr/^# Time: ([0-9: ]{15})/;
+my $slow_log_ts_line = qr/^# Time: ((?:[0-9: ]{15})|(?:[-0-9: T]{19}))/;
 my $slow_log_uh_line = qr/# User\@Host: ([^\[]+|\[[^[]+\]).*?@ (\S*) \[(.*)\]\s*(?:Id:\s*(\d+))?/;
 my $slow_log_hd_line = qr{
       ^(?:

--- a/bin/pt-upgrade
+++ b/bin/pt-upgrade
@@ -6628,7 +6628,7 @@ sub new {
    return bless $self, $class;
 }
 
-my $slow_log_ts_line = qr/^# Time: ([0-9: ]{15})/;
+my $slow_log_ts_line = qr/^# Time: ((?:[0-9: ]{15})|(?:[-0-9: T]{19}))/;
 my $slow_log_uh_line = qr/# User\@Host: ([^\[]+|\[[^[]+\]).*?@ (\S*) \[(.*)\]\s*(?:Id:\s*(\d+))?/;
 my $slow_log_hd_line = qr{
       ^(?:

--- a/lib/SlowLogParser.pm
+++ b/lib/SlowLogParser.pm
@@ -41,7 +41,7 @@ sub new {
    return bless $self, $class;
 }
 
-my $slow_log_ts_line = qr/^# Time: ([0-9: ]{15})/;
+my $slow_log_ts_line = qr/^# Time: ((?:[0-9: ]{15})|(?:[-0-9: T]{19}))/;
 my $slow_log_uh_line = qr/# User\@Host: ([^\[]+|\[[^[]+\]).*?@ (\S*) \[(.*)\]\s*(?:Id:\s*(\d+))?/;
 # These can appear in the log file when it's opened -- for example, when someone
 # runs FLUSH LOGS or the server starts.

--- a/t/lib/SlowLogParser.t
+++ b/t/lib/SlowLogParser.t
@@ -17,6 +17,46 @@ use PerconaTest;
 my $p      = new SlowLogParser;
 my $sample = "t/lib/samples/slowlogs";
 
+# Check that we can parse MySQL 5.7+ slow log with dates in RFC3339 format.
+test_log_parser(
+   parser => $p,
+   file   => "$sample/mysql5.7.log",
+   result => [
+   {
+     Lock_time => '0.000324',
+     Query_time => '0.003464',
+     Rows_examined => '2000',
+     Rows_sent => '1000',
+     Thread_id => '3',
+     arg => 'SELECT * FROM db_facturacion.facturas LIMIT 0, 1000',
+     bytes => 51,
+     cmd => 'Query',
+     host => 'localhost',
+     ip => '127.0.0.1',
+     pos_in_log => 0,
+     timestamp => '1469038405',
+     ts => '2016-07-20T18:13:25',
+     user => 'root'
+   },
+   {
+     Lock_time => '0.000055',
+     Query_time => '0.000241',
+     Rows_examined => '0',
+     Rows_sent => '0',
+     Thread_id => '4',
+     arg => 'SHOW INDEX FROM `db_facturacion`.`facturas`',
+     bytes => 43,
+     cmd => 'Query',
+     host => 'localhost',
+     ip => '127.0.0.1',
+     pos_in_log => 608,
+     timestamp => '1469038405',
+     ts => '2016-07-20T18:13:25',
+     user => 'root'
+   }
+
+   ],
+);
 # Check that I can parse a slow log in the default slow log format.
 test_log_parser(
    parser => $p,

--- a/t/lib/samples/slowlogs/mysql5.7.log
+++ b/t/lib/samples/slowlogs/mysql5.7.log
@@ -1,0 +1,16 @@
+/usr/sbin/mysqld, Version: 5.7.12-0ubuntu1.1-log ((Ubuntu)). started with:
+Tcp port: 3306  Unix socket: /var/run/mysqld/mysqld.sock
+Time                 Id Command    Argument
+/usr/sbin/mysqld, Version: 5.7.12-0ubuntu1.1-log ((Ubuntu)). started with:
+Tcp port: 3306  Unix socket: /var/run/mysqld/mysqld.sock
+Time                 Id Command    Argument
+# Time: 2016-07-20T18:13:25.698433Z
+# User@Host: root[root] @ localhost [127.0.0.1]  Id:     3
+# Query_time: 0.003464  Lock_time: 0.000324 Rows_sent: 1000  Rows_examined: 2000
+SET timestamp=1469038405;
+SELECT * FROM db_facturacion.facturas LIMIT 0, 1000;
+# Time: 2016-07-20T18:13:25.699880Z
+# User@Host: root[root] @ localhost [127.0.0.1]  Id:     4
+# Query_time: 0.000241  Lock_time: 0.000055 Rows_sent: 0  Rows_examined: 0
+SET timestamp=1469038405;
+SHOW INDEX FROM `db_facturacion`.`facturas`;


### PR DESCRIPTION
Tests added for SlowLogParser
SlowLogParser now is able to handle MySQL dates in RFC3339 format.
A new test for this case was added and all scripts using SlowLogParser in bin/ have been updated.
