### PR TITLE
PT-1638 Fixed MariaDB support

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -9817,7 +9817,8 @@ sub main {
       }
    }
 
-   if ($server_version >= '8.0' && $alter_fk_method eq 'drop_swap') {
+   my $vp = VersionParser->new($cxn->dbh());
+   if ($vp->cmp('8.0') > -1 && $vp->flavor() !~ m/maria/i && $alter_fk_method eq 'drop_swap') {
        my $msg = "--alter-foreign-keys-method=drop_swap doesn't work with MySQL 8.0+\n".
                  "See https://bugs.mysql.com/bug.php?id=89441";
        die($msg);


### PR DESCRIPTION
Because https://bugs.mysql.com/bug.php?id=89441 pt-osc with --drop-swap
doesn't work with MySQL 8.0+ (it will be fixed in MySQL 8.0.14) but it
should work with MariaDB 10.
Fixed version comparison to include the MySQL 'flavor'.