### PR TITLE
PT-1881: Fix missing argument error of pt-upgrade

### DIFF
--- a/bin/pt-upgrade
+++ b/bin/pt-upgrade
@@ -6159,7 +6159,7 @@ sub _print_failures {
    foreach my $failure ( @$failures ) {
       print "\n-- $failno.\n";
       if ( ($failure->[1] || '') eq ($failure->[2] || '') ) {
-         printf "\nOn both hosts:\n\n" . ($failure->[1] || '') . "\n";
+         printf "\nOn both hosts:\n\n%s\n", ($failure->[1] || '');
       }
       else {
          printf "\n%s\n\nvs.\n\n%s\n",

--- a/bin/pt-upgrade
+++ b/bin/pt-upgrade
@@ -6159,7 +6159,7 @@ sub _print_failures {
    foreach my $failure ( @$failures ) {
       print "\n-- $failno.\n";
       if ( ($failure->[1] || '') eq ($failure->[2] || '') ) {
-         printf "\nOn both hosts:\n\n%s\n", ($failure->[1] || '');
+         print "\nOn both hosts:\n\n" . ($failure->[1] || '') . "\n";
       }
       else {
          printf "\n%s\n\nvs.\n\n%s\n",

--- a/lib/UpgradeResults.pm
+++ b/lib/UpgradeResults.pm
@@ -405,7 +405,7 @@ sub _print_failures {
    foreach my $failure ( @$failures ) {
       print "\n-- $failno.\n";
       if ( ($failure->[1] || '') eq ($failure->[2] || '') ) {
-         printf "\nOn both hosts:\n\n%s\n", ($failure->[1] || '');
+         print "\nOn both hosts:\n\n" . ($failure->[1] || '') . "\n";
       }
       else {
          printf "\n%s\n\nvs.\n\n%s\n",

--- a/lib/UpgradeResults.pm
+++ b/lib/UpgradeResults.pm
@@ -405,7 +405,7 @@ sub _print_failures {
    foreach my $failure ( @$failures ) {
       print "\n-- $failno.\n";
       if ( ($failure->[1] || '') eq ($failure->[2] || '') ) {
-         printf "\nOn both hosts:\n\n" . ($failure->[1] || '') . "\n";
+         printf "\nOn both hosts:\n\n%s\n", ($failure->[1] || '');
       }
       else {
          printf "\n%s\n\nvs.\n\n%s\n",


### PR DESCRIPTION
https://jira.percona.com/browse/PT-1881

I've found that pt-upgrade fails when a query including format strings and SQL errors is given. For example, 
```
SELECT '%s', A
```
leads the following error:
```
Error reporting query class 56A6741F24C4C3EF: Missing argument in printf at /usr/local/Cellar/percona-toolkit/3.2.0/libexec/bin/pt-upgrade line 6162.
```
We can fix the issue by slightly modifying _print_failures. 