### PR TITLE
diskstats not working for kernel 4.18+

### DIFF
--- a/bin/pt-diskstats
+++ b/bin/pt-diskstats
@@ -2240,8 +2240,11 @@ sub design_print_formats {
 sub parse_diskstats_line {
    my ( $self, $line, $block_size ) = @_;
 
+   # linux kernel source => Documentation/iostats.txt
+   # 2.6+   => 14 fields
+   # 4.18+  => 18 fields
    my @dev_stats = split ' ', $line;
-   return unless @dev_stats == 14;
+   return unless @dev_stats == 14 or @dev_stats == 18;
 
    my $read_bytes    = $dev_stats[READ_SECTORS]    * $block_size;
    my $written_bytes = $dev_stats[WRITTEN_SECTORS] * $block_size;


### PR DESCRIPTION
kernel 4.18+ has 18 fields in /proc/diskstats