### PR TITLE
PT-143 Fixed key handling

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,7 @@ Changelog for Percona Toolkit
 
 v3.0.4
 
+ * Fixed bug PT-143 : pt-archiver SELECT query fails because of primary key
  * Fixed bug PT-142 : pt-online-schema-change find_child_tables slow
  * Fixed bug PT-138 : Added --output-format option to pt-mongodb-summary
  * Feature   PT-141 : pt-archiver archive records into csv file

--- a/bin/pt-archiver
+++ b/bin/pt-archiver
@@ -6294,10 +6294,8 @@ sub main {
    # this ensures returned sets are disjoint when ran on partitioned tables
    # issue 1376561
    my $index_cols;
-   if (  $sel_stmt->{index} 
-         && $src->{info}->{keys}->{$sel_stmt->{index}}->{cols} 
-   ) {
-      $index_cols = $src->{info}->{keys}->{$sel_stmt->{index}}->{colnames};
+   if (  $sel_stmt->{index} && $src->{info}->{keys}->{$sel_stmt->{index}}->{cols} ) {
+      $index_cols = join(",",map { "`$_`" } @{$src->{info}->{keys}->{$sel_stmt->{index}}->{cols}});
    }
 
    foreach my $thing ( $first_sql, $next_sql ) {

--- a/t/pt-archiver/pt-143.t
+++ b/t/pt-archiver/pt-143.t
@@ -1,0 +1,68 @@
+#!/usr/bin/env perl
+
+BEGIN {
+   die "The PERCONA_TOOLKIT_BRANCH environment variable is not set.\n"
+      unless $ENV{PERCONA_TOOLKIT_BRANCH} && -d $ENV{PERCONA_TOOLKIT_BRANCH};
+   unshift @INC, "$ENV{PERCONA_TOOLKIT_BRANCH}/lib";
+};
+
+use strict;
+use warnings FATAL => 'all';
+use English qw(-no_match_vars);
+use Test::More;
+
+use PerconaTest;
+use Sandbox;
+require "$trunk/bin/pt-archiver";
+
+my $dp  = new DSNParser(opts=>$dsn_opts);
+my $sb  = new Sandbox(basedir => '/tmp', DSNParser => $dp);
+my $dbh = $sb->get_dbh_for('master');
+
+if ( !$dbh ) {
+   plan skip_all => 'Cannot connect to sandbox master';
+}
+else {
+   plan tests => 3;
+}
+
+my $output;
+
+# #############################################################################
+# Issue 1152: mk-archiver columns option resulting in null archived table data
+# #############################################################################
+$sb->load_file('master', 't/pt-archiver/samples/pt-143.sql');
+
+my $original_rows = $dbh->selectall_arrayref('select * from test.stats_r');
+my $exit_status;
+
+$output = output(
+   sub { $exit_status = pt_archiver::main(
+      '--source',  'h=127.1,P=12345,D=test,t=stats_r,u=msandbox,p=msandbox',
+      '--dest', 'D=test,t=stats_s',
+      qw(--where 1=1 --purge))
+   },
+);
+
+is (
+    $exit_status,
+    0,
+    "PT-143 exit status OK",
+);
+
+my $archived_rows = $dbh->selectall_arrayref('select * from test.stats_s');
+
+is_deeply(
+   $original_rows,
+   $archived_rows,
+   "PT-143 Archived rows match original rows"
+);
+
+$dbh->do('DROP DATABASE test');
+
+# #############################################################################
+# Done.
+# #############################################################################
+$sb->wipe_clean($dbh);
+ok($sb->ok(), "Sandbox servers") or BAIL_OUT(__FILE__ . " broke the sandbox");
+exit;

--- a/t/pt-archiver/samples/pt-143.sql
+++ b/t/pt-archiver/samples/pt-143.sql
@@ -1,0 +1,33 @@
+DROP SCHEMA IF EXISTS test;
+CREATE SCHEMA test;
+
+CREATE TABLE test.`stats_r` (
+`id` int(10) unsigned NOT NULL,
+`end` datetime NOT NULL,
+`start` datetime NOT NULL,
+`sum_value` float DEFAULT NULL,
+`user_id` varchar(100) NOT NULL DEFAULT '',
+`interval` int(10) unsigned NOT NULL DEFAULT '0',
+`mean` float DEFAULT NULL,
+`max` float DEFAULT NULL,
+`min` float DEFAULT NULL,
+PRIMARY KEY (`id`,`start`,`end`,`user_id`(13),`interval`),
+KEY `cid_start_end` (`user_id`(13),`start`,`end`)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+
+CREATE TABLE test.stats_s LIKE test.stats_r;
+
+INSERT INTO `test`.`stats_r`
+(`id`,`end`,`start`,`sum_value`,`user_id`,`interval`,`mean`,`max`,`min`)
+VALUES
+(1,now() + INTERVAL 1 hour, NOW(), 1,1,1,1,1,1),
+(2,now() + INTERVAL 1 hour, NOW(), 1,1,1,1,1,1),
+(3,now() + INTERVAL 1 hour, NOW(), 1,1,1,1,1,1),
+(4,now() + INTERVAL 1 hour, NOW(), 1,1,1,1,1,1),
+(5,now() + INTERVAL 1 hour, NOW(), 1,1,1,1,1,1),
+(6,now() + INTERVAL 1 hour, NOW(), 1,1,1,1,1,1),
+(7,now() + INTERVAL 1 hour, NOW(), 1,1,1,1,1,1),
+(8,now() + INTERVAL 1 hour, NOW(), 1,1,1,1,1,1),
+(9,now() + INTERVAL 1 hour, NOW(), 1,1,1,1,1,1),
+(10,now() + INTERVAL 1 hour, NOW(), 1,1,1,1,1,1);
+


### PR DESCRIPTION
When there is a table having a key like:
PRIMARY KEY (`id`,`start`,`end`,`user_id`(13),`interval`),
DBI driver is taking (13) as part of the field name.
Fixed the way pt-archiver composes the key using DBI cols field
instead of the colnames field since the cols field has the correct
field names for the key.