### PR TITLE
Fix some syntax errors in `pt-summary`

### DIFF
--- a/bin/pt-summary
+++ b/bin/pt-summary
@@ -2257,10 +2257,11 @@ report_system_summary () { local PTFUNCNAME=report_system_summary;
 
 report_transparent_huge_pages () {
 
+  STATUS_THP_SYSTEM=""
   if [ -f /sys/kernel/mm/transparent_hugepage/enabled ]; then
     CONTENT_TRANSHP=$(</sys/kernel/mm/transparent_hugepage/enabled)
     STATUS_THP_SYSTEM=$(echo $CONTENT_TRANSHP | grep -cv '\[never\]')
-  elif [ -f /sys/kernel/mm/redhat_transparent_hugepage/enabled]; then
+  elif [ -f /sys/kernel/mm/redhat_transparent_hugepage/enabled ]; then
     CONTENT_TRANSHP=$(</sys/kernel/mm/redhat_transparent_hugepage/enabled)
     STATUS_THP_SYSTEM=$(echo $CONTENT_TRANSHP | grep -cv '\[never\]')
   fi


### PR DESCRIPTION
before:
```console
$ pt-summary
...
/usr/local/Cellar/percona-toolkit/3.0.2/libexec/bin/pt-summary: line 2263: [: missing `]'
/usr/local/Cellar/percona-toolkit/3.0.2/libexec/bin/pt-summary: line 2268: STATUS_THP_SYSTEM: unbound variable
$ echo $?
1
```
after:
works:)