### PR TITLE
Fix in MariaDB sandbox for pt-config-diff/basics.t tests

### DIFF
--- a/sandbox/servers/mariadb/10.0/my.sandbox.cnf
+++ b/sandbox/servers/mariadb/10.0/my.sandbox.cnf
@@ -26,4 +26,4 @@ log-error                  = /tmp/PORT/data/mysqld.log
 innodb_lock_wait_timeout   = 3
 general_log
 general_log_file           = genlog
-performance_schema         = on
+performance_schema         = ON

--- a/sandbox/servers/mariadb/10.1/my.sandbox.cnf
+++ b/sandbox/servers/mariadb/10.1/my.sandbox.cnf
@@ -26,4 +26,4 @@ log-error                  = /tmp/PORT/data/mysqld.log
 innodb_lock_wait_timeout   = 3
 general_log
 general_log_file           = genlog
-performance_schema         = on
+performance_schema         = ON


### PR DESCRIPTION
The error was this:
```#   Failed test 'my.sandbox.cnf doesn't differ with active config'
#   at t/pt-config-diff/basics.t line 90.
#          got: '1'
#     expected: '0'

#   Failed test 'No output'
#   at t/pt-config-diff/basics.t line 96.
#          got: '1 config difference
# Variable                  /tmp/12345/my.sandbox.cnf v-ubuntu-xenial-x64-01
# ========================= ========================= ======================
# performance_schema        on                        ON
# '
#     expected: ''```