### PR TITLE
PT-1824: Name of a constraint can exceed 64 when --alter-foreign-keys…

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -11135,6 +11135,9 @@ sub rebuild_constraints {
            ($new_fk = $fk) =~ s/^__//;
          } else {
            $new_fk = '_'.$fk;
+           if(length $new_fk > 64) {
+             substr($new_fk, 64 - length $new_fk) = '';
+           }
          }
 
          PTDEBUG && _d("Old FK name: $fk New FK name: $new_fk");


### PR DESCRIPTION
…-method=rebuild_constraints used

The maxium possible length of a constraint name is 64. When --alter-foreign-keys-method=rebuild_constraints used,
pt-online-schema-change just adds `_`-character. This commit forces the maximum length of constraint name to 64 characters.