### PR TITLE
Fix expecting iter.Close()

### DIFF
--- a/src/go/mongolib/profiler/profiler_test.go
+++ b/src/go/mongolib/profiler/profiler_test.go
@@ -89,6 +89,7 @@ func TestRegularIterator(t *testing.T) {
 		},
 	}
 	prof.Start()
+	defer prof.Stop()
 	select {
 	case queries := <-prof.QueriesChan():
 		if !reflect.DeepEqual(queries, want) {
@@ -150,6 +151,7 @@ func TestIteratorTimeout(t *testing.T) {
 	}
 
 	prof.Start()
+	defer prof.Stop()
 	gotTimeout := false
 
 	// Get a timeout
@@ -174,8 +176,6 @@ func TestIteratorTimeout(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Error("Didn't get any query after 2 seconds")
 	}
-
-	prof.Stop()
 }
 
 func TestTailIterator(t *testing.T) {
@@ -251,6 +251,7 @@ func TestTailIterator(t *testing.T) {
 		},
 	}
 	prof.Start()
+	defer prof.Stop()
 	index := 0
 	// Since the mocked iterator has a Sleep(1500 ms) between Next methods calls,
 	// we are going to have two ticker ticks and on every tick it will return one document.
@@ -300,6 +301,7 @@ func TestCalcStats(t *testing.T) {
 	prof := NewProfiler(iter, filters, nil, s)
 
 	prof.Start()
+	defer prof.Stop()
 	select {
 	case queries := <-prof.QueriesChan():
 		s := queries.CalcQueriesStats(1)
@@ -349,6 +351,7 @@ func TestCalcTotalStats(t *testing.T) {
 	prof := NewProfiler(iter, filters, nil, s)
 
 	prof.Start()
+	defer prof.Stop()
 	select {
 	case queries := <-prof.QueriesChan():
 		s := queries.CalcTotalQueriesStats(1)


### PR DESCRIPTION
Adding `defer prof.Stop()`
https://github.com/percona/percona-toolkit/blob/228d87e108e76328a7571bfcfd627b1db6ff6590/src/go/mongolib/profiler/profiler_test.go#L92
ensures iterator gets closed (`p.iterator.Close()`)
https://github.com/percona/percona-toolkit/blob/228d87e108e76328a7571bfcfd627b1db6ff6590/src/go/mongolib/profiler/profiler.go#L114-L115
before running testing expectations for `iter.EXPECT().Close()`
https://github.com/percona/percona-toolkit/blob/228d87e108e76328a7571bfcfd627b1db6ff6590/src/go/mongolib/profiler/profiler_test.go#L62

Without this sometimes expectations were tested before iterator got closed.