### PR TITLE
Parse "use" to exclude NULs

### DIFF
--- a/bin/pt-index-usage
+++ b/bin/pt-index-usage
@@ -2910,7 +2910,7 @@ sub parse_event {
                push @properties, @temp;
             }
 
-            elsif ( !$got_db && (my ( $db ) = $line =~ m/^use ([^;]+)/ ) ) {
+            elsif ( !$got_db && (my ( $db ) = $line =~ m/^use ([^;\000]+)/ ) ) {
                PTDEBUG && _d("Got a default database:", $db);
                push @properties, 'db', $db;
                ++$got_db;

--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -5104,7 +5104,7 @@ sub parse_event {
                push @properties, @temp;
             }
 
-            elsif ( !$got_db && (my ( $db ) = $line =~ m/^use ([^;]+)/ ) ) {
+            elsif ( !$got_db && (my ( $db ) = $line =~ m/^use ([^;\000]+)/ ) ) {
                PTDEBUG && _d("Got a default database:", $db);
                push @properties, 'db', $db;
                ++$got_db;
@@ -9716,7 +9716,7 @@ sub parse_event {
 
          elsif ( $line =~ m/^(?:#|use |SET)/i ) {
 
-            if ( my ( $db ) = $line =~ m/^use ([^;]+)/ ) {
+            if ( my ( $db ) = $line =~ m/^use ([^;\000]+)/ ) {
                PTDEBUG && _d("Got a default database:", $db);
                push @properties, 'db', $db;
             }

--- a/bin/pt-table-usage
+++ b/bin/pt-table-usage
@@ -2350,7 +2350,7 @@ sub parse_event {
                push @properties, @temp;
             }
 
-            elsif ( !$got_db && (my ( $db ) = $line =~ m/^use ([^;]+)/ ) ) {
+            elsif ( !$got_db && (my ( $db ) = $line =~ m/^use ([^;\000]+)/ ) ) {
                PTDEBUG && _d("Got a default database:", $db);
                push @properties, 'db', $db;
                ++$got_db;

--- a/bin/pt-upgrade
+++ b/bin/pt-upgrade
@@ -6739,7 +6739,7 @@ sub parse_event {
                push @properties, @temp;
             }
 
-            elsif ( !$got_db && (my ( $db ) = $line =~ m/^use ([^;]+)/ ) ) {
+            elsif ( !$got_db && (my ( $db ) = $line =~ m/^use ([^;\000]+)/ ) ) {
                PTDEBUG && _d("Got a default database:", $db);
                push @properties, 'db', $db;
                ++$got_db;
@@ -7092,7 +7092,7 @@ sub parse_event {
 
          elsif ( $line =~ m/^(?:#|use |SET)/i ) {
 
-            if ( my ( $db ) = $line =~ m/^use ([^;]+)/ ) {
+            if ( my ( $db ) = $line =~ m/^use ([^;\000]+)/ ) {
                PTDEBUG && _d("Got a default database:", $db);
                push @properties, 'db', $db;
             }

--- a/lib/BinaryLogParser.pm
+++ b/lib/BinaryLogParser.pm
@@ -150,7 +150,7 @@ sub parse_event {
 
             # Include the current default database given by 'use <db>;'  Again
             # as per the code in sql/log.cc this is case-sensitive.
-            if ( my ( $db ) = $line =~ m/^use ([^;]+)/ ) {
+            if ( my ( $db ) = $line =~ m/^use ([^;\000]+)/ ) {
                PTDEBUG && _d("Got a default database:", $db);
                push @properties, 'db', $db;
             }

--- a/lib/SlowLogParser.pm
+++ b/lib/SlowLogParser.pm
@@ -219,7 +219,7 @@ sub parse_event {
 
             # Include the current default database given by 'use <db>;'  Again
             # as per the code in sql/log.cc this is case-sensitive.
-            elsif ( !$got_db && (my ( $db ) = $line =~ m/^use ([^;]+)/ ) ) {
+            elsif ( !$got_db && (my ( $db ) = $line =~ m/^use ([^;\000]+)/ ) ) {
                PTDEBUG && _d("Got a default database:", $db);
                push @properties, 'db', $db;
                ++$got_db;


### PR DESCRIPTION
### Short explanation

The NULs (byte `\000`) that, at least under some circumstances, terminate the name of the database in a `tcpdump` capture aren't processed as terminators by Percona Toolkit 2.2.14. Instead, its regex to find "use DB_NAME" calls for a semicolon terminator.

This is a highly-targeted patch that allows either semicolon or `\000` to terminate that match.

There may be other places where this change would be appropriate as well, but I didn't investigate that.
### Long explanation

In production, we did a `tcpdump` capture on Ubuntu 12.04 against MySQL 5.5.40-36.1-log, into the standard capture format because it's 1/3 the size (thus 1/3 the production disk I/O):

```
tcpdump -wcapture_db1.cap -s 0 -i bond0 port 3306
```

In order to do processing with Percona Toolkit, we then expanded/reformatted that packet capture using the stock Mac OS X `tcpdump`:

```
tcpdump -x -n -q -tttt -r capture_db1.cap > capture_db1.xnqtttt
```

I'm not savvy enough to read the raw bytestream, but both files include concatenated strings with NUL byte separators. Here's how they look to `less`:

```
capture_db1.cap:
MYSQL_USER^@^@DB_NAME^@mysql_native_password^@

capture_db1.xnqtttt:
2016-09-09 15:22:15.614678 IP x.x.x.x.58826 > y.y.y.y.3306: tcp 78
[...]
    0x0050:  [MYSQL_USER]00 00[DB_...
    0x0060:                     ...NAME]00 6d79 7371 # ^@mysq
    0x0070:  6c5f 6e61 7469 7665 5f70 6173 7377 6f72 # l_native_passwor
    0x0080:  6400                                    # d^@
2016-09-09 15:22:15.614689 ...
```

I can then write a slow query log successfully using `pt-query-digest`'s neat little feature to fake slow log output. But the resulting log continues to have NULs. Again on Mac OS X, PT 2.2.14:

```
$ pt-query-digest --type tcpdump --output slowlog --sample 200 --limit 5000 --no-report capture_db1.xnqtttt > capture_db1.slowlog
[...]
$ less capture_db1.slowlog
# Time: 160909 15:22:15.614623
# Client: x.x.x.x:38621
# Thread_id: 4294967413
# Query_time: 0.000253  Lock_time: 0.000000  Rows_sent: 0  Rows_examined: 0
use DB_NAME^@mysql_native_password;
SELECT [...]
```

A slow query log that identifies the database in question incorrectly is one thing. That's human-readable.

But in attempting to use the resulting log file with pt-index-usage, it tries to connect to a database of that name to run the EXPLAINs, and since it can't find that db, it errors out. Here's some output -- I manually added a `print Dumper $event` shortly before the error line:

```
$ pt-index-usage -h x -u x -D DB_NAME -d DB_NAME --save-results-database='D=capture_db1_pt_index,h=localhost,u=root' capture_db1.slowlog 2>&1 | head -n 60
$VAR1 = {
  Client => 'x.x.x.x:58822',
  Lock_time => '0.000000',
  Query_time => '0.000597',
  Rows_examined => '0',
  Rows_sent => '0',
  Thread_id => '246245003',
  arg => 'administrator command: Connect',
  bytes => 30,
  cmd => 'Admin',
  db => 'DB_NAMEmysql_native_password',
  fingerprint => 'administrator command: Connect',
  host => 'x.x.x.x',
  ip => '',
  pos_in_log => 285268,
  ts => '160909 15:22:15',
  user => 'MYSQL_USER'
};
DBD::mysql::db do failed: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '`DB_NAME' at line 1 [for Statement "USE `DB_NAME at /usr/local/Cellar/percona-toolkit/2.2.14/libexec/bin/pt-index-usage line 6574, <> line 673.
[...]
```

Once I patch the tool with the regex change in this PR (applied manually), it can at least process the NULlified slowlog.

```
$ pt-index-usage -h x -u x -D x -d DB_NAME --save-results-database='D=x,h=localhost,u=root' capture_db1.slowlog
capture_db1.slowlog:   1% 26:55 remain
[...]
```

I kind of assume the same change is going to let `pt-query-digest --output slowlog` work in the same fashion, but I admit I didn't try that.
