### PR TITLE
PT-132 pt-online-schema-change should imply --no-drop-new-table when --no-swap-tables and --no-drop-triggers used

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -8195,9 +8195,9 @@ sub main {
 
    # Explicit --chunk-size disable auto chunk sizing.
    $o->set('chunk-time', 0) if $o->got('chunk-size');
-   if ($o->get('no-swap-tables') && $o->get('no-drop-triggers')) {
+   if (!$o->get('swap-tables') && !$o->get('drop-triggers')) {
        PTDEBUG && _d('Enabling no-drop-new-table since no-swap-tables & no-drop-triggers were specified');
-       $o->set('no-drop-new-table', 1);
+       $o->set('drop-new-table', 0);
    }
 
    foreach my $opt ( qw(max-load critical-load) ) {

--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -8195,6 +8195,10 @@ sub main {
 
    # Explicit --chunk-size disable auto chunk sizing.
    $o->set('chunk-time', 0) if $o->got('chunk-size');
+   if ($o->get('no-swap-tables') && $o->get('no-drop-triggers')) {
+       PTDEBUG && _d('Enabling no-drop-new-table since no-swap-tables & no-drop-triggers were specified');
+       $o->set('no-drop-new-table', 1);
+   }
 
    foreach my $opt ( qw(max-load critical-load) ) {
       next unless $o->has($opt);

--- a/t/pt-online-schema-change/no_drop_no_swap.t
+++ b/t/pt-online-schema-change/no_drop_no_swap.t
@@ -69,6 +69,27 @@ is_deeply(
 ) or diag(Dumper($tables), $output);
 
 # #############################################################################
+# --no-swap-tables --no-drop-triggers implies --no-drop-new-table
+# #############################################################################
+$sb->load_file('master', "$sample/basic_no_fks_innodb.sql");
+
+$output = output(
+   sub { pt_online_schema_change::main(
+      "$master_dsn,D=pt_osc,t=t",
+      '--alter', 'ADD COLUMN d INT',
+      qw(--execute --no-swap-tables --no-drop-triggers))
+   },
+   stderr => 1,
+);
+
+$tables = $dbh1->selectall_arrayref("SHOW TABLES FROM pt_osc");
+is_deeply(
+   $tables,
+   [ ['_t_new'], ['t'] ],
+   "no swap-tables, --no-drop-triggers implies --no-drop-new-table"
+) or diag(Dumper($tables), $output);
+
+# #############################################################################
 # Done.
 # #############################################################################
 $sb->wipe_clean($dbh1);


### PR DESCRIPTION
Jira: https://jira.percona.com/browse/PT-132
Launchpad: https://bugs.launchpad.net/percona-toolkit/+bug/1658274