### PR TITLE
Use full_output to avoid to die (PT-1967)

### DIFF
--- a/t/pt-online-schema-change/bugs.t
+++ b/t/pt-online-schema-change/bugs.t
@@ -518,7 +518,7 @@ $sb->load_file('master', "$sample/bug-1340728_cleanup.sql");
 # If this test fails it might lead to "segmentation fault" or "out of memory"
 # #############################################################################
 
-$output = output(
+($output, $exit_status) = full_output(
    sub { pt_online_schema_change::main(@args, "$master_dsn,D=sakila,t=actor",
          '--execute', 
          '--alter-foreign-keys-method=drop_swap',
@@ -526,7 +526,6 @@ $output = output(
          '--nocheck-plan',
          ),
       },
-      stderr => 1,
 );
 
 like(


### PR DESCRIPTION
This is the fix of [PT-1967](https://jira.percona.com/browse/PT-1967).
I fixed a same way as #493 (PT-1966).