### PR TITLE
pt-stalk ps include memory usage outputs

### DIFF
--- a/bin/pt-stalk
+++ b/bin/pt-stalk
@@ -865,7 +865,7 @@ collect() {
       local strace_pid=$!
    fi
 
-   ps -eaf  >> "$d/$p-ps"  &
+   ps -eaF  >> "$d/$p-ps"  &
    top -bn${OPT_RUN_TIME} >> "$d/$p-top" &
 
    [ "$mysqld_pid" ] && _lsof $mysqld_pid >> "$d/$p-lsof" &
@@ -956,7 +956,6 @@ collect() {
          (echo $ts; transactions) >>"$d/$p-transactions" &
       fi
 
-      echo "$ps_instrumentation_enabled" > /tmp/k1
       if [ "${mysql_version}" '>' "5.6" ] && [ $ps_instrumentation_enabled == "yes" ]; then
          ps_locks_transactions "$d/$p-ps-locks-transactions"
       fi
@@ -1148,6 +1147,7 @@ slave_status() {
       echo -e "\n$sql\n" >> $outfile
       $CMD_MYSQL $EXT_ARGV -e "$sql" >> $outfile
    fi
+
 }
 
 collect_mysql_variables() {
@@ -1168,6 +1168,7 @@ collect_mysql_variables() {
    sql="select * from performance_schema.status_by_thread order by thread_id, variable_name; "
    echo -e "\n$sql\n" >> $outfile
    $CMD_MYSQL $EXT_ARGV -e "$sql" >> $outfile
+
 }
 
 # ###########################################################################

--- a/lib/bash/collect.sh
+++ b/lib/bash/collect.sh
@@ -141,7 +141,7 @@ collect() {
 
    # Grab a few general things first.  Background all of these so we can start
    # them all up as quickly as possible.  
-   ps -eaf  >> "$d/$p-ps"  &
+   ps -eaF  >> "$d/$p-ps"  &
    top -bn${OPT_RUN_TIME} >> "$d/$p-top" &
 
    [ "$mysqld_pid" ] && _lsof $mysqld_pid >> "$d/$p-lsof" &


### PR DESCRIPTION
Pull request for changes for LP: 1510809.

`ps` outputs will now have the following additional columns:

```    
    SZ   size in physical pages of the core image of the process.
         This includes text, data, and stack space.  Device mappings
         are currently excluded; this is subject to change.
    
    RSS  resident set size, the non-swapped physical memory that a
         task has used (inkiloBytes).
    
    PSR  processor that process is currently assigned to.
```

No columns were removed from the outputs. I tried that the changes were minimal, this is why I only changed `-f` for `-F`. If more information on memory usage is needed, one can check the `top` outputs from `pt-stalk`.

All tests passed:

```
All tests successful.
Files=3, Tests=42, 100 wallclock secs ( 0.07 usr  0.02 sys +  5.84 cusr 14.53 csys = 20.46 CPU)
Result: PASS
```