### PR TITLE
Adding replSetGetConfig structs

### DIFF
--- a/src/go/mongolib/proto/replconfig.go
+++ b/src/go/mongolib/proto/replconfig.go
@@ -4,8 +4,8 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
-type ReplConfigTags map[string]string
-type GetLastErrorModes map[string]*ReplConfigTags
+type ReplicaSetConfigTags map[string]string
+type GetLastErrorModes map[string]*ReplicaSetConfigTags
 
 // https://docs.mongodb.com/v3.2/reference/command/getLastError/#dbcmd.getLastError
 type GetLastErrorDefaults struct {
@@ -15,16 +15,16 @@ type GetLastErrorDefaults struct {
 }
 
 // https://docs.mongodb.com/v3.2/reference/replica-configuration/#rsconf.members
-type ReplConfigMember struct {
-	ID           int64           `bson:"_id,omitempty"`          // An integer identifier of every member in the replica set.
-	Host         string          `bson:"host,omitempty"`         // The hostname and, if specified, the port number, of the set member.
-	ArbiterOnly  bool            `bson:"arbiterOnly,omitempty"`  // A boolean that identifies an arbiter. A value of true indicates that the member is an arbiter.
-	BuildIndexes bool            `bson:"buildIndexes,omitempty"` // A boolean that indicates whether the mongod builds indexes on this member.
-	Hidden       bool            `bson:"hidden,omitempty"`       // When this value is true, the replica set hides this instance and does not include the member in the output of db.isMaster() or isMaster.
-	Priority     int64           `bson:"priority,omitempty"`     // A number that indicates the relative eligibility of a member to become a primary.
-	Tags         *ReplConfigTags `bson:"tags,omitempty"`         // A tag set document containing mappings of arbitrary keys and values.
-	SlaveDelay   int64           `bson:"slaveDelay,omitempty"`   // The number of seconds “behind” the primary that this replica set member should “lag”.
-	Votes        int64           `bson:"votes,omitempty"`        // The number of votes a server will cast in a replica set election.
+type ReplicaSetConfigMember struct {
+	ID           int64                 `bson:"_id,omitempty"`          // An integer identifier of every member in the replica set.
+	Host         string                `bson:"host,omitempty"`         // The hostname and, if specified, the port number, of the set member.
+	ArbiterOnly  bool                  `bson:"arbiterOnly,omitempty"`  // A boolean that identifies an arbiter. A value of true indicates that the member is an arbiter.
+	BuildIndexes bool                  `bson:"buildIndexes,omitempty"` // A boolean that indicates whether the mongod builds indexes on this member.
+	Hidden       bool                  `bson:"hidden,omitempty"`       // When this value is true, the replica set hides this instance and does not include the member in the output of db.isMaster() or isMaster.
+	Priority     int64                 `bson:"priority,omitempty"`     // A number that indicates the relative eligibility of a member to become a primary.
+	Tags         *ReplicaSetConfigTags `bson:"tags,omitempty"`         // A tag set document containing mappings of arbitrary keys and values.
+	SlaveDelay   int64                 `bson:"slaveDelay,omitempty"`   // The number of seconds “behind” the primary that this replica set member should “lag”.
+	Votes        int64                 `bson:"votes,omitempty"`        // The number of votes a server will cast in a replica set election.
 }
 
 // https://docs.mongodb.com/v3.2/reference/replica-configuration/#rsconf.settings
@@ -42,7 +42,7 @@ type ReplicaSetConfig struct {
 	Config struct {
 		ID       string                    `bson:"_id,omitempty"`      // The name of the replica set. Once set, you cannot change the name of a replica set.
 		Version  int64                     `bson:"version,omitempty"`  // An incrementing number used to distinguish revisions of the replica set configuration object from previous iterations.
-		Members  []*ReplConfigMember       `bson:"members,omitempty"`  // An array of member configuration documents, one for each member of the replica set.
+		Members  []*ReplicaSetConfigMember `bson:"members,omitempty"`  // An array of member configuration documents, one for each member of the replica set.
 		Settings *ReplicaSetConfigSettings `bson:"settings,omitempty"` // A document that contains configuration options that apply to the whole replica set.
 	} `bson:"config,omitempty"` // https://docs.mongodb.com/v3.2/reference/replica-configuration/#replica-set-configuration-fields
 	Ok int64 `bson:"ok,omitempty"`

--- a/src/go/mongolib/proto/replconfig.go
+++ b/src/go/mongolib/proto/replconfig.go
@@ -40,10 +40,11 @@ type ReplicaSetConfigSettings struct {
 
 type ReplicaSetConfig struct {
 	Config struct {
-		ID       string                    `bson:"_id,omitempty"`      // The name of the replica set. Once set, you cannot change the name of a replica set.
-		Version  int64                     `bson:"version,omitempty"`  // An incrementing number used to distinguish revisions of the replica set configuration object from previous iterations.
-		Members  []*ReplicaSetConfigMember `bson:"members,omitempty"`  // An array of member configuration documents, one for each member of the replica set.
-		Settings *ReplicaSetConfigSettings `bson:"settings,omitempty"` // A document that contains configuration options that apply to the whole replica set.
+		ID              string                    `bson:"_id,omitempty"`             // The name of the replica set. Once set, you cannot change the name of a replica set.
+		ProtocolVersion int64                     `bson:"protocolVersion,omitempty"` // By default, new replica sets in MongoDB 3.2 use protocolVersion: 1. Previous versions of MongoDB use version 0.
+		Version         int64                     `bson:"version,omitempty"`         // An incrementing number used to distinguish revisions of the replica set configuration object from previous iterations.
+		Members         []*ReplicaSetConfigMember `bson:"members,omitempty"`         // An array of member configuration documents, one for each member of the replica set.
+		Settings        *ReplicaSetConfigSettings `bson:"settings,omitempty"`        // A document that contains configuration options that apply to the whole replica set.
 	} `bson:"config,omitempty"` // https://docs.mongodb.com/v3.2/reference/replica-configuration/#replica-set-configuration-fields
 	Ok int64 `bson:"ok,omitempty"`
 }

--- a/src/go/mongolib/proto/replconfig.go
+++ b/src/go/mongolib/proto/replconfig.go
@@ -1,0 +1,49 @@
+package proto
+
+import (
+	"gopkg.in/mgo.v2/bson"
+)
+
+type ReplConfigTags map[string]string
+type GetLastErrorModes map[string]*ReplConfigTags
+
+// https://docs.mongodb.com/v3.2/reference/command/getLastError/#dbcmd.getLastError
+type GetLastErrorDefaults struct {
+	Journal      bool  `bson:"j,omitempty"`        // If true, wait for the next journal commit before returning, rather than waiting for a full disk flush.
+	WriteConcern int64 `bson:"w,omitempty"`        // When running with replication, this is the number of servers to replicate to before returning.
+	WTimeout     int64 `bson:"wtimeout,omitempty"` // Optional. Milliseconds. Specify a value in milliseconds to control how long to wait for write propagation to complete.
+}
+
+// https://docs.mongodb.com/v3.2/reference/replica-configuration/#rsconf.members
+type ReplConfigMember struct {
+	ID           int64           `bson:"_id,omitempty"`          // An integer identifier of every member in the replica set.
+	Host         string          `bson:"host,omitempty"`         // The hostname and, if specified, the port number, of the set member.
+	ArbiterOnly  bool            `bson:"arbiterOnly,omitempty"`  // A boolean that identifies an arbiter. A value of true indicates that the member is an arbiter.
+	BuildIndexes bool            `bson:"buildIndexes,omitempty"` // A boolean that indicates whether the mongod builds indexes on this member.
+	Hidden       bool            `bson:"hidden,omitempty"`       // When this value is true, the replica set hides this instance and does not include the member in the output of db.isMaster() or isMaster.
+	Priority     int64           `bson:"priority,omitempty"`     // A number that indicates the relative eligibility of a member to become a primary.
+	Tags         *ReplConfigTags `bson:"tags,omitempty"`         // A tag set document containing mappings of arbitrary keys and values.
+	SlaveDelay   int64           `bson:"slaveDelay,omitempty"`   // The number of seconds “behind” the primary that this replica set member should “lag”.
+	Votes        int64           `bson:"votes,omitempty"`        // The number of votes a server will cast in a replica set election.
+}
+
+// https://docs.mongodb.com/v3.2/reference/replica-configuration/#rsconf.settings
+type ReplicaSetConfigSettings struct {
+	ChainingAllowed         bool                  `bson:"chainingAllowed,omitempty"`         // When chainingAllowed is true, the replica set allows secondary members to replicate from other secondary members.
+	HeartbeatTimeoutSecs    int64                 `bson:"heartbeatTimeoutSecs,omitempty"`    // Number of seconds that the replica set members wait for a successful heartbeat from each other.
+	HeartbeatIntervalMillis int64                 `bson:"heartbeatIntervalMillis,omitempty"` // The frequency in milliseconds of the heartbeats.
+	ElectionTimeoutMillis   int64                 `bson:"electionTimeoutMillis,omitempty"`   // The time limit in milliseconds for detecting when a replica set’s primary is unreachable.
+	GetLastErrorDefaults    *GetLastErrorDefaults `bson:"getLastErrorDefaults,omitempty"`    // A document that specifies the write concern for the replica set.
+	GetLastErrorModes       *GetLastErrorModes    `bson:"getLastErrorModes,omitempty"`       // A document used to define an extended write concern through the use of members[n].tags.
+	ReplicaSetId            *bson.ObjectId        `bson:"replicaSetId,omitempty"`            // Replset Id (ObjectId)
+}
+
+type ReplicaSetConfig struct {
+	Config struct {
+		ID       string                    `bson:"_id,omitempty"`      // The name of the replica set. Once set, you cannot change the name of a replica set.
+		Version  int64                     `bson:"version,omitempty"`  // An incrementing number used to distinguish revisions of the replica set configuration object from previous iterations.
+		Members  []*ReplConfigMember       `bson:"members,omitempty"`  // An array of member configuration documents, one for each member of the replica set.
+		Settings *ReplicaSetConfigSettings `bson:"settings,omitempty"` // A document that contains configuration options that apply to the whole replica set.
+	} `bson:"config,omitempty"` // https://docs.mongodb.com/v3.2/reference/replica-configuration/#replica-set-configuration-fields
+	Ok int64 `bson:"ok,omitempty"`
+}


### PR DESCRIPTION
replSetGetConfig structs:

https://docs.mongodb.com/v3.2/reference/command/replSetGetConfig/

```
[tim@centos7 tmp]$ cat test.go 
package main

import (
	"fmt"

	"github.com/percona/percona-toolkit/src/go/mongolib/proto"
	"gopkg.in/mgo.v2"
	"gopkg.in/mgo.v2/bson"
)

func main() {
	session, err := mgo.Dial("mongodb://localhost:27017")
	if err != nil {
		panic(err)
	}
	out := &proto.ReplicaSetConfig{}
	err = session.DB("admin").Run(bson.D{{"replSetGetConfig", 1}}, out)
	if err != nil {
		panic(err)
	}
	fmt.Println(out.Config)
	for _, member := range out.Config.Members {
		fmt.Println(member)
	}
	fmt.Println(out.Config.Settings)
}
[tim@centos7 tmp]$ go run test.go 
{test1 2 [0xc420018880 0xc420018980] 0xc4200189c0}
&{0 localhost:27017 false true false 1 0xc4200260d0 0 1}
&{1 localhost:27027 false true false 1 0xc4200260e8 0 1}
&{true 10 2000 10000 0xc420010da0 0xc4200260f8 ObjectIdHex("58bee0384464a11ae86c0977")}
[tim@centos7 tmp]$ mongo --quiet --eval 'db.serverStatus().version'
3.2.11-3.1
```