### PR TITLE
PT-1631 fix ioprofile ubuntu18.04, ubuntu16.04 support

### DIFF
--- a/bin/pt-ioprofile
+++ b/bin/pt-ioprofile
@@ -572,6 +572,7 @@ tabulate_strace() {
    }
    /^COMMAND/ { mode = "lsof";   }
    /^Process/ { mode = "strace"; }
+   /^strace/ { mode = "strace"; }
    {
       # Save the file descriptor and name for lookup later.
       if ( mode == "lsof" ) {


### PR DESCRIPTION
Fixes [PT-1631](https://jira.percona.com/browse/PT-1631), make pt-ioprofile works on ubuntu 16.04, ubuntu 18.04.