### PR TITLE
Turn off statement based binlog checks

### DIFF
--- a/bin/pt-table-checksum
+++ b/bin/pt-table-checksum
@@ -9272,35 +9272,36 @@ sub main {
          die "Error setting SQL_MODE"
            . ": $EVAL_ERROR";
       }
- 
 
-      # https://bugs.launchpad.net/percona-toolkit/+bug/919352
-      # The tool shouldn't blindly attempt to change binlog_format;
-      # instead, it should check if it's already set to STATEMENT.
-      # This is becase starting with MySQL 5.1.29, changing the format
-      # requires a SUPER user.
-      if ( VersionParser->new($dbh) >= '5.1.5' ) {
-         $sql = 'SELECT @@binlog_format';
-         PTDEBUG && _d($dbh, $sql);
-         my ($original_binlog_format) = $dbh->selectrow_array($sql);
-         PTDEBUG && _d('Original binlog_format:', $original_binlog_format);
-         if ( $original_binlog_format !~ /STATEMENT/i ) {
-            $sql = q{/*!50108 SET @@binlog_format := 'STATEMENT'*/};
-            eval {
-               PTDEBUG && _d($dbh, $sql);
-               $dbh->do($sql);
-            };
-            if ( $EVAL_ERROR ) {
-               die "Failed to $sql: $EVAL_ERROR\n"
-                  . "This tool requires binlog_format=STATEMENT, "
-                  . "but the current binlog_format is set to "
-                  ."$original_binlog_format and an error occurred while "
-                  . "attempting to change it.  If running MySQL 5.1.29 or newer, "
-                  . "setting binlog_format requires the SUPER privilege.  "
-                  . "You will need to manually set binlog_format to 'STATEMENT' "
-                  . "before running this tool.\n";
-            }
-         }
+      if ( $o->get('check-binlog-format') ) {
+        # https://bugs.launchpad.net/percona-toolkit/+bug/919352
+        # The tool shouldn't blindly attempt to change binlog_format;
+        # instead, it should check if it's already set to STATEMENT.
+        # This is becase starting with MySQL 5.1.29, changing the format
+        # requires a SUPER user.
+        if ( VersionParser->new($dbh) >= '5.1.5' ) {
+           $sql = 'SELECT @@binlog_format';
+           PTDEBUG && _d($dbh, $sql);
+           my ($original_binlog_format) = $dbh->selectrow_array($sql);
+           PTDEBUG && _d('Original binlog_format:', $original_binlog_format);
+           if ( $original_binlog_format !~ /STATEMENT/i ) {
+              $sql = q{/*!50108 SET @@binlog_format := 'STATEMENT'*/};
+              eval {
+                 PTDEBUG && _d($dbh, $sql);
+                 $dbh->do($sql);
+              };
+              if ( $EVAL_ERROR ) {
+                 die "Failed to $sql: $EVAL_ERROR\n"
+                    . "This tool requires binlog_format=STATEMENT, "
+                    . "but the current binlog_format is set to "
+                    ."$original_binlog_format and an error occurred while "
+                    . "attempting to change it.  If running MySQL 5.1.29 or newer, "
+                    . "setting binlog_format requires the SUPER privilege.  "
+                    . "You will need to manually set binlog_format to 'STATEMENT' "
+                    . "before running this tool.\n";
+              }
+           }
+        }
       }
 
       # Set transaction isolation level. We set binlog_format to STATEMENT,


### PR DESCRIPTION
For RDS we use row based replication however `pt-table-checksum` wants
to enforce statement and despite passing in the
`--no-check-binlog-format` flag, it would still run it (even though the
documentation [suggests](https://www.percona.com/doc/percona-toolkit/3.0/pt-table-checksum.html#cmdoption-pt-table-checksum--[no]check-binlog-format) it shouldn't). This appears to be a bug
because there is another binlog format check that is wrapped in
`$o->get('check-binlog-format')` slightly further down.

To resolve this, I've updated the remaining binlog format check in the
same expression as the one below and it now honours the
`--no-check-binlog-format` as expected.