### PR TITLE
Restrict the FK check if needed

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -8969,6 +8969,7 @@ sub main {
          tbl    => $orig_tbl,
          Cxn    => $cxn,
          Quoter => $q,
+         only_same_schema_fks => $o->get('only-same-schema-fks'), 
       );
 
    my $vp = VersionParser->new($cxn->dbh());


### PR DESCRIPTION
The find_child_tables is a heavy call if there are a lot of tables. This should honor the `only-same-schema-fks` option.