### PR TITLE
PT-81 Collect information about locks and transactions using P_S

### DIFF
--- a/bin/pt-stalk
+++ b/bin/pt-stalk
@@ -1074,6 +1074,10 @@ ps_locks_transactions() {
       echo -e "\n$status\n" >> $outfile
       $CMD_MYSQL $EXT_ARGV -e "$status" >> $outfile
 
+      local status="select t.processlist_id, th.* from performance_schema.table_handles th left join performance_schema.threads t on (th.owner_thread_id=t.thread_id)\G"
+      echo -e "\n$status\n" >> $outfile
+      $CMD_MYSQL $EXT_ARGV -e "$status" >> $outfile
+
       local status="select t.processlist_id, et.* from performance_schema.events_transactions_current et join performance_schema.threads t using(thread_id)\G"
       echo -e "\n$status\n" >> $outfile
       $CMD_MYSQL $EXT_ARGV -e "$status" >> $outfile

--- a/bin/pt-stalk
+++ b/bin/pt-stalk
@@ -832,6 +832,8 @@ collect() {
       log "Could not find the MySQL error log"
    fi
 
+   ps_locks_transactions "$d/$p-ps-locks-transactions"
+
    if [ "${mysql_version}" '>' "5.1" ]; then
       local mutex="SHOW ENGINE INNODB MUTEX"
    else
@@ -1060,6 +1062,29 @@ tokudb_status() {
 
     $CMD_MYSQL $EXT_ARGV -e "SHOW ENGINE TOKUDB STATUS\G" \
       >> "$d/$p-tokudbstatus$n" || rm -f "$d/$p-tokudbstatus$n"
+}
+
+ps_locks_transactions() {
+   local outfile=$1 
+   
+   mysql -e 'select @@performance_schema' | grep "1" &>/dev/null
+
+   if [ $? -eq 0 ]; then
+      local status="select t.processlist_id, ml.* from performance_schema.metadata_locks ml join performance_schema.threads t on (ml.owner_thread_id=t.thread_id)\G"
+      echo -e "\n$status\n" >> $outfile
+      $CMD_MYSQL $EXT_ARGV -e "$status" >> $outfile
+
+      local status="select t.processlist_id, et.* from performance_schema.events_transactions_current et join performance_schema.threads t using(thread_id)\G"
+      echo -e "\n$status\n" >> $outfile
+      $CMD_MYSQL $EXT_ARGV -e "$status" >> $outfile
+
+      local status="select t.processlist_id, et.* from performance_schema.events_transactions_history_long et join performance_schema.threads t using(thread_id)\G"
+      echo -e "\n$status\n" >> $outfile
+      $CMD_MYSQL $EXT_ARGV -e "$status" >> $outfile
+  else
+      echo "Performance schema is not enabled" >> outfile
+   fi
+
 }
 
 innodb_status() {

--- a/bin/pt-stalk
+++ b/bin/pt-stalk
@@ -1082,7 +1082,7 @@ ps_locks_transactions() {
       echo -e "\n$status\n" >> $outfile
       $CMD_MYSQL $EXT_ARGV -e "$status" >> $outfile
   else
-      echo "Performance schema is not enabled" >> outfile
+      echo "Performance schema is not enabled" >> $outfile
    fi
 
 }


### PR DESCRIPTION
Performance Schema allows to collect information about metadata, table locks as well as on server level transaction. Please collect it if enabled:

`select t.processlist_id, ml.* from performance_schema.metadata_locks ml join performance_schema.threads t on (ml.owner_thread_id=t.thread_id);`

`select t.processlist_id, th.* from performance_schema.table_handles th left join performance_schema.threads t on (th.owner_thread_id=t.thread_id);`

`select t.processlist_id, et.* from performance_schema.events_transactions_current et join performance_schema.threads t using(thread_id);`

`select t.processlist_id, et.* from performance_schema.events_transactions_history_long et join performance_schema.threads t using(thread_id);`

Launchpad: https://bugs.launchpad.net/percona-toolkit/+bug/1642751