### PR TITLE
Fix test PT-1966

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -4,6 +4,7 @@ Changelog for Percona Toolkit
  * Fixed bug   PT-1914: Column data lost when 'Generated' is in the column comment
  * Fixed bug   PT-1919: pt-online-schema change drop_swap can lose triggers. (Thanks Bob)
  * Fixed bug   PT-1943:	BEFORE triggers are dropped after pt-online-schema-change run
+ * Fixed bug   PT-1966: Fixed test (Thanks @yoku0825)
 
 v3.3.0 release 2021-01-14 
 

--- a/t/pt-online-schema-change/no_drop_no_swap.t
+++ b/t/pt-online-schema-change/no_drop_no_swap.t
@@ -77,7 +77,7 @@ eval {
   $output = output(
      sub { pt_online_schema_change::main(
         "$master_dsn,D=pt_osc,t=t",
-        '--alter', 'ADD COLUMN d INT',
+        '--alter', 'ADD COLUMN t INT',
         qw(--execute --no-swap-tables --no-drop-triggers))
      },
      stderr => 1,

--- a/t/pt-online-schema-change/no_drop_no_swap.t
+++ b/t/pt-online-schema-change/no_drop_no_swap.t
@@ -73,17 +73,14 @@ is_deeply(
 # #############################################################################
 $sb->load_file('master', "$sample/basic_no_fks_innodb.sql");
 
-eval {
-  $output = output(
-     sub { pt_online_schema_change::main(
-        "$master_dsn,D=pt_osc,t=t",
-        '--alter', 'ADD COLUMN t INT',
-        qw(--execute --no-swap-tables --no-drop-triggers))
-     },
-     stderr => 1,
-  );
-};
-ok(!($@), "No error(PT-1966)") or diag($@);
+($output, $exit) = full_output(
+   sub { pt_online_schema_change::main(
+      "$master_dsn,D=pt_osc,t=t",
+      '--alter', 'ADD COLUMN t INT',
+      qw(--execute --no-swap-tables --no-drop-triggers))
+   }
+);
+unlike($output, qr/DBD::mysql::db do failed:/, "Not failed (PT-1966)");
 
 $tables = $dbh1->selectall_arrayref("SHOW TABLES FROM pt_osc");
 is_deeply(

--- a/t/pt-online-schema-change/no_drop_no_swap.t
+++ b/t/pt-online-schema-change/no_drop_no_swap.t
@@ -73,14 +73,17 @@ is_deeply(
 # #############################################################################
 $sb->load_file('master', "$sample/basic_no_fks_innodb.sql");
 
-$output = output(
-   sub { pt_online_schema_change::main(
-      "$master_dsn,D=pt_osc,t=t",
-      '--alter', 'ADD COLUMN d INT',
-      qw(--execute --no-swap-tables --no-drop-triggers))
-   },
-   stderr => 1,
-);
+eval {
+  $output = output(
+     sub { pt_online_schema_change::main(
+        "$master_dsn,D=pt_osc,t=t",
+        '--alter', 'ADD COLUMN d INT',
+        qw(--execute --no-swap-tables --no-drop-triggers))
+     },
+     stderr => 1,
+  );
+};
+ok(!($@), "No error(PT-1966)") or diag($@);
 
 $tables = $dbh1->selectall_arrayref("SHOW TABLES FROM pt_osc");
 is_deeply(


### PR DESCRIPTION
- [\[PT\-1966\] t/pt\-online\-schema\-change/no\_drop\_no\_swap\.t is broken \- Percona JIRA](https://jira.percona.com/browse/PT-1966)

no_drop_no_swap.t  dies by `Error altering new table `pt_osc`.`_t_new`: DBD::mysql::db do failed: Duplicate column name 'd' [for Statement "ALTER TABLE `pt_osc`.`_t_new` ADD COLUMN d INT"]` .

This pull-request changes adding column name to avoid duplicate column name.