### PR TITLE
Increase time precision

### DIFF
--- a/bin/pt-kill
+++ b/bin/pt-kill
@@ -724,7 +724,7 @@ sub _validate_type {
 
    if ( $val && $opt->{type} eq 'm' ) {  # type time
       PTDEBUG && _d('Parsing option', $opt->{long}, 'as a time value');
-      my ( $prefix, $num, $suffix ) = $val =~ m/([+-]?)(\d+)([a-z])?$/;
+      my ( $prefix, $num, $suffix ) = $val =~ m/([+-]?)([0-9]*[.]?[0-9]+)([a-z])?$/;
       if ( !$suffix ) {
          my ( $s ) = $opt->{desc} =~ m/\(suffix (.)\)/;
          $suffix = $s || 's';
@@ -6791,6 +6791,7 @@ use English qw(-no_match_vars);
 use POSIX qw(setsid);
 use List::Util qw(max);
 use Digest::MD5 qw(md5_hex);
+use Time::HiRes qw(sleep);
 
 use Data::Dumper;
 $Data::Dumper::Indent    = 1;

--- a/lib/OptionParser.pm
+++ b/lib/OptionParser.pm
@@ -799,7 +799,7 @@ sub _validate_type {
 
    if ( $val && $opt->{type} eq 'm' ) {  # type time
       PTDEBUG && _d('Parsing option', $opt->{long}, 'as a time value');
-      my ( $prefix, $num, $suffix ) = $val =~ m/([+-]?)(\d+)([a-z])?$/;
+      my ( $prefix, $num, $suffix ) = $val =~ m/([+-]?)([0-9]*[.]?[0-9]+)([a-z])?$/;
       # The suffix defaults to 's' unless otherwise specified.
       if ( !$suffix ) {
          my ( $s ) = $opt->{desc} =~ m/\(suffix (.)\)/;


### PR DESCRIPTION
Time type in OptionParser accepts only integers. In pt-kill, we can set `interval` option (time) to 0, to run as fast as possible, or 1 second, with the risk of being too slow. Say we have more than one connection that matches the pattern every second, pt-kill cannot keep up with the killing rate or will allocate a full CPU core all the time. If we insist and we set a float like 0.25, it's parsed as 25. Theses commits allow floating-point numbers to be passed for time. In pt-kill, the `sleep` function from `Time::HiRes` module has to be used because Perl built-in `sleep` function doesn't handle floating numbers.