### PR TITLE
Add --[no]-collect-mysql

### DIFF
--- a/bin/pt-stalk
+++ b/bin/pt-stalk
@@ -797,7 +797,7 @@ collect() {
    local p="$2"  # prefix for each result file
 
    local mysqld_pid=""
-   if [ ! "$OPT_MYSQL_ONLY" ]; then
+   if [ ! "$OPT_MYSQL_ONLY" -a ! "$OPT_COLLECT_MYSQL" ]; then
       mysqld_pid=$(_pidof mysqld | awk '{print $1; exit;}')
    fi
 
@@ -817,38 +817,44 @@ collect() {
          >> "$d/$p-stacktrace"
    fi
 
-   collect_mysql_variables "$d/$p-variables" &
-   sleep .5
+   if [ "$OPT_COLLECT_MYSQL" ]; then
+    collect_mysql_variables "$d/$p-variables" &
+    sleep .5
 
-   local mysql_version="$(awk '/^version[^_]/{print substr($2,1,3)}' "$d/$p-variables")"
+    local mysql_version="$(awk '/^version[^_]/{print substr($2,1,3)}' "$d/$p-variables")"
 
-   local mysql_error_log="$(awk '/^log_error/{print $2}' "$d/$p-variables")"
-   if [ -z "$mysql_error_log" -a "$mysqld_pid" ]; then
-      mysql_error_log="$(ls -l /proc/$mysqld_pid/fd | awk '/ 2 ->/{print $NF}')"
-   fi
+    local mysql_error_log="$(awk '/^log_error/{print $2}' "$d/$p-variables")"
+    if [ -z "$mysql_error_log" -a "$mysqld_pid" ]; then
+	# Try getting it from the open filehandle...
+	mysql_error_log="$(ls -l /proc/$mysqld_pid/fd | awk '/ 2 ->/{print $NF}')"
+    fi
 
-   local tail_error_log_pid=""
-   if [ "$mysql_error_log" -a ! "$OPT_MYSQL_ONLY" ]; then
-      log "The MySQL error log seems to be $mysql_error_log"
-      tail -f "$mysql_error_log" >"$d/$p-log_error" &
-      tail_error_log_pid=$!
+    local tail_error_log_pid=""
+    if [ "$mysql_error_log" -a ! "$OPT_MYSQL_ONLY" ]; then
+	log "The MySQL error log seems to be $mysql_error_log"
+	tail -f "$mysql_error_log" >"$d/$p-log_error" &
+	tail_error_log_pid=$!
 
-      $CMD_MYSQLADMIN $EXT_ARGV debug
-   else
-      log "Could not find the MySQL error log"
-   fi 
-   if [ "${mysql_version}" '>' "5.1" ]; then
-      local mutex="SHOW ENGINE INNODB MUTEX"
-   else
-      local mutex="SHOW MUTEX STATUS"
-   fi
-   innodb_status 1
-   tokudb_status 1
-   rocksdb_status 1
+	# Send a mysqladmin debug to the server so we can potentially learn about
+	# locking etc.
+	$CMD_MYSQLADMIN $EXT_ARGV debug
+    else
+	log "Could not find the MySQL error log"
+    fi 
+    if [ "${mysql_version}" '>' "5.1" ]; then
+	local mutex="SHOW ENGINE INNODB MUTEX"
+    else
+	local mutex="SHOW MUTEX STATUS"
+    fi
+    innodb_status 1
+    tokudb_status 1
+    rocksdb_status 1
 
-   $CMD_MYSQL $EXT_ARGV -e "$mutex" >> "$d/$p-mutex-status1" &
-   open_tables                      >> "$d/$p-opentables1"   &
+    $CMD_MYSQL $EXT_ARGV -e "$mutex" >> "$d/$p-mutex-status1" &
+    open_tables                      >> "$d/$p-opentables1"   &
 
+   fi # if [ "$OPT_COLLECT_MYSQL" ]
+   
    local tcpdump_pid=""
    if [ "$CMD_TCPDUMP" -a  "$OPT_COLLECT_TCPDUMP" ]; then
       local port=$(awk '/^port/{print $2}' "$d/$p-variables")
@@ -899,25 +905,35 @@ collect() {
          $CMD_MPSTAT -P ALL $OPT_RUN_TIME 1 >> "$d/$p-mpstat-overall" &
       fi
 
-      $CMD_MYSQLADMIN $EXT_ARGV ext -i$OPT_SLEEP_COLLECT -c$cnt >>"$d/$p-mysqladmin" &
-      local mysqladmin_pid=$!
+      if [ "$OPT_COLLECT_MYSQL" ]; then
+	# Collect multiple snapshots of the status variables.  We use
+	# mysqladmin -c even though it is buggy and won't stop on its
+	# own in 5.1 and newer, because there is a chance that we will
+	# get and keep a connection to the database; in troubled times
+	# the database tends to exceed max_connections, so reconnecting
+	# in the loop tends not to work very well.
+	$CMD_MYSQLADMIN $EXT_ARGV ext -i$OPT_SLEEP_COLLECT -c$cnt >>"$d/$p-mysqladmin" &
+	local mysqladmin_pid=$!
+      fi
    fi 
 
-   local have_lock_waits_table=""
-   $CMD_MYSQL $EXT_ARGV -e "SHOW TABLES FROM INFORMATION_SCHEMA" \
-      | grep -i "INNODB_LOCK_WAITS" >/dev/null 2>&1
-   if [ $? -eq 0 ]; then
-      have_lock_waits_table="yes"
-   fi
+   if [ "$OPT_COLLECT_MYSQL" ]; then
+    local have_lock_waits_table=""
+    $CMD_MYSQL $EXT_ARGV -e "SHOW TABLES FROM INFORMATION_SCHEMA" \
+	| grep -i "INNODB_LOCK_WAITS" >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+	have_lock_waits_table="yes"
+    fi
 
-   log "Loop start: $(date +'TS %s.%N %F %T')"
-   local start_time=$(date +'%s')
-   local curr_time=$start_time
-   local ps_instrumentation_enabled=$($CMD_MYSQL $EXT_ARGV -e 'SELECT ENABLED FROM performance_schema.setup_instruments WHERE NAME = "transaction";' \
-                                      | sed "2q;d" | sed 'y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/')
+    log "Loop start: $(date +'TS %s.%N %F %T')"
+    local start_time=$(date +'%s')
+    local curr_time=$start_time
+    local ps_instrumentation_enabled=$($CMD_MYSQL $EXT_ARGV -e 'SELECT ENABLED FROM performance_schema.setup_instruments WHERE NAME = "transaction";' \
+					| sed "2q;d" | sed 'y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/')
 
-   if [ $ps_instrumentation_enabled != "yes" ]; then
-      log "Performance Schema instrumentation is disabled"
+    if [ $ps_instrumentation_enabled != "yes" ]; then
+	log "Performance Schema instrumentation is disabled"
+    fi
    fi
 
    while [ $((curr_time - start_time)) -lt $OPT_RUN_TIME ]; do
@@ -956,22 +972,24 @@ collect() {
          (echo $ts; netstat -antp) >> "$d/$p-netstat"   &
          (echo $ts; netstat -s)    >> "$d/$p-netstat_s" &
       fi
-      (echo $ts; $CMD_MYSQL $EXT_ARGV -e "SHOW FULL PROCESSLIST\G") \
-         >> "$d/$p-processlist" &
-      if [ "$have_lock_waits_table" ]; then
-         (echo $ts; lock_waits)   >>"$d/$p-lock-waits" &
-         (echo $ts; transactions) >>"$d/$p-transactions" &
-      fi
+      if [ "$OPT_COLLECT_MYSQL" ]; then
+	(echo $ts; $CMD_MYSQL $EXT_ARGV -e "SHOW FULL PROCESSLIST\G") \
+	    >> "$d/$p-processlist" &
+	if [ "$have_lock_waits_table" ]; then
+	    (echo $ts; lock_waits)   >>"$d/$p-lock-waits" &
+	    (echo $ts; transactions) >>"$d/$p-transactions" &
+	fi
 
-      if [ "${mysql_version}" '>' "5.6" ] && [ $ps_instrumentation_enabled == "yes" ]; then
-         ps_locks_transactions "$d/$p-ps-locks-transactions"
-      fi
+	if [ "${mysql_version}" '>' "5.6" ] && [ $ps_instrumentation_enabled == "yes" ]; then
+	    ps_locks_transactions "$d/$p-ps-locks-transactions"
+	fi
 
-      if [ "${mysql_version}" '>' "5.6" ]; then
-         (echo $ts; ps_prepared_statements) >> "$d/$p-prepared-statements" &
-      fi
+	if [ "${mysql_version}" '>' "5.6" ]; then
+	    (echo $ts; ps_prepared_statements) >> "$d/$p-prepared-statements" &
+	fi
 
-      slave_status "$d/$p-slave-status" "${mysql_version}" 
+	slave_status "$d/$p-slave-status" "${mysql_version}" 
+      fi
 
       curr_time=$(date +'%s')
    done
@@ -1013,14 +1031,16 @@ collect() {
       [ "$mysqld_pid" ] && kill -s 18 $mysqld_pid
    fi
 
-   innodb_status 2
-   tokudb_status 2
-   rocksdb_status 2
+   if [ "$OPT_COLLECT_MYSQL" ]; then
+    innodb_status 2
+    tokudb_status 2
+    rocksdb_status 2
 
-   $CMD_MYSQL $EXT_ARGV -e "$mutex" >> "$d/$p-mutex-status2" &
-   open_tables                      >> "$d/$p-opentables2"   &
+    $CMD_MYSQL $EXT_ARGV -e "$mutex" >> "$d/$p-mutex-status2" &
+    open_tables                      >> "$d/$p-opentables2"   &
+   fi
 
-   kill $mysqladmin_pid
+   [ "$OPT_COLLECT_MYSQL" ] && kill $mysqladmin_pid
    [ "$tail_error_log_pid" ] && kill $tail_error_log_pid
    [ "$tcpdump_pid" ]        && kill $tcpdump_pid
 
@@ -1828,6 +1848,13 @@ for diagnosis.
 
 In addition to freezing the server, there is also some risk of the server
 crashing or performing badly after GDB detaches from it.
+
+=item --collect-mysql
+
+default: yes; negatable: yes
+
+Collect MySQL diagnostic data. Disable if you want to use pt-stalk on a system
+where MySQL is not running (e.g. a Cassandra or MongoDB node)
 
 =item --collect-oprofile
 

--- a/bin/pt-stalk
+++ b/bin/pt-stalk
@@ -1622,20 +1622,20 @@ if    [ "${0##*/}" = "$TOOL" ] \
    MYSQL_ARGS="$(mysql_options)"
    EXT_ARGV="$(arrange_mysql_options "$EXT_ARGV $MYSQL_ARGS")"
 
+   if [ "$OPT_COLLECT_MYSQL" ]; then
+    # Check that mysql and mysqladmin are in PATH.  If not, we're
+    # already dead in the water, so don't bother with cmd line opts,
+    # just error and exit.
+    [ -n "$(mysql --help)" ] \
+	|| die "Cannot execute mysql.  Check that it is in PATH."
+    [ -n "$(mysqladmin --help)" ] \
+	|| die "Cannot execute mysqladmin.  Check that it is in PATH."
 
-   # Check that mysql and mysqladmin are in PATH.  If not, we're
-   # already dead in the water, so don't bother with cmd line opts,
-   # just error and exit.
-   [ -n "$(mysql --help)" ] \
-      || die "Cannot execute mysql.  Check that it is in PATH."
-   [ -n "$(mysqladmin --help)" ] \
-      || die "Cannot execute mysqladmin.  Check that it is in PATH."
-
-   # Now that we have the cmd line opts, check that we can actually
-   # connect to MySQL.
-   [ -n "$(mysql $EXT_ARGV -e 'SELECT 1')" ] \
-      || die "Cannot connect to MySQL.  Check that MySQL is running and that the options after -- are correct."
-
+    # Now that we have the cmd line opts, check that we can actually
+    # connect to MySQL.
+    [ -n "$(mysql $EXT_ARGV -e 'SELECT 1')" ] \
+	|| die "Cannot connect to MySQL.  Check that MySQL is running and that the options after -- are correct."
+   fi
    # Check existence and access to the --dest dir if we're collecting.
    if [ "$OPT_COLLECT" ]; then
       if [ ! -d "$OPT_DEST" ]; then


### PR DESCRIPTION
This PR adds the --collect-mysql option, which is enabled by default. 
If disabled (by specifying --no-collect-mysql) then none of the MySQL collectors (or checks, such as presence of mysql and mysqladmin on the path) are performed. 

The goal is to make it possible to use pt-stalk with plugins that capture data about other systems (e.g. Cassandra) without having it failed due to missing mysql binaries on the host. 