### PR TITLE
Improved handling of enum columns in pk

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -3019,6 +3019,7 @@ sub generate_asc_stmt {
             cols        => \@cols,
             quoter      => $q,
             is_nullable => $tbl_struct->{is_nullable},
+            type_for    => $tbl_struct->{type_for},
          );
          $asc_stmt->{boundaries}->{$cmp} = $cmp_where->{where};
       }
@@ -3039,6 +3040,7 @@ sub generate_cmp_where {
    my @slice       = @{$args{slice}};
    my @cols        = @{$args{cols}};
    my $is_nullable = $args{is_nullable};
+   my $type_for    = $args{type_for};
    my $type        = $args{type};
    my $q           = $self->{Quoter};
 
@@ -3055,13 +3057,14 @@ sub generate_cmp_where {
          my $ord = $slice[$j];
          my $col = $cols[$ord];
          my $quo = $q->quote($col);
+         my $val = $type_for->{$col} eq 'enum' ? "CAST(? AS UNSIGNED)" : "?";
          if ( $is_nullable->{$col} ) {
-            push @clause, "((? IS NULL AND $quo IS NULL) OR ($quo = ?))";
+            push @clause, "(($val IS NULL AND $quo IS NULL) OR ($quo = $val))";
             push @r_slice, $ord, $ord;
             push @r_scols, $col, $col;
          }
          else {
-            push @clause, "$quo = ?";
+            push @clause, "$quo = $val";
             push @r_slice, $ord;
             push @r_scols, $col;
          }
@@ -3071,15 +3074,16 @@ sub generate_cmp_where {
       my $col = $cols[$ord];
       my $quo = $q->quote($col);
       my $end = $i == $#slice; # Last clause of the whole group.
+      my $val = $type_for->{$col} eq 'enum' ? "CAST(? AS UNSIGNED)" : "?";
       if ( $is_nullable->{$col} ) {
          if ( $type =~ m/=/ && $end ) {
-            push @clause, "(? IS NULL OR $quo $type ?)";
+            push @clause, "($val IS NULL OR $quo $type $val)";
          }
          elsif ( $type =~ m/>/ ) {
-            push @clause, "((? IS NULL AND $quo IS NOT NULL) OR ($quo $cmp ?))";
+            push @clause, "(($val IS NULL AND $quo IS NOT NULL) OR ($quo $cmp $val))";
          }
          else { # If $type =~ m/</ ) {
-            push @clause, "((? IS NOT NULL AND $quo IS NULL) OR ($quo $cmp ?))";
+            push @clause, "(($val IS NOT NULL AND $quo IS NULL) OR ($quo $cmp $val))";
          }
          push @r_slice, $ord, $ord;
          push @r_scols, $col, $col;
@@ -3087,7 +3091,7 @@ sub generate_cmp_where {
       else {
          push @r_slice, $ord;
          push @r_scols, $col;
-         push @clause, ($type =~ m/=/ && $end ? "$quo $type ?" : "$quo $cmp ?");
+         push @clause, ($type =~ m/=/ && $end ? "$quo $type $val" : "$quo $cmp $val");
       }
 
       push @clauses, '(' . join(' AND ', @clause) . ')';
@@ -5487,7 +5491,7 @@ sub new {
       my $nibble_sql
          = ($args{dml} ? "$args{dml} " : "SELECT ")
          . ($args{select} ? $args{select}
-                          : join(', ', map { $q->quote($_) } @cols))
+                          : join(', ', map { $tbl->{tbl_struct}->{type_for}->{$_} eq 'enum' ? "CAST(".$q->quote($_)." AS UNSIGNED)" : $q->quote($_) } @cols))
          . " FROM $tbl->{name}"
          . ($where ? " WHERE $where" : '')
          . ($args{lock_in_share_mode} ? " LOCK IN SHARE MODE" : "")
@@ -5497,7 +5501,7 @@ sub new {
       my $explain_nibble_sql
          = "EXPLAIN SELECT "
          . ($args{select} ? $args{select}
-                          : join(', ', map { $q->quote($_) } @cols))
+                          : join(', ', map { $tbl->{tbl_struct}->{type_for}->{$_} eq 'enum' ? "CAST(".$q->quote($_)." AS UNSIGNED)" : $q->quote($_) } @cols))
          . " FROM $tbl->{name}"
          . ($where ? " WHERE $where" : '')
          . ($args{lock_in_share_mode} ? " LOCK IN SHARE MODE" : "")
@@ -5526,40 +5530,14 @@ sub new {
       );
       PTDEBUG && _d('Ascend params:', Dumper($asc));
 
-      my $force_concat_enums = $o->has('force-concat-enums') && $o->get('force-concat-enums');
-      my $i=0;
-      for my $index (@{$index_cols}) {
-          last if $args{n_chunk_index_cols} && $i >= $args{n_chunk_index_cols};
-          $i++;
-          if ($tbl->{tbl_struct}->{type_for}->{$index} eq 'enum') {
-             if ($tbl->{tbl_struct}->{defs}->{$index} =~ m/enum\s*\((.*?)\)/) {
-                 my @items = split(/,\s*/, $1);
-                 my $sorted = 1; # Asume the items list is sorted to later check if this is true
-                 for (my $i=1; $i < scalar(@items); $i++) {
-                     if ($items[$i-1] gt $items[$i]) {
-                         $sorted = 0;
-                         last;
-                     }
-                 }
-                 if (!$force_concat_enums && !$sorted) {
-                    die "The index " . $index . " in table " .  $tbl->{name} .
-                    " has unsorted enum items.\nPlease read the documentation for the --force-concat-enums parameter\n";
-                 }
-             }
-          }
-      }
-
-
       my $from     = "$tbl->{name} FORCE INDEX(`$index`)";
-      my $order_by = join(', ', map { $tbl->{tbl_struct}->{type_for}->{$_} eq 'enum' && $force_concat_enums
-                                        ? "CONCAT(".$q->quote($_).")" : $q->quote($_)} @{$index_cols});
+      my $order_by = join(', ', map {$q->quote($_)} @{$index_cols});
 
-      my $order_by_dec = join(' DESC,', map { $tbl->{tbl_struct}->{type_for}->{$_} eq 'enum' && $force_concat_enums
-                                        ? "CONCAT(".$q->quote($_).")" : $q->quote($_)} @{$index_cols});
+      my $order_by_dec = join(' DESC,', map {$q->quote($_)} @{$index_cols});
 
       my $first_lb_sql
          = "SELECT /*!40001 SQL_NO_CACHE */ "
-         . join(', ', map { $q->quote($_) } @{$asc->{scols}})
+         . join(', ', map { $tbl->{tbl_struct}->{type_for}->{$_} eq 'enum' ? "CAST(".$q->quote($_)." AS UNSIGNED)" : $q->quote($_)} @{$asc->{scols}})
          . " FROM $from"
          . ($where ? " WHERE $where" : '')
          . " ORDER BY $order_by"
@@ -5571,7 +5549,7 @@ sub new {
       if ( $args{resume} ) {
          $resume_lb_sql
             = "SELECT /*!40001 SQL_NO_CACHE */ "
-            . join(', ', map { $q->quote($_) } @{$asc->{scols}})
+            . join(', ', map { $tbl->{tbl_struct}->{type_for}->{$_} eq 'enum' ? "CAST(".$q->quote($_)." AS UNSIGNED)" : $q->quote($_)} @{$asc->{scols}})
             . " FROM $from"
             . " WHERE " . $asc->{boundaries}->{'>'}
             . ($where ? " AND ($where)" : '')
@@ -5583,7 +5561,7 @@ sub new {
 
       my $last_ub_sql
          = "SELECT /*!40001 SQL_NO_CACHE */ "
-         . join(', ', map { $q->quote($_) } @{$asc->{scols}})
+         . join(', ', map { $tbl->{tbl_struct}->{type_for}->{$_} eq 'enum' ? "CAST(".$q->quote($_)." AS UNSIGNED)" : $q->quote($_)} @{$asc->{scols}})
          . " FROM $from"
          . ($where ? " WHERE $where" : '')
          . " ORDER BY "
@@ -5594,7 +5572,7 @@ sub new {
 
       my $ub_sql
          = "SELECT /*!40001 SQL_NO_CACHE */ "
-         . join(', ', map { $q->quote($_) } @{$asc->{scols}})
+         . join(', ', map { $tbl->{tbl_struct}->{type_for}->{$_} eq 'enum' ? "CAST(".$q->quote($_)." AS UNSIGNED)" : $q->quote($_)} @{$asc->{scols}})
          . " FROM $from"
          . " WHERE " . $asc->{boundaries}->{'>='}
                      . ($where ? " AND ($where)" : '')
@@ -5606,7 +5584,7 @@ sub new {
       my $nibble_sql
          = ($args{dml} ? "$args{dml} " : "SELECT ")
          . ($args{select} ? $args{select}
-                          : join(', ', map { $q->quote($_) } @{$asc->{cols}}))
+                          : join(', ', map { $tbl->{tbl_struct}->{type_for}->{$_} eq 'enum' ? "CAST(".$q->quote($_)." AS UNSIGNED)" : $q->quote($_)} @{$asc->{cols}}))
          . " FROM $from"
          . " WHERE " . $asc->{boundaries}->{'>='}  # lower boundary
          . " AND "   . $asc->{boundaries}->{'<='}  # upper boundary
@@ -5619,7 +5597,7 @@ sub new {
       my $explain_nibble_sql 
          = "EXPLAIN SELECT "
          . ($args{select} ? $args{select}
-                          : join(', ', map { $q->quote($_) } @{$asc->{cols}}))
+                          : join(', ', map { $tbl->{tbl_struct}->{type_for}->{$_} eq 'enum' ? "CAST(".$q->quote($_)." AS UNSIGNED)" : $q->quote($_)} @{$asc->{cols}}))
          . " FROM $from"
          . " WHERE " . $asc->{boundaries}->{'>='}  # lower boundary
          . " AND "   . $asc->{boundaries}->{'<='}  # upper boundary
@@ -6731,13 +6709,13 @@ sub _make_range_query {
       foreach my $n ( 0..($n_index_cols - 2) ) {
          my $col = $index_cols->[$n];
          my $val = $vals->[$n];
-         push @where, $q->quote($col) . " = ?";
+         push @where, $q->quote($col) . " = " . $tbl->{tbl_struct}->{type_for}->{$col} eq 'enum' ? "CAST(? AS UNSIGNED)" : "?";
       }
    }
 
    my $col = $index_cols->[$n_index_cols - 1];
    my $val = $vals->[-1];  # should only be as many vals as cols
-   push @where, $q->quote($col) . " >= ?";
+   push @where, $q->quote($col) . " >= " . $tbl->{tbl_struct}->{type_for}->{$col} eq 'enum' ? "CAST(? AS UNSIGNED)" : "?";
 
    my $sql = "EXPLAIN SELECT /*!40001 SQL_NO_CACHE */ * "
            . "FROM $tbl->{name} FORCE INDEX (" . $q->quote($index) . ") "
@@ -12320,30 +12298,6 @@ duplicate rows and this data will be lost.
 =item --force
 
 This options bypasses confirmation in case of using alter-foreign-keys-method = none , which might break foreign key constraints.
-
-=item --force-concat-enums
-
-The NibbleIterator in Percona Toolkit can detect indexes having ENUM fields and 
-if the items it has are sorted or not. According to MySQL documentation at 
-L<https://dev.mysql.com/doc/refman/8.0/en/enum.html>:
-
-ENUM values are sorted based on their index numbers, which depend on the order in 
-which the enumeration members were listed in the column specification. 
-For example, 'b' sorts before 'a' for ENUM('b', 'a'). 
-The empty string sorts before nonempty strings, and NULL values sort before all other 
-enumeration values.
-
-To prevent unexpected results when using the ORDER BY clause on an ENUM column, 
-use one of these techniques:
-- Specify the ENUM list in alphabetic order.
-- Make sure that the column is sorted lexically rather than by index number by coding 
-ORDER BY CAST(col AS CHAR) or ORDER BY CONCAT(col).
-
-The NibbleIterator in Percona Toolkit uses CONCAT(col) but, doing that, adds overhead
-since MySQL cannot use the column directly and has to calculate the result of CONCAT
-for every row.
-To make this scenario vissible to the user, if there are indexes having ENUM fields 
-with usorted items, it is necessary to specify the C<--force-concat-enums> parameter.
 
 =item --help
 


### PR DESCRIPTION
https://jira.percona.com/browse/PT-1591
https://jira.percona.com/browse/PT-1572

These tickets describe a problem with the underlying NibbleIterator in the way it treats enum values in keys.  In short, e.g., c enum('a', 'z', 'b'), the issue is that MySQL ORDER BY clause orders by enum index value ('a', 'z', 'b') and the NibbleIterator specifies boundaries as enum name value strings, e.g., WHERE c <= 'b', which are treated as alphanumeric comparisons-- not enum index value comparisons. In MySQL, this returns only 'a' because 'a' is alphanumerically <= 'b', but the ORDER BY returns 'z' rows before 'b' rows because ORDER BY is sorting by enum index values; thus, 'z' rows may be missed in the nibble. The solution provided in the tickets quoted above changes the ORDER BY clause to force conversion of the enum to a string, which in turn forces creation of a new sort index each nibble.  On large tables, this is unreasonably slow (it would have taken 32 years to convert our table of 1.7billion rows).

The solution in this patch assures all references to enum columns are referenced by their enum index value.  In MySQL, this is done by casting an enum column to an UNSIGNED; when an enum value is cast to an UNSIGNED, its enum index value is used.  This allows the ORDER BY clause to naturally sort by the PK sort order using the enum index value, and also allows comparisons to operate correctly on enum index values, since they are comparing the index values as UNSIGNEDs instead of performing an alphanumeric comparison on the enum name values.  This patch removes all references to enum columns by their name values.  This enables the natural order of the key to be used in the ORDER BY, removing the forced conversion of enum values to strings, which in turn removes the need for MySQL to create a sort index for each nibble.  The practical result of this patch reduces the duration for a schema update of our tables from years to hours, and I hope is a more desired fix for the issue recorded in the tickets mentioned above.  In summary: reference enums by enum index values, always.