### PR TITLE
PT-1633 fix incorrect parsing of a variable with number + K,M,G,T

### DIFF
--- a/bin/pt-config-diff
+++ b/bin/pt-config-diff
@@ -3244,7 +3244,7 @@ sub _process_val {
       $val =~ s/\s*#.*//;
    }
 
-   if ( my ($num, $factor) = $val =~ m/(\d+)([KMGT])b?$/i ) {
+   if ( my ($num, $factor) = $val =~ m/^(\d+)([KMGT])b?$/i ) {
       my %factor_for = (
          k => 1_024,
          m => 1_048_576,


### PR DESCRIPTION
This fixes bug https://jira.percona.com/browse/PT-1633

A regexp to convert numbers matches any variable ending in a number followed by character K, M, G or T, even if the variable contains other characters, fe. 'ibtmp1:12M:autoextend:max:5G'.
This fix changes the regexp so it matches only those variables that contain only a number followed by K,M,G or T