### PR TITLE
[pt-deadlock-logger] add --disable-buffering-stdout option

### DIFF
--- a/bin/pt-deadlock-logger
+++ b/bin/pt-deadlock-logger
@@ -4650,6 +4650,15 @@ sub main {
    $o->usage_or_errors();
 
    # ########################################################################
+   # Disable buffering log messages to STDOUT
+   # ########################################################################
+   if ( $o->get('disable-buffering-stdout') ) {
+      PTDEBUG && _d('Disabled buffering log messages to STDOUT');
+      use IO::Handle;
+      STDOUT->autoflush(1);
+   }
+
+   # ########################################################################
    # Connect to MySQL and set up the --dest, if any.
    # ########################################################################
    my $q = new Quoter();
@@ -5406,6 +5415,14 @@ MAGIC_dest_table
 
 If you use L<"--columns">, you can omit whichever columns you don't want to
 store.
+
+=item --disable-buffering-stdout
+
+Disable buffering log messages to STDOUT.
+
+This option is useful if you are not attaching any terminal
+(e.g. running as a docker container) and want to get the output
+as soon as possible.
 
 =item --help
 


### PR DESCRIPTION
## Problem

It is a common behaviour that Perl uses buffering for I/O
to reduce the number of syscalls from the point of performance.

This can be a problem, for example, when `pt-deadlock-logger` is
running as a Docker container (which means that no terminal is attached)
and the number of deadlock events are scarce.

The `print()`'s output does not appear until the buffer gets filled up,
which prevents users from getting deadlock events as soon as possible.

## Solution

Add `--disable-buffering-stdout` to disable the buffering behaviour.

The buffering should not be disabled by default, because the buffering
is basically for improving the performances by optimizing the number of
syscalls for I/O. That's why the option should be enabled explicitly.

## Further Reading

- https://perl.plover.com/FAQs/Buffering.html

## NOTE

Double-checked that this fixes our problem on the production environment.
