### PR TITLE
    PT-1804  Query information schema for list of tables

### DIFF
--- a/bin/pt-table-checksum
+++ b/bin/pt-table-checksum
@@ -7807,7 +7807,8 @@ sub _iterate_dbh {
       }
 
       if ( !$self->{tbls} ) {
-         my $sql = 'SHOW /*!50002 FULL*/ TABLES FROM ' . $q->quote($self->{db});
+         #my $sql = 'SHOW /*!50002 FULL*/ TABLES FROM ' . $q->quote($self->{db});
+         my $sql = 'SELECT TABLE_NAME as Tables_in_'.$self->{db}.", TABLE_TYPE as Table_type from information_schema.TABLES where TABLE_SCHEMA= '".$self->{db}."'";
          PTDEBUG && _d($sql);
          my @tbls = map {
             $_->[0];  # (tbl, type)


### PR DESCRIPTION
Modified line 7810 of pt-table-checksum to fetch tables from information schema rather than the actual catalog.

Also added aliases to make sure returned value would be evaluated in the same way.

This will make execution of the script faster as previous query is often slow, depending on the number of tables and usage of the catalog