### PR TITLE
PT-1734: Tailing log_error in pt-stalk doesn't work

### DIFF
--- a/bin/pt-stalk
+++ b/bin/pt-stalk
@@ -822,7 +822,7 @@ collect() {
 
    local mysql_version="$(awk '/^version[^_]/{print substr($2,1,3)}' "$d/$p-variables")"
 
-   local mysql_error_log="$(awk '/^log_error/{print $2}' "$d/$p-variables")"
+   local mysql_error_log="$(awk '/^log_error /{print $2}' "$d/$p-variables")"
    if [ -z "$mysql_error_log" -a "$mysqld_pid" ]; then
       mysql_error_log="$(ls -l /proc/$mysqld_pid/fd | awk '/ 2 ->/{print $NF}')"
    fi


### PR DESCRIPTION
pt-stalk matches variables for 'log_error' phrases, which also
accidentaly matches log_error_verbosity.

This patches changes pattern 'log_error' to 'log_error '.