### PR TITLE
Fix prove2junit.pl to better catch test errors for jenkins report

### DIFF
--- a/sandbox/prove2junit.pl
+++ b/sandbox/prove2junit.pl
@@ -7,28 +7,50 @@ my $file = $ARGV[0];
 my $testcase = "";
 my $testsuite = "";
 my $error_collect = "";
-my $error_print = "";
+my $open_error = 0;
 
 if (not defined $file) {
   die "Need filename as parameter!\n";
+}
+
+sub close_error {
+  if ( $open_error == 1 ) {
+    print "$error_collect ]]></system-err></testcase>\n";
+    $error_collect=""; $open_error=0;
+  }
+
+  return;
 }
 
 open (my $info, $file) or die "Could not open $file: $!";
 
 print "<testsuites name=\"PT-MySQL\">\n";
 while(my $line = <$info>) {
-  if ($line =~ /^(t\/)(\S+)(\/)(\S+).* (\.*) (skipped:) (.*)$/) { print "<testcase name=\"$4\"><skipped/><system-out>Skip reason:<![CDATA[ $7 ]]></system-out></testcase>\n"; }
-  elsif ($line =~ /^ok (\d+) - (.*)$/) { print "<testcase name=\"$testcase - test $1\"><system-out>Test description:<![CDATA[ $2 ]]></system-out></testcase>\n"; }
-  elsif ($line =~ /^not ok (\d+) - (.*)$/) { print "<testcase name=\"$testcase - test $1\"><failure/><system-out>Test description:<![CDATA[ $2 ]]></system-out><system-err><![CDATA[ $error_print ]]></system-err></testcase>\n"; }
+  if ($line =~ /^(t\/)(\S+)(\/)(\S+).* (\.*) (skipped:) (.*)$/) {
+    close_error();
+    print "<testcase name=\"$4\"><skipped/><system-out>Skip reason:<![CDATA[ $7 ]]></system-out></testcase>\n";
+  }
+  elsif ($line =~ /^ok (\d+) - (.*)$/) {
+    close_error();
+    print "<testcase name=\"$testcase - test $1\"><system-out>Test description:<![CDATA[ $2 ]]></system-out></testcase>\n";
+  }
+  elsif ($line =~ /^not ok (\d+) - (.*)$/) {
+    close_error();
+    print "<testcase name=\"$testcase - test $1\"><failure/><system-out>Test description:<![CDATA[ $2 ]]></system-out><system-err><![CDATA[ ";
+    $open_error=1;
+  }
   elsif ($line =~ /^(t\/)(\S+)(\/)(\S+).* (\.*) $/) {
+    close_error();
     if ( "$2" eq "$testsuite" ) {
-      $testcase = "$4"; $error_print = $error_collect; $error_collect = "";
+      $testcase="$4"; $error_collect="";
     }
     else {
       if ( "$testsuite" ne "" ) { print "</testsuite>\n"; }
-      $testsuite = "$2"; $testcase = "$4"; $error_print = $error_collect; $error_collect = ""; print "<testsuite name=\"$testsuite\">\n";
+      $testsuite="$2"; $testcase="$4"; $error_collect=""; print "<testsuite name=\"$testsuite\">\n";
     }
   }
-  elsif ($line !~ /^ok$/ && $line !~ /^\d+..\d+$/) { $error_collect = $error_collect . $line; }
+  elsif ($line !~ /^ok$/ && $line !~ /^\d+..\d+$/) {
+    $error_collect=$error_collect . $line;
+  }
 }
 print "</testsuite>\n</testsuites>\n";


### PR DESCRIPTION
This is to fix catching of reasons why tests failed and better show output in jenkins.
It should look like this:
```
Standard Output
Test description: --verbose option doesn't skip dupes reporting (bug 1402730) 

Standard Error
 
#   Failed test '--verbose option doesn't skip dupes reporting (bug 1402730)'
#   at t/pt-duplicate-key-checker/basics.t line 158.
# 15c15
# < #	  `domain` varchar(175) character set utf8 collate utf8_bin not null
# ---
# > #	  `domain` varchar(175) collate utf8_bin not null
```