### PR TITLE
Patch newlines in table columns

### DIFF
--- a/bin/pt-table-checksum
+++ b/bin/pt-table-checksum
@@ -4481,7 +4481,7 @@ sub parse {
 
    my $engine = $self->get_engine($ddl);
 
-   my @defs   = $ddl =~ m/^(\s+`.*?),?$/gm;
+   my @defs   = $ddl =~ m/(?:(?<=,\n)|(?<=\(\n))(\s+`(?:.|\n)+?`.+?),?\n/g;
    my @cols   = map { $_ =~ m/`([^`]+)`/ } @defs;
    PTDEBUG && _d('Table cols:', join(', ', map { "`$_`" } @cols));
 


### PR DESCRIPTION
mysql 5.6.40 allows newlines in column names however the following code:

``` my @defs = $ddl =~ m/^(\s+`.*?),?$/gm; ```

breaks due to it detecting newlines as line ends. The 'm' argument at the end does this by auto-detecting lines by newline characters.

To correct this issue I've made use of zero-length assertions known as " positive lookback"

https://www.regular-expressions.info/lookaround.html

what does it do?

```m/(?:(?<=,\n)|(?<=\(\n))(\s+`(?:.|\n)+?`.+?),?\n/g; ```

TLDR:

Treat the string as one long string and don't treat \n as the end of a line.

look for ``` (\s+`(?:.|\n)+?`.+?),?\n ```

if one of those matches look at what precedes the string

if it's ',\n' or '(\n' the string matches. Only save what's in ``` (\s+`(?:.|\n)+?`.+?) ```

m/ is declaring this a matching regex.

``` (?:(?<=,\n)|(?<=(\n)) ``` This is an OR statement including two look-behind clauses. The ?: tells the enclosing parentheses to not store the result as a variable. I've put the two look-behinds in this OR statement below this line:

(?<=,\n) Look behind the matched string for a comma followed by a newline, the comma must be there for this look behind to match.

(?<=(\n) Look behind the matched string for a open parentheses followed by a newline, the open parentheses must be there.

``` (\s+`(?:.|\n)+?`.+?),?\n ``` This is the actual match. Match newline character followed by one or more spaces followed by back-tick followed by a character which can be any character or a newline one or more times, but don't be greedy and take the rest of the match into consideration. Followed by a back tick and any character one or more times. This match stops where there is a comma or failing that a newline following a back tick and some characters.

,?\n match a comma that may not be there followed by a newline.
/g don't stop if this pattern matches keep looking for more patterns to the end of the string.