### PR TITLE
Added option to log queries to database

### DIFF
--- a/bin/pt-kill
+++ b/bin/pt-kill
@@ -1949,7 +1949,7 @@ sub parse {
    foreach my $key ( keys %$opts ) {
       PTDEBUG && _d('Finding value for', $key);
       $final_props{$key} = $given_props{$key};
-      if (   !defined $final_props{$key}
+      if ( !defined $final_props{$key}  
            && defined $prev->{$key} && $opts->{$key}->{copy} )
       {
          $final_props{$key} = $prev->{$key};
@@ -1974,6 +1974,10 @@ sub parse {
                . "for complete documentation."
             unless $final_props{$key};
       }
+   }
+
+   if ($final_props{F}) {
+       %final_props = ( 'F' => $final_props{F} );
    }
 
    return \%final_props;
@@ -2156,6 +2160,28 @@ sub get_dbh {
            . ($sql_mode ? " and $sql_mode" : '')
            . ": $EVAL_ERROR";
       }
+   }
+   my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
+   if ($EVAL_ERROR) {
+       die "Cannot get MySQL version: $EVAL_ERROR";
+   }
+
+   my (undef, $character_set_server) = eval { $dbh->selectrow_array("SHOW VARIABLES LIKE 'character_set_server'") };
+   if ($EVAL_ERROR) {
+       die "Cannot get MySQL var character_set_server: $EVAL_ERROR";
+   }
+
+   if ($mysql_version =~ m/^(\d+)\.(\d)\.(\d+).*/) {
+       if ($1 >= 8 && $character_set_server =~ m/^utf8/) {
+           $dbh->{mysql_enable_utf8} = 1;
+           my $msg = "MySQL version $mysql_version >= 8 and character_set_server = $character_set_server\n".
+                     "Setting: SET NAMES $character_set_server";
+           PTDEBUG && _d($msg);
+           eval { $dbh->do("SET NAMES 'utf8mb4'") };
+           if ($EVAL_ERROR) {
+               die "Cannot SET NAMES $character_set_server: $EVAL_ERROR";
+           }
+       }
    }
 
    PTDEBUG && _d('DBH info: ',
@@ -4171,12 +4197,19 @@ sub get_slave_status {
               if (!$self->{channel}) {
                   die 'This server returned more than one row for SHOW SLAVE STATUS but "channel" was not specified on the command line';
               }
+              my $slave_use_channels;
               for my $row (@$sss_rows) {
                   $row = { map { lc($_) => $row->{$_} } keys %$row }; # lowercase the keys
+                  if ($row->{channel_name}) {
+                      $slave_use_channels = 1;
+                  }
                   if ($row->{channel_name} eq $self->{channel}) {
                       $ss = $row;
                       last;
                   }
+              }
+              if (!$ss && $slave_use_channels) {
+                 die 'This server is using replication channels but "channel" was not specified on the command line';
               }
           } else {
               if ($sss_rows->[0]->{channel_name} && $sss_rows->[0]->{channel_name} ne $self->{channel}) {
@@ -4189,6 +4222,9 @@ sub get_slave_status {
           if ( $ss && %$ss ) {
              $ss = { map { lc($_) => $ss->{$_} } keys %$ss }; # lowercase the keys
              return $ss;
+          }
+          if (!$ss && $self->{channel}) {
+              die "Specified channel name is invalid";
           }
       }
 
@@ -7648,7 +7684,7 @@ with the command.
 
 =head1 OPTIONS
 
-Specify at least one of L<"--kill">, L<"--kill-query">, L<"--logdb">, L<"--print">, L<"--execute-command"> or L<"--stop">.
+Specify at least one of L<"--kill">, L<"--kill-query">, L<"--logdb">,L<"--print">, L<"--execute-command"> or L<"--stop">.
 
 L<"--any-busy-time"> and L<"--each-busy-time"> are mutually exclusive.
 

--- a/bin/pt-kill
+++ b/bin/pt-kill
@@ -1949,7 +1949,7 @@ sub parse {
    foreach my $key ( keys %$opts ) {
       PTDEBUG && _d('Finding value for', $key);
       $final_props{$key} = $given_props{$key};
-      if ( !defined $final_props{$key}  
+      if (   !defined $final_props{$key}
            && defined $prev->{$key} && $opts->{$key}->{copy} )
       {
          $final_props{$key} = $prev->{$key};
@@ -1974,10 +1974,6 @@ sub parse {
                . "for complete documentation."
             unless $final_props{$key};
       }
-   }
-
-   if ($final_props{F}) {
-       %final_props = ( 'F' => $final_props{F} );
    }
 
    return \%final_props;
@@ -2160,28 +2156,6 @@ sub get_dbh {
            . ($sql_mode ? " and $sql_mode" : '')
            . ": $EVAL_ERROR";
       }
-   }
-   my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
-   if ($EVAL_ERROR) {
-       die "Cannot get MySQL version: $EVAL_ERROR";
-   }
-
-   my (undef, $character_set_server) = eval { $dbh->selectrow_array("SHOW VARIABLES LIKE 'character_set_server'") };
-   if ($EVAL_ERROR) {
-       die "Cannot get MySQL var character_set_server: $EVAL_ERROR";
-   }
-
-   if ($mysql_version =~ m/^(\d+)\.(\d)\.(\d+).*/) {
-       if ($1 >= 8 && $character_set_server =~ m/^utf8/) {
-           $dbh->{mysql_enable_utf8} = 1;
-           my $msg = "MySQL version $mysql_version >= 8 and character_set_server = $character_set_server\n".
-                     "Setting: SET NAMES $character_set_server";
-           PTDEBUG && _d($msg);
-           eval { $dbh->do("SET NAMES 'utf8mb4'") };
-           if ($EVAL_ERROR) {
-               die "Cannot SET NAMES $character_set_server: $EVAL_ERROR";
-           }
-       }
    }
 
    PTDEBUG && _d('DBH info: ',
@@ -4197,19 +4171,12 @@ sub get_slave_status {
               if (!$self->{channel}) {
                   die 'This server returned more than one row for SHOW SLAVE STATUS but "channel" was not specified on the command line';
               }
-              my $slave_use_channels;
               for my $row (@$sss_rows) {
                   $row = { map { lc($_) => $row->{$_} } keys %$row }; # lowercase the keys
-                  if ($row->{channel_name}) {
-                      $slave_use_channels = 1;
-                  }
                   if ($row->{channel_name} eq $self->{channel}) {
                       $ss = $row;
                       last;
                   }
-              }
-              if (!$ss && $slave_use_channels) {
-                 die 'This server is using replication channels but "channel" was not specified on the command line';
               }
           } else {
               if ($sss_rows->[0]->{channel_name} && $sss_rows->[0]->{channel_name} ne $self->{channel}) {
@@ -4222,9 +4189,6 @@ sub get_slave_status {
           if ( $ss && %$ss ) {
              $ss = { map { lc($_) => $ss->{$_} } keys %$ss }; # lowercase the keys
              return $ss;
-          }
-          if (!$ss && $self->{channel}) {
-              die "Specified channel name is invalid";
           }
       }
 
@@ -7379,6 +7343,17 @@ sub main {
                exec_cmd($o->get('execute-command'));
                msg('Executed ' . $o->get('execute-command'));
             }
+            if ( $o->get('logdb') ) {
+               if ( $log ) {
+                  log_to_table(
+                     log        => $log,
+                     query      => $query,
+                     proclist   => $pl,
+                     columns    => \@processlist_columns,
+                     eval_error => $EVAL_ERROR,
+                  );
+               }
+            }
             if ( $o->get('kill') || $o->get('kill-query') ) {
                if ( $o->get('wait-before-kill') ) {
                   msg("Sleeping " . $o->get('wait-before-kill')
@@ -7673,7 +7648,7 @@ with the command.
 
 =head1 OPTIONS
 
-Specify at least one of L<"--kill">, L<"--kill-query">, L<"--print">, L<"--execute-command"> or L<"--stop">.
+Specify at least one of L<"--kill">, L<"--kill-query">, L<"--logdb">, L<"--print">, L<"--execute-command"> or L<"--stop">.
 
 L<"--any-busy-time"> and L<"--each-busy-time"> are mutually exclusive.
 
@@ -8381,6 +8356,17 @@ Kill matching queries.
 This option makes pt-kill kill matching queries.  This requires MySQL 5.0 or
 newer.  Unlike L<"--kill"> which kills the connection for matching queries,
 this option only kills the query, not its connection.
+
+=item --logdb
+
+group: Actions
+
+Logs a KILL statement for matching queries to the database using --log-dsn;
+does not actually kill queries.
+
+If you just want to see which queries match and would be killed without
+actually killing them, specify L<"--logdb">.  To both kill and print
+matching queries, specify L<"--kill"> instead.
 
 =item --print
 


### PR DESCRIPTION
Added option to log potential victims to the database specified in the dsn that is specified for logging killed queries.
This to get a central place to store the logged potential victims, instead of just locally on the file system of the target database.