### PR TITLE
It isn't possible to build packages as cp: cannot stat `README'

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3,7 +3,7 @@ COPYING
 INSTALL
 Makefile.PL
 MANIFEST
-README
+README.md
 bin/pt-align
 bin/pt-archiver
 bin/pt-config-diff


### PR DESCRIPTION
README file was deleted and README.md has been created, but MANIFEST wasn't updated