### PR TITLE
workaround for year 2020 problem

### DIFF
--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -3666,7 +3666,7 @@ sub parse_event {
       $pos_in_log -= 1 if $pos_in_log;
 
       $raw_packet =~ s/\n20\Z//;
-      $raw_packet = "20$raw_packet" if $raw_packet =~ /\A20-\d\d-\d\d/; # workaround for 2020 problem
+      $raw_packet = "20$raw_packet" if $raw_packet =~ /\A20-\d\d-\d\d/; # workaround for year 2020 problem
       $raw_packet = "20$raw_packet" unless $raw_packet =~ m/\A20/;
 
       $raw_packet =~ s/0x0000:.+?(450.) /0x0000:  $1 /;

--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -3666,6 +3666,7 @@ sub parse_event {
       $pos_in_log -= 1 if $pos_in_log;
 
       $raw_packet =~ s/\n20\Z//;
+      $raw_packet = "20$raw_packet" if $raw_packet =~ /\A20-\d\d-\d\d/; # workaround for 2020 problem
       $raw_packet = "20$raw_packet" unless $raw_packet =~ m/\A20/;
 
       $raw_packet =~ s/0x0000:.+?(450.) /0x0000:  $1 /;

--- a/bin/pt-upgrade
+++ b/bin/pt-upgrade
@@ -7724,6 +7724,7 @@ sub parse_event {
       $pos_in_log -= 1 if $pos_in_log;
 
       $raw_packet =~ s/\n20\Z//;
+      $raw_packet = "20$raw_packet" if $raw_packet =~ /\A20-\d\d-\d\d/; # workaround for year 2020 problem
       $raw_packet = "20$raw_packet" unless $raw_packet =~ m/\A20/;
 
       $raw_packet =~ s/0x0000:.+?(450.) /0x0000:  $1 /;

--- a/lib/TcpdumpParser.pm
+++ b/lib/TcpdumpParser.pm
@@ -88,6 +88,7 @@ sub parse_event {
       # Remove the separator from the packet, and restore it to the front if
       # necessary.
       $raw_packet =~ s/\n20\Z//;
+      $raw_packet = "20$raw_packet" if $raw_packet =~ /\A20-\d\d-\d\d/; # workaround for year 2020 problem
       $raw_packet = "20$raw_packet" unless $raw_packet =~ m/\A20/;
 
       # Remove special headers (e.g. vlan) before the IPv4 header.


### PR DESCRIPTION
I've fix the year 2020 problem of `pt-query-digest`.

```
pt-query-digest --type tcpdump --limit 100 $tcpdump_result
```
If we execute this command for the result of tcpdump which ran in 2020, we cannot get correct data because of the warning below:
```
Pipeline process 4 (MySQLProtocolParser) caused an error: Argument “” isn’t numeric in multiplication (*) at pt-query-digest line 4551
```

This script parses tcpdump result by `\n20`.
For example,
```
2020-01-09 12:17:18.690344 IP 10.127.88.228.52034 > 10.228.144.92.mysql: tcp 10
        0x0000:  0123 4567 89ab cdef 
2020-01-09 12:17:18.690370 IP 10.228.144.92.mysql > 10.127.88.228.52034: tcp 11
        0x0000:  0123 4567 89ab cdef 
```
this data is separated into 
```
2020-01-09 12:17:18.690344 IP 10.127.88.228.52034 > 10.228.144.92.mysql: tcp 10
        0x0000:  0123 4567 89ab cdef 
20
```
and
```
20-01-09 12:17:18.690370 IP 10.228.144.92.mysql > 10.127.88.228.52034: tcp 11
        0x0000:  0123 4567 89ab cdef 
```
.

Then, `20` is added as a prefix by:
```perl
$raw_packet = "20$raw_packet" unless $raw_packet =~ m/\A20/;
```
But if year is 2020, this code doesn't work.
So, I've fix the problem by this PR.