### PR TITLE
We should regenerate manifets before creating tar

### DIFF
--- a/util/build-packages
+++ b/util/build-packages
@@ -342,6 +342,7 @@ prep_release_dir() {
       cd $RELEASE_DIR
       mkdir -p $PKG $PKG/bin $PKG/docs $PKG/lib
    )
+   update_manifest
    for file in `cat MANIFEST`; do
       cp $file $RELEASE_DIR/$PKG/$file
    done


### PR DESCRIPTION
As we are compiling mongo tools we couldn't add pt-mongo-* files into MANIFEST on preparation stage as these files doesn't exist. s other tools might be compiled in future the best approach is to regenerate MANIFEST before making tarball