### PR TITLE
Add prove2junit.pl script to parse mysql test results into format jenkins can understand

### DIFF
--- a/sandbox/prove2junit.pl
+++ b/sandbox/prove2junit.pl
@@ -1,0 +1,25 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+my $file = $ARGV[0];
+my $testcase = "";
+my $error_collect = "";
+my $error_print = "";
+
+if (not defined $file) {
+  die "Need filename as parameter!\n";
+}
+
+open (my $info, $file) or die "Could not open $file: $!";
+
+print "<testsuite name=\"PT MySQL Test\">\n";
+while(my $line = <$info>) {
+  if ($line =~ /^(t\/\S+).* (\.*) (skipped:) (.*)$/) { print "<testcase name=\"$1\"><skipped/><system-out>Skip reason:<![CDATA[ $4 ]]></system-out></testcase>\n"; }
+  elsif ($line =~ /^ok (\d+) - (.*)$/) { print "<testcase name=\"$testcase - test $1\"><system-out>Test description:<![CDATA[ $2 ]]></system-out></testcase>\n"; }
+  elsif ($line =~ /^not ok (\d+) - (.*)$/) { print "<testcase name=\"$testcase - test $1\"><failure/><system-out>Test description:<![CDATA[ $2 ]]></system-out><system-err><![CDATA[ $error_print ]]></system-err></testcase>\n"; }
+  elsif ($line =~ /^(t\/\S+).* (\.*) $/) { $testcase = "$1"; $error_print = $error_collect; $error_collect = ""; }
+  elsif ($line !~ /^ok$/ && $line !~ /^\d+..\d+$/) { $error_collect = $error_collect . $line; }
+}
+print "</testsuite>\n"

--- a/t/pt-online-schema-change/alter_active_table.t
+++ b/t/pt-online-schema-change/alter_active_table.t
@@ -165,7 +165,7 @@ else {
 }
 $master_dbh->do("USE pt_osc");
 $master_dbh->do("TRUNCATE TABLE t");
-$master_dbh->do("LOAD DATA INFILE '$trunk/t/pt-online-schema-change/samples/basic_no_fks.data' INTO TABLE t");
+$master_dbh->do("LOAD DATA LOCAL INFILE '$trunk/t/pt-online-schema-change/samples/basic_no_fks.data' INTO TABLE t");
 $master_dbh->do("ANALYZE TABLE t");
 $sb->wait_for_slaves();
 
@@ -215,7 +215,7 @@ is(
 
 $master_dbh->do("USE pt_osc");
 $master_dbh->do("TRUNCATE TABLE t");
-$master_dbh->do("LOAD DATA INFILE '$trunk/t/pt-online-schema-change/samples/basic_no_fks.data' INTO TABLE t");
+$master_dbh->do("LOAD DATA LOCAL INFILE '$trunk/t/pt-online-schema-change/samples/basic_no_fks.data' INTO TABLE t");
 $master_dbh->do("ANALYZE TABLE t");
 $sb->wait_for_slaves();
 


### PR DESCRIPTION
The are some packages in at least ubuntu distro that can parse `prove` results into `junit` format, but there's many more perl dependencies for this and I didn't test it. Also it might not be available in all distributions.
This short script should work well for us to have some normal report in jenkins for mysql related tests.
Also there's a small "fix" for alter_active_table.t test which I needed to be able to complete the whole test suite. If that fix is not appropriate let me know and I'll remove it from the PR.

One of the jenkins jobs for which I use prove2junit.pl is here:
http://jenkins.percona.com/view/PT/job/percona-toolkit-param/

Parsed test results look like this:
http://jenkins.percona.com/view/PT/job/percona-toolkit-param/16/testReport/