### PR TITLE
Oplog struct update

### DIFF
--- a/src/go/mongolib/proto/oplog.go
+++ b/src/go/mongolib/proto/oplog.go
@@ -41,11 +41,13 @@ func (s OpLogs) Less(i, j int) bool {
 }
 
 type OplogRow struct {
-	H  int64  `bson:"h"`
-	V  int64  `bson:"v"`
-	Op string `bson:"op"`
-	O  bson.M `bson:"o"`
-	Ts int64  `bson:"ts"`
+	Timestamp int64  `bson:"ts,omitempty"`
+	HistoryId int64  `bson:"h,omitempty"`
+	Version   int64  `bson:"v,omitempty"`
+	Operation string `bson:"op,omitempty"`
+	Namespace string `bson:"ns,omitempty"`
+	Object    bson.D `bson:"o,omitempty"`
+	Query     bson.D `bson:"o2,omitempty"`
 }
 
 type OplogColStats struct {


### PR DESCRIPTION
https://github.com/mongodb/mongo-tools/blob/master/common/db/db.go#L83

1. Added missing oplog document fields ("ns" + "o2")
2. Moved to ordered bson.D for object and query fields (instead of bson.M - somewhere this matters).
3. Moved to descriptive struct field names. This struct doesn't seem to be used anywhere yet but let me know if this is breaking.
4. Used 'omitempty' hints to bson marshaller to remove empty fields. Not all of these fields exist in every oplog document so I believe this saves space.