### PR TITLE
PT-1535 Changed tool name in --help output message

### DIFF
--- a/src/go/pt-secure-collect/main.go
+++ b/src/go/pt-secure-collect/main.go
@@ -164,7 +164,7 @@ func processCliParams(baseTempPath string, usageWriter io.Writer) (*cliOptions, 
 	}
 	msg += "\n "
 
-	app := kingpin.New("pt-secure-data", msg)
+	app := kingpin.New("pt-secure-collect", msg)
 	if usageWriter != nil {
 		app.UsageWriter(usageWriter)
 		app.Terminate(nil)


### PR DESCRIPTION
It now correctly prints `pt-secure-collect`:

```
usage: pt-secure-collect [<flags>] <command> [<args> ...]
...
```