### PR TITLE
Fix pt-show-grants for MariaDB

### DIFF
--- a/bin/pt-show-grants
+++ b/bin/pt-show-grants
@@ -84,7 +84,7 @@ sub new {
       rules             => [],  # desc of rules for --help
       mutex             => [],  # rule: opts are mutually exclusive
       atleast1          => [],  # rule: at least one opt is required
-      disables          => {},  # rule: opt disables other opts 
+      disables          => {},  # rule: opt disables other opts
       defaults_to       => {},  # rule: opt defaults to value of other opt
       DSNParser         => undef,
       default_files     => [
@@ -247,7 +247,7 @@ sub _pod_to_specs {
          }
 
          push @specs, {
-            spec  => $self->{parse_attributes}->($self, $option, \%attribs), 
+            spec  => $self->{parse_attributes}->($self, $option, \%attribs),
             desc  => $para
                . (defined $attribs{default} ? " (default $attribs{default})" : ''),
             group => ($attribs{'group'} ? $attribs{'group'} : 'default'),
@@ -338,7 +338,7 @@ sub _parse_specs {
          $self->{opts}->{$long} = $opt;
       }
       else { # It's an option rule, not a spec.
-         PTDEBUG && _d('Parsing rule:', $opt); 
+         PTDEBUG && _d('Parsing rule:', $opt);
          push @{$self->{rules}}, $opt;
          my @participants = $self->_get_participants($opt);
          my $rule_ok = 0;
@@ -383,7 +383,7 @@ sub _parse_specs {
       PTDEBUG && _d('Option', $long, 'disables', @participants);
    }
 
-   return; 
+   return;
 }
 
 sub _get_participants {
@@ -470,7 +470,7 @@ sub _set_option {
 }
 
 sub get_opts {
-   my ( $self ) = @_; 
+   my ( $self ) = @_;
 
    foreach my $long ( keys %{$self->{opts}} ) {
       $self->{opts}->{$long}->{got} = 0;
@@ -601,7 +601,7 @@ sub _check_opts {
                   else {
                      $err = join(', ',
                                map { "--$self->{opts}->{$_}->{long}" }
-                               grep { $_ } 
+                               grep { $_ }
                                @restricted_opts[0..scalar(@restricted_opts) - 2]
                             )
                           . ' or --'.$self->{opts}->{$restricted_opts[-1]}->{long};
@@ -611,7 +611,7 @@ sub _check_opts {
             }
 
          }
-         elsif ( $opt->{is_required} ) { 
+         elsif ( $opt->{is_required} ) {
             $self->save_error("Required option --$long must be specified");
          }
 
@@ -995,7 +995,7 @@ sub clone {
       $clone{$scalar} = $self->{$scalar};
    }
 
-   return bless \%clone;     
+   return bless \%clone;
 }
 
 sub _parse_size {
@@ -1361,7 +1361,7 @@ sub get_dbh {
    my $dbh;
    my $tries = 2;
    while ( !$dbh && $tries-- ) {
-      PTDEBUG && _d($cxn_string, ' ', $user, ' ', $pass, 
+      PTDEBUG && _d($cxn_string, ' ', $user, ' ', $pass,
          join(', ', map { "$_=>$defaults->{$_}" } keys %$defaults ));
 
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
@@ -1537,7 +1537,7 @@ sub set_vars {
       }
    }
 
-   return; 
+   return;
 }
 
 sub _d {
@@ -1624,7 +1624,7 @@ sub daemonize {
 
       close STDERR;
       open  STDERR, ">&STDOUT"
-         or die "Cannot dupe STDERR to STDOUT: $OS_ERROR"; 
+         or die "Cannot dupe STDERR to STDOUT: $OS_ERROR";
    }
    else {
       if ( -t STDOUT ) {
@@ -1777,13 +1777,13 @@ sub cmp {
    $v1 =~ s/[^\d\.]//;
    $v2 =~ s/[^\d\.]//;
 
-   my @a = ( $v1 =~ /(\d+)\.?/g ); 
-   my @b = ( $v2 =~ /(\d+)\.?/g ); 
+   my @a = ( $v1 =~ /(\d+)\.?/g );
+   my @b = ( $v2 =~ /(\d+)\.?/g );
    foreach my $n1 (@a) {
       $n1 += 0;
       if (!@b) {
          return 1;
-      }  
+      }
       my $n2 = shift @b;
       $n2 += 0;
       if ($n1 == $n2) {
@@ -1791,8 +1791,8 @@ sub cmp {
       }
       else {
          return $n1 <=> $n2;
-      }  
-   }  
+      }
+   }
    return @b ? -1 : 0;
 }
 
@@ -1852,7 +1852,7 @@ sub main {
 
    # ########################################################################
    # Parse --only and --ignore users.
-   # ######################################################################## 
+   # ########################################################################
    my @all_hosts;
    if ( my $users = $o->get('only') ) {
       my @users = map {
@@ -1902,7 +1902,7 @@ sub main {
                               { AutoCommit => 1, });
 
    my ( $version, $ts ) = $dbh->selectrow_array("SELECT VERSION(), NOW()");
-   
+
    print join("\n",
       "-- Grants dumped by pt-show-grants",
       "-- Dumped from server " . ($dbh->{mysql_hostinfo} || '')
@@ -1910,10 +1910,11 @@ sub main {
       ), "\n" if $o->get('header');
 
    # MySQL 8 roles must be excluded from the regular users list.
-   # Roles can be identified because the user password is expired, the authentication 
+   # Roles can be identified because the user password is expired, the authentication
    # string is empty and the account is locked
    my $mysql8_where = '';
-   if (VersionCompare::cmp($version, '8.0.0') >= 0) {
+   if (($version !~ "-MariaDB" && VersionCompare::cmp($version, '8.0.0') >= 0) ||
+       ($version =~ "-MariaDB" && VersionCompare::cmp($version, '10.3.0') >= 0)) {
        $mysql8_where = ' WHERE NOT ( `account_locked`="Y" AND ' .
                                       ' `password_expired`="Y" AND ' .
                                       ' `authentication_string`="" ) ';
@@ -1948,7 +1949,7 @@ sub main {
        }
        print "-- End of roles listing\n";
    }
-   
+
    USER:
    foreach my $u ( @$users ) {
       my $user_host = "'$u->{User}'\@'$u->{Host}'";
@@ -2053,7 +2054,7 @@ sub main {
             }
 
             # The WITH GRANT OPTION must be revoked separately.
-            if ( $grant =~ m/WITH GRANT OPTION/ ) { 
+            if ( $grant =~ m/WITH GRANT OPTION/ ) {
                push @result, "REVOKE GRANT OPTION ON *.* FROM $user" if $user;
             }
 
@@ -2073,7 +2074,7 @@ sub main {
             "DELETE FROM `mysql`.`user` WHERE `User`='$u->{User}' AND `Host`='$u->{Host}';",
             ), "\n";
       }
-      
+
       print join( "\n", "-- Grants for $user_host",
          map {"$_;"} @grants ), "\n";
 
@@ -2126,7 +2127,7 @@ __EOQ
        $query .= " AND to_user IN ($user_names)";
     }
     PTDEBUG && _d("Getting roles");
-    PTDEBUG && _d($query);                                      
+    PTDEBUG && _d($query);
     my $roles;
     eval { $roles = $dbh->selectall_arrayref($query, { Slice => {} }) };
     if ($EVAL_ERROR) {


### PR DESCRIPTION
Hey,

I'm migrating from MariaDB 10.0 to Percona 5.7 and found `pt-show-grants` to be problematic.

This fixes the issue and should be good for both Percona 8+ and MariaDB 10.3+

Any feedback appreciated, 

Tim. 