### PR TITLE
Fix for PT-1799

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -4293,7 +4293,7 @@ sub recurse_to_slaves {
    my $slave_dsn = $dsn;
    if ($slave_user) {
       $slave_dsn->{u} = $slave_user;
-      PTDEBUG && _d("Using slave user $slave_user on ".$slave_dsn->{h}.":".$slave_dsn->{P});
+      PTDEBUG && _d("Using slave user $slave_user on ".$slave_dsn->{h}.":".($slave_dsn->{P}?$slave_dsn->{P}:""));
    }
    if ($slave_password) {
       $slave_dsn->{p} = $slave_password;


### PR DESCRIPTION
When slave DSN received from the processlist any non-default port is removed by the _resolve_recursion_methods function. Therefore printing port if slave_user is used makes sense only for the original DSN, specified as an argument to the tool. For all slaves, found by a recursion method, the port is not defined. This pull request checks if the port is defined and prints it only if it is.