### PR TITLE
PT-716 Forced free to use wide mode

### DIFF
--- a/bin/pt-summary
+++ b/bin/pt-summary
@@ -1174,7 +1174,7 @@ find_memory_stats () { local PTFUNCNAME=find_memory_stats;
    local platform="$1"
 
    if [ "${platform}" = "Linux" ]; then
-      free -b
+      free -bw
       cat /proc/meminfo
    elif [ "${platform}" = "SunOS" ]; then
       $CMD_PRTCONF | awk -F: '/Memory/{print $2}'


### PR DESCRIPTION
Jira: https://jira.percona.com/browse/PT-716
At some point, the Linux's `free` command started to merge buffers/cached memory.
I've added `-w` to force the wide mode so the parser get the correct column.