### PR TITLE
PT-1573 Fixed General log parser regex

### DIFF
--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -9928,7 +9928,7 @@ sub new {
 
 my $genlog_line_1= qr{
    \A
-   (?:(\d{6}\s+\d{1,2}:\d\d:\d\d|\d{4}-\d{1,2}-\d{1,2}T\d\d:\d\d:\d\d\.\d+(?:Z|-?\d\d:\d\d)?))? # Timestamp
+   (?:(\d{6}\s+\d{1,2}:\d\d:\d\d|\d{4}-\d{1,2}-\d{1,2}T\d\d:\d\d:\d\d\.\d+(?:Z|[-+]?\d\d:\d\d)?))? # Timestamp
    \s+
    (?:\s*(\d+))                     # Thread ID
    \s

--- a/bin/pt-upgrade
+++ b/bin/pt-upgrade
@@ -6930,7 +6930,7 @@ sub new {
 
 my $genlog_line_1= qr{
    \A
-   (?:(\d{6}\s+\d{1,2}:\d\d:\d\d|\d{4}-\d{1,2}-\d{1,2}T\d\d:\d\d:\d\d\.\d+(?:Z|-?\d\d:\d\d)?))? # Timestamp
+   (?:(\d{6}\s+\d{1,2}:\d\d:\d\d|\d{4}-\d{1,2}-\d{1,2}T\d\d:\d\d:\d\d\.\d+(?:Z|[-+]?\d\d:\d\d)?))? # Timestamp
    \s+
    (?:\s*(\d+))                     # Thread ID
    \s

--- a/lib/GeneralLogParser.pm
+++ b/lib/GeneralLogParser.pm
@@ -43,7 +43,7 @@ sub new {
 
 my $genlog_line_1= qr{
    \A
-   (?:(\d{6}\s+\d{1,2}:\d\d:\d\d|\d{4}-\d{1,2}-\d{1,2}T\d\d:\d\d:\d\d\.\d+(?:Z|-?\d\d:\d\d)?))? # Timestamp
+   (?:(\d{6}\s+\d{1,2}:\d\d:\d\d|\d{4}-\d{1,2}-\d{1,2}T\d\d:\d\d:\d\d\.\d+(?:Z|[-+]?\d\d:\d\d)?))? # Timestamp
    \s+
    (?:\s*(\d+))                     # Thread ID
    \s

--- a/t/lib/GeneralLogParser.t
+++ b/t/lib/GeneralLogParser.t
@@ -270,6 +270,61 @@ test_log_parser(
    ],
 );
 
+# Customer issue from Ernie.
+test_log_parser(
+   parser  => $p,
+   file    => $sample.'pt-1573-general-log-system.log',
+   oktorun => sub { $oktorun = $_[0]; },
+   result  => [
+               {
+                 Query_time => 0,
+                 Thread_id => '257426',
+                 arg => 'administrator command: Connect',
+                 bytes => 30,
+                 cmd => 'Admin',
+                 host => '127.0.0.1',
+                 pos_in_log => 0,
+                 ts => '2018-09-07T18:45:40.098124+08:00',
+                 user => 'mysqlha_common'
+               },
+               {
+                 Query_time => 0,
+                 Thread_id => '257426',
+                 arg => 'set autocommit=0',
+                 bytes => 16,
+                 cmd => 'Query',
+                 pos_in_log => 285,
+                 ts => '2018-09-07T18:45:40.098511+08:00'
+               },
+               {
+                 Query_time => 0,
+                 Thread_id => '257426',
+                 arg => 'set autocommit=1',
+                 bytes => 16,
+                 cmd => 'Query',
+                 pos_in_log => 411,
+                 ts => '2018-09-07T18:45:40.098613+08:00'
+               },
+               {
+                 Query_time => 0,
+                 Thread_id => '257426',
+                 arg => 'show global status like \'Threads_connected\'',
+                 bytes => 43,
+                 cmd => 'Query',
+                 pos_in_log => 501,
+                 ts => '2018-09-07T18:45:40.098769+08:00'
+               },
+               {
+                 Query_time => 0,
+                 Thread_id => '257426',
+                 arg => 'administrator command: Quit',
+                 bytes => 27,
+                 cmd => 'Admin',
+                 pos_in_log => 547,
+                 ts => '2018-09-07T18:45:40.101009+08:00'
+               }
+              ],   
+);
 # #############################################################################
 # Done.
 # #############################################################################

--- a/t/lib/samples/genlogs/pt-1573-general-log-system.log
+++ b/t/lib/samples/genlogs/pt-1573-general-log-system.log
@@ -1,0 +1,8 @@
+/usr/local/mysql-5.7.21/bin/mysqld, Version: 5.7.21-log (MySQL Community Server (GPL)). started with:
+Tcp port: 5721  Unix socket: /tmp/mysql5721.sock
+Time                 Id Command    Argument
+2018-09-07T18:45:40.098124+08:00	257426 Connect	mysqlha_common@127.0.0.1 on  using TCP/IP
+2018-09-07T18:45:40.098511+08:00	257426 Query	set autocommit=0
+2018-09-07T18:45:40.098613+08:00	257426 Query	set autocommit=1
+2018-09-07T18:45:40.098769+08:00	257426 Query	show global status like 'Threads_connected'
+2018-09-07T18:45:40.101009+08:00	257426 Quit	


### PR DESCRIPTION
The regexp to process log entries was not considering timestamps in +n,
it was only considering timestamps in -n hours