### PR TITLE
PT-1509 Only set binlog_format when necessary

### DIFF
--- a/bin/pt-table-sync
+++ b/bin/pt-table-sync
@@ -10957,7 +10957,8 @@ sub get_cxn {
    # instead, it should check if it's already set to STATEMENT.
    # This is becase starting with MySQL 5.1.29, changing the format
    # requires a SUPER user.
-   if ( VersionParser->new($dbh) >= '5.1.29' ) {
+   if ( VersionParser->new($dbh) >= '5.1.29'
+        && ($o->get('replicate') || $o->get('sync-to-master'))) {
       $sql = 'SELECT @@binlog_format';
       PTDEBUG && _d($dbh, $sql);
       my ($original_binlog_format) = $dbh->selectrow_array($sql);


### PR DESCRIPTION
The documentation states that --sync-to-master or --replicate need
the `binlog_format` to be `STATEMENT`, but the code set the `binlog format`
regardless of the operation mode.

With this patch, the `binlog_format` is only set if `--sync-to-master`
or `--replicate` options have actually been supplied on the command line,
enabling a node-to-node sync without these options without the SUPER
privilege.