### PR TITLE
PT-1507 pt-summary does not reliably read in the transparent huge pages setting

### DIFF
--- a/bin/pt-summary
+++ b/bin/pt-summary
@@ -2259,7 +2259,7 @@ report_transparent_huge_pages () {
 
   STATUS_THP_SYSTEM=""
   if [ -f /sys/kernel/mm/transparent_hugepage/enabled ]; then
-    CONTENT_TRANSHP=$(</sys/kernel/mm/transparent_hugepage/enabled)
+    CONTENT_TRANSHP=$(cat /sys/kernel/mm/transparent_hugepage/enabled)
     STATUS_THP_SYSTEM=$(echo $CONTENT_TRANSHP | grep -cv '\[never\]')
   elif [ -f /sys/kernel/mm/redhat_transparent_hugepage/enabled ]; then
     CONTENT_TRANSHP=$(</sys/kernel/mm/redhat_transparent_hugepage/enabled)


### PR DESCRIPTION
Reproduced on Ubuntu 16.04:

On the system

```
cat /sys/kernel/mm/transparent_hugepage/enabled
always madvise [never]
```

Tool reports:

```
# pt-summary
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
	LANGUAGE = (unset),
	LC_ALL = (unset),
	LC_CTYPE = "UTF-8",
	LANG = (unset)
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
# Percona Toolkit System Summary Report ######################
        Date | 2018-02-25 16:04:32 UTC (local TZ: CET +0100)
    Hostname | atlas
      Uptime |  2:49,  1 user,  load average: 0.47, 0.20, 0.12
    Platform | Linux
     Release | Ubuntu 16.04.1 LTS (xenial)
      Kernel | 4.4.0-75-lowlatency
Architecture | CPU = 64-bit, OS = 64-bit
   Threading | NPTL 2.23
     SELinux | No SELinux detected
 Virtualized | No virtualization detected
# Processor ##################################################
  Processors | physical = 1, cores = 2, virtual = 2, hyperthreading = no
      Speeds | 2x2199.974
      Models | 2xIntel(R) Xeon(R) CPU E5-2650 v4 @ 2.20GHz
      Caches | 2x30720 KB
# Memory #####################################################
       Total | 7.9G
        Free | 2.5G
        Used | physical = 2.6G, swap allocated = 1024.0M, swap used = 0.0, virtual = 2.6G
      Shared | 285.9M
     Buffers | 2.7G
      Caches | 4.8G
       Dirty | 252 kB
     UsedRSS | 3.4G
  Swappiness | 10
 DirtyPolicy | 20, 10
 DirtyStatus | 0, 0
# Mounted Filesystems ########################################
  Filesystem  Size Used Type     Opts                                                        Mountpoint
  /dev/sda    197G  59% ext3     rw,noatime,errors=remount-ro,data=ordered                   /
  /dev/sdc     50G  47% ext3     rw,nosuid,nodev,noatime,data=ordered                        /srv/data_atlas
  tmpfs        24K   0% tmpfs    rw,nosuid,nodev                                             /var/gandi
  tmpfs        24K   0% tmpfs    rw,nosuid,noexec,relatime,size=823676k,mode=755             /var/gandi
  tmpfs        24K   0% tmpfs    rw,nosuid,nodev,noexec,relatime,size=5120k                  /var/gandi
  tmpfs        24K   0% tmpfs    ro,nosuid,nodev,noexec,mode=755                             /var/gandi
  tmpfs        24K   0% tmpfs    rw,relatime,size=24k,mode=755                               /var/gandi
  tmpfs       4.0G   0% tmpfs    rw,nosuid,nodev                                             /dev/shm
  tmpfs       4.0G   0% tmpfs    rw,nosuid,noexec,relatime,size=823676k,mode=755             /dev/shm
  tmpfs       4.0G   0% tmpfs    rw,nosuid,nodev,noexec,relatime,size=5120k                  /dev/shm
  tmpfs       4.0G   0% tmpfs    ro,nosuid,nodev,noexec,mode=755                             /dev/shm
  tmpfs       4.0G   0% tmpfs    rw,relatime,size=24k,mode=755                               /dev/shm
  tmpfs       4.0G   0% tmpfs    rw,nosuid,nodev                                             /sys/fs/cgroup
  tmpfs       4.0G   0% tmpfs    rw,nosuid,noexec,relatime,size=823676k,mode=755             /sys/fs/cgroup
  tmpfs       4.0G   0% tmpfs    rw,nosuid,nodev,noexec,relatime,size=5120k                  /sys/fs/cgroup
  tmpfs       4.0G   0% tmpfs    ro,nosuid,nodev,noexec,mode=755                             /sys/fs/cgroup
  tmpfs       4.0G   0% tmpfs    rw,relatime,size=24k,mode=755                               /sys/fs/cgroup
  tmpfs       5.0M   0% tmpfs    rw,nosuid,nodev                                             /run/lock
  tmpfs       5.0M   0% tmpfs    rw,nosuid,noexec,relatime,size=823676k,mode=755             /run/lock
  tmpfs       5.0M   0% tmpfs    rw,nosuid,nodev,noexec,relatime,size=5120k                  /run/lock
  tmpfs       5.0M   0% tmpfs    ro,nosuid,nodev,noexec,mode=755                             /run/lock
  tmpfs       5.0M   0% tmpfs    rw,relatime,size=24k,mode=755                               /run/lock
  tmpfs       805M  12% tmpfs    rw,nosuid,nodev                                             /run
  tmpfs       805M  12% tmpfs    rw,nosuid,noexec,relatime,size=823676k,mode=755             /run
  tmpfs       805M  12% tmpfs    rw,nosuid,nodev,noexec,relatime,size=5120k                  /run
  tmpfs       805M  12% tmpfs    ro,nosuid,nodev,noexec,mode=755                             /run
  tmpfs       805M  12% tmpfs    rw,relatime,size=24k,mode=755                               /run
  udev        4.0G   0% devtmpfs rw,nosuid,relatime,size=4100768k,nr_inodes=1025192,mode=755 /dev
# Disk Schedulers And Queue Size #############################
         sda | [deadline] 128
         sdb | [deadline] 128
         sdc | [deadline] 128
# Disk Partioning ############################################
Device       Type      Start        End               Size
============ ==== ========== ========== ==================
/dev/sda     Disk                             214748364800
/dev/sdb     Disk                               1073741824
/dev/sdc     Disk                              53687091200
# Kernel Inode State #########################################
dentry-state | 344426	323718	45	0	0	0
     file-nr | 2368	0	65535
    inode-nr | 303115	902
# LVM Volumes ################################################
Unable to collect information
# LVM Volume Groups ##########################################
Unable to collect information
# RAID Controller ############################################
  Controller | No RAID controller detected
# Network Config #############################################
 FIN Timeout | 60
  Port Range | 60999
# Interface Statistics #######################################
  interface  rx_bytes rx_packets  rx_errors   tx_bytes tx_packets  tx_errors
  ========= ========= ========== ========== ========== ========== ==========
  lo          6000000      17500          0    6000000      17500          0
  eth0       15000000      80000          0   45000000      70000          0
# Network Devices ############################################
  Device    Speed     Duplex
  ========= ========= =========
  eth0       Unknown!   Unknown!
# Network Connections ########################################
  Connections from remote IP addresses
     [censored]      1
     [censored]       1
     [censored]       1
     [censored]        2
  Connections to local IP addresses
     [censored]       5
  Connections to top 10 local ports
    22                  2
    6556                1
    80                  2
  States of connections
    CLOSE_WAIT          5
    ESTABLISHED         3
    LAST_ACK            1
    LISTEN             15
    TIME_WAIT           9
# Top Processes ##############################################
  PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND
    1 root      20   0   37720   5784   3964 S   0.0  0.1   0:02.56 systemd
    2 root      20   0       0      0      0 S   0.0  0.0   0:00.01 kthreadd
    3 root      20   0       0      0      0 S   0.0  0.0   0:10.22 ksoftirqd/0
    5 root       0 -20       0      0      0 S   0.0  0.0   0:00.00 kworker/0:+
    7 root      20   0       0      0      0 S   0.0  0.0   0:06.56 rcu_preempt
    8 root      20   0       0      0      0 S   0.0  0.0   0:00.00 rcu_sched
    9 root      20   0       0      0      0 S   0.0  0.0   0:00.00 rcu_bh
   10 root      rt   0       0      0      0 S   0.0  0.0   0:00.17 migration/0
   11 root      rt   0       0      0      0 S   0.0  0.0   0:00.04 watchdog/0
# Notable Processes ##########################################
  PID    OOM    COMMAND
 1208    -17    sshd
# Memory mamagement ##########################################
Transparent huge pages are enabled.
# The End ####################################################
```

After the fix:

```
# pt-summary
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
	LANGUAGE = (unset),
	LC_ALL = (unset),
	LC_CTYPE = "UTF-8",
	LANG = (unset)
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
# Percona Toolkit System Summary Report ######################
        Date | 2018-02-25 16:05:16 UTC (local TZ: CET +0100)
    Hostname | atlas
      Uptime |  2:50,  1 user,  load average: 0.29, 0.18, 0.12
    Platform | Linux
     Release | Ubuntu 16.04.1 LTS (xenial)
      Kernel | 4.4.0-75-lowlatency
Architecture | CPU = 64-bit, OS = 64-bit
   Threading | NPTL 2.23
     SELinux | No SELinux detected
 Virtualized | No virtualization detected
# Processor ##################################################
  Processors | physical = 1, cores = 2, virtual = 2, hyperthreading = no
      Speeds | 2x2199.974
      Models | 2xIntel(R) Xeon(R) CPU E5-2650 v4 @ 2.20GHz
      Caches | 2x30720 KB
# Memory #####################################################
       Total | 7.9G
        Free | 2.5G
        Used | physical = 2.6G, swap allocated = 1024.0M, swap used = 0.0, virtual = 2.6G
      Shared | 285.9M
     Buffers | 2.7G
      Caches | 4.8G
       Dirty | 132 kB
     UsedRSS | 3.4G
  Swappiness | 10
 DirtyPolicy | 20, 10
 DirtyStatus | 0, 0
# Mounted Filesystems ########################################
  Filesystem  Size Used Type     Opts                                                        Mountpoint
  /dev/sda    197G  59% ext3     rw,noatime,errors=remount-ro,data=ordered                   /
  /dev/sdc     50G  47% ext3     rw,nosuid,nodev,noatime,data=ordered                        /srv/data_atlas
  tmpfs        24K   0% tmpfs    rw,nosuid,nodev                                             /var/gandi
  tmpfs        24K   0% tmpfs    rw,nosuid,noexec,relatime,size=823676k,mode=755             /var/gandi
  tmpfs        24K   0% tmpfs    rw,nosuid,nodev,noexec,relatime,size=5120k                  /var/gandi
  tmpfs        24K   0% tmpfs    ro,nosuid,nodev,noexec,mode=755                             /var/gandi
  tmpfs        24K   0% tmpfs    rw,relatime,size=24k,mode=755                               /var/gandi
  tmpfs       4.0G   0% tmpfs    rw,nosuid,nodev                                             /dev/shm
  tmpfs       4.0G   0% tmpfs    rw,nosuid,noexec,relatime,size=823676k,mode=755             /dev/shm
  tmpfs       4.0G   0% tmpfs    rw,nosuid,nodev,noexec,relatime,size=5120k                  /dev/shm
  tmpfs       4.0G   0% tmpfs    ro,nosuid,nodev,noexec,mode=755                             /dev/shm
  tmpfs       4.0G   0% tmpfs    rw,relatime,size=24k,mode=755                               /dev/shm
  tmpfs       4.0G   0% tmpfs    rw,nosuid,nodev                                             /sys/fs/cgroup
  tmpfs       4.0G   0% tmpfs    rw,nosuid,noexec,relatime,size=823676k,mode=755             /sys/fs/cgroup
  tmpfs       4.0G   0% tmpfs    rw,nosuid,nodev,noexec,relatime,size=5120k                  /sys/fs/cgroup
  tmpfs       4.0G   0% tmpfs    ro,nosuid,nodev,noexec,mode=755                             /sys/fs/cgroup
  tmpfs       4.0G   0% tmpfs    rw,relatime,size=24k,mode=755                               /sys/fs/cgroup
  tmpfs       5.0M   0% tmpfs    rw,nosuid,nodev                                             /run/lock
  tmpfs       5.0M   0% tmpfs    rw,nosuid,noexec,relatime,size=823676k,mode=755             /run/lock
  tmpfs       5.0M   0% tmpfs    rw,nosuid,nodev,noexec,relatime,size=5120k                  /run/lock
  tmpfs       5.0M   0% tmpfs    ro,nosuid,nodev,noexec,mode=755                             /run/lock
  tmpfs       5.0M   0% tmpfs    rw,relatime,size=24k,mode=755                               /run/lock
  tmpfs       805M  12% tmpfs    rw,nosuid,nodev                                             /run
  tmpfs       805M  12% tmpfs    rw,nosuid,noexec,relatime,size=823676k,mode=755             /run
  tmpfs       805M  12% tmpfs    rw,nosuid,nodev,noexec,relatime,size=5120k                  /run
  tmpfs       805M  12% tmpfs    ro,nosuid,nodev,noexec,mode=755                             /run
  tmpfs       805M  12% tmpfs    rw,relatime,size=24k,mode=755                               /run
  udev        4.0G   0% devtmpfs rw,nosuid,relatime,size=4100768k,nr_inodes=1025192,mode=755 /dev
# Disk Schedulers And Queue Size #############################
         sda | [deadline] 128
         sdb | [deadline] 128
         sdc | [deadline] 128
# Disk Partioning ############################################
Device       Type      Start        End               Size
============ ==== ========== ========== ==================
/dev/sda     Disk                             214748364800
/dev/sdb     Disk                               1073741824
/dev/sdc     Disk                              53687091200
# Kernel Inode State #########################################
dentry-state | 344468	323747	45	0	0	0
     file-nr | 2432	0	65535
    inode-nr | 303156	902
# LVM Volumes ################################################
Unable to collect information
# LVM Volume Groups ##########################################
Unable to collect information
# RAID Controller ############################################
  Controller | No RAID controller detected
# Network Config #############################################
 FIN Timeout | 60
  Port Range | 60999
# Interface Statistics #######################################
  interface  rx_bytes rx_packets  rx_errors   tx_bytes tx_packets  tx_errors
  ========= ========= ========== ========== ========== ========== ==========
  lo          6000000      17500          0    6000000      17500          0
  eth0       15000000      80000          0   45000000      70000          0
# Network Devices ############################################
  Device    Speed     Duplex
  ========= ========= =========
  eth0       Unknown!   Unknown!
# Network Connections ########################################
  Connections from remote IP addresses
     [censored]      1
     [censored]       1
     [censored]       1
     [censored]        2
  Connections to local IP addresses
    [censored]       5
  Connections to top 10 local ports
    22                  2
    6556                1
    80                  2
  States of connections
    CLOSE_WAIT          5
    ESTABLISHED         4
    LISTEN             15
    TIME_WAIT           9
# Top Processes ##############################################
  PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND
    1 root      20   0   37720   5784   3964 S   0.0  0.1   0:02.56 systemd
    2 root      20   0       0      0      0 S   0.0  0.0   0:00.01 kthreadd
    3 root      20   0       0      0      0 S   0.0  0.0   0:10.25 ksoftirqd/0
    5 root       0 -20       0      0      0 S   0.0  0.0   0:00.00 kworker/0:+
    7 root      20   0       0      0      0 S   0.0  0.0   0:06.57 rcu_preempt
    8 root      20   0       0      0      0 S   0.0  0.0   0:00.00 rcu_sched
    9 root      20   0       0      0      0 S   0.0  0.0   0:00.00 rcu_bh
   10 root      rt   0       0      0      0 S   0.0  0.0   0:00.17 migration/0
   11 root      rt   0       0      0      0 S   0.0  0.0   0:00.04 watchdog/0
# Notable Processes ##########################################
  PID    OOM    COMMAND
 1208    -17    sshd
# Simplified and fuzzy rounded vmstat (wait please) ##########
  procs  ---swap-- -----io---- ---system---- --------cpu--------
   r  b    si   so    bi    bo     ir     cs  us  sy  il  wa  st
   1  0     0    0   200   175    250    600   7   2  89   3   0
   1  0     0    0     0  1500   2500   6000   4   9  85   3   0
   0  0     0    0     0   500    200    400   1   1  98   1   0
   1  0     0    0     0  1250   3500   8000  35  17  45   3   0
   2  0     0    0     0    50   1500   4000  45  11  43   2   0
# Memory mamagement ##########################################
Transparent huge pages are currently disabled on the system.
# The End ####################################################
```