### PR TITLE
Add --unstop option to remove sentinel file.

### DIFF
--- a/bin/pt-archiver
+++ b/bin/pt-archiver
@@ -6096,6 +6096,12 @@ sub main {
       return 0;
    }
 
+   # Remove sentinel file.
+   if ( $o->get('unstop') ) {
+      unlink $sentinel 
+         or die "Cannot unlink sentinel file: $OS_ERROR\n";
+   }
+
    # Generate a filename with sprintf-like formatting codes.
    if ( $archive_file ) {
       my @time = localtime();
@@ -8200,6 +8206,13 @@ autocommit, dropped performance to 38 seconds per thousand rows.
 
 If you are not archiving from or to a transactional storage engine, you may
 want to disable transactions so pt-archiver doesn't try to commit.
+
+=item --unstop
+
+Remove sentinel file
+
+Causes pt-archiver to remove the sentinel file specified by L<"--sentinel"> and
+continue.
 
 =item --user
 


### PR DESCRIPTION
I want to stop archiving when backup scripts starts from cron, to do so, I create sentinel file, but after that, I have to parse config file to get sentinel file and remove it. --unstop permits to remove sentinel file without to parse config file.