### PR TITLE
Change jemalloc detection

### DIFF
--- a/bin/pt-mysql-summary
+++ b/bin/pt-mysql-summary
@@ -2264,30 +2264,14 @@ parse_wsrep_provider_options () {
 }
 
 report_jemalloc_enabled() {
-  local JEMALLOC_STATUS=''
-  local GENERAL_JEMALLOC_STATUS=0
-  local JEMALLOC_LOCATION=''
-
-  for pid in $(pidof mysqld); do
-     grep -qc jemalloc /proc/${pid}/environ || ldd $(which mysqld) 2>/dev/null | grep -qc jemalloc
-     jemalloc_status=$?
-     if [ $jemalloc_status = 1 ]; then
-       echo "jemalloc is not enabled in mysql config for process with id ${pid}" 
-     else
-       echo "jemalloc enabled in mysql config for process with id ${pid}"
-       GENERAL_JEMALLOC_STATUS=1
-     fi
-  done
-
-  if [ $GENERAL_JEMALLOC_STATUS -eq 1 ]; then
-     JEMALLOC_LOCATION=$(find /usr/lib64/ /usr/lib/x86_64-linux-gnu /usr/lib -name "libjemalloc.*" 2>/dev/null | head -n 1)
-     if [ -z "$JEMALLOC_LOCATION" ]; then
-       echo "Jemalloc library not found"
-     else
-       echo "Using jemalloc from $JEMALLOC_LOCATION"
-     fi
-  fi
- 
+   for pid in $(pidof mysqld); do
+      if pmap $pid | grep jemalloc > /dev/null; then
+         local jemalloc_location=`pmap $pid | grep jemalloc | awk '{print $4}' | uniq`
+         echo "Using jemalloc from $jemalloc_location for mysqld with id ${pid}"
+      else
+         echo "Jemalloc is not in use for mysqld with id ${pid}"
+      fi
+   done
 }
 
 report_mysql_summary () {


### PR DESCRIPTION
Simplify jemalloc detection for cases where is not in standard locations or we have multiple versions available in the system. 
pmap is always the source of truth for what libraries are being used.