### PR TITLE
PMM-7689 Updated data type for getLastErrorDefaults.w

### DIFF
--- a/src/go/mongolib/proto/replstatus.go
+++ b/src/go/mongolib/proto/replstatus.go
@@ -75,8 +75,8 @@ type RSConfig struct {
 }
 
 type LastErrorDefaults struct {
-	W        int32 `bson:"w"`
-	WTimeout int32 `bson:"wtimeout"`
+	W        interface{} `bson:"w"`
+	WTimeout int32       `bson:"wtimeout"`
 }
 
 type RSSettings struct {


### PR DESCRIPTION
Jira: https://jira.percona.com/browse/PMM-7689

This field is not being used by any tool but it is needed to decode bigger structures having it. Since the value can be an int to indicate the number 1-primary, etc, or 'majority', I've changed the field type from int to interface{}