### PR TITLE
PT-135 - Only return slaves which have a port

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -4332,7 +4332,7 @@ sub get_connected_slaves {
 
    $sql = 'SHOW FULL PROCESSLIST';
    PTDEBUG && _d($dbh, $sql);
-   grep { $_->{command} =~ m/Binlog Dump/i }
+   grep { $_->{command} =~ m/Binlog Dump/i && $_->{host} =~ m/^([^:]+):/ }
    map  { # Lowercase the column names
       my %hash;
       @hash{ map { lc $_ } keys %$_ } = values %$_;


### PR DESCRIPTION
Some binlog dump connections (not normal replicas) may not be using a port. pt-online-schema-change picks those up because of the use of `SHOW FULL PROCESSLIST`, but in those cases, the tool fails with the following:

```
Use of uninitialized value $host in string eq at /usr/bin/pt-online-schema-change line 4256, <STDIN> line 1.
```

Replication never uses sockets, but non-replication users of Binlog Dump may. So for our purposes we should require a port. This change filters the list of returned slaves to only those which have the `:` we are filtering on in `_find_slaves_by_processlist`.