### PR TITLE
PT-1930: pt-k8s-debug-collector should not attempt collecting PXC information when running against PSMDB

### DIFF
--- a/src/go/pt-k8s-debug-collector/dumper/dumper.go
+++ b/src/go/pt-k8s-debug-collector/dumper/dumper.go
@@ -61,6 +61,12 @@ func New(location, namespace, resource string) Dumper {
 				"perconaxtradbclusterbackups",
 				"perconaxtradbclusterrestores",
 				"perconaxtradbclusters")
+		} else if resource == "psmdb" {
+			resources = append(resources,
+				"perconaservermongodbbackups",
+				"perconaservermongodbrestores",
+				"perconaservermongodbs",
+			)
 		}
 	}
 	return Dumper{

--- a/src/go/pt-k8s-debug-collector/dumper/dumper.go
+++ b/src/go/pt-k8s-debug-collector/dumper/dumper.go
@@ -54,13 +54,13 @@ func New(location, namespace, resource string) Dumper {
 	if len(resource) > 0 {
 		resources = append(resources, resource)
 
-		if resource == "pxc" {
+		if resourceType(resource) == "pxc" {
 			resources = append(resources,
 				"perconaxtradbbackups",
 				"perconaxtradbclusterbackups",
 				"perconaxtradbclusterrestores",
 				"perconaxtradbclusters")
-		} else if resource == "psmdb" {
+		} else if resourceType(resource) == "psmdb" {
 			resources = append(resources,
 				"perconaservermongodbbackups",
 				"perconaservermongodbrestores",

--- a/src/go/pt-k8s-debug-collector/dumper/dumper.go
+++ b/src/go/pt-k8s-debug-collector/dumper/dumper.go
@@ -44,10 +44,6 @@ func New(location, namespace, resource string) Dumper {
 		"jobs",
 		"podsecuritypolicies",
 		"poddisruptionbudgets",
-		"perconaxtradbbackups",
-		"perconaxtradbclusterbackups",
-		"perconaxtradbclusterrestores",
-		"perconaxtradbclusters",
 		"clusterrolebindings",
 		"clusterroles",
 		"rolebindings",
@@ -58,6 +54,14 @@ func New(location, namespace, resource string) Dumper {
 	}
 	if len(resource) > 0 {
 		resources = append(resources, resource)
+
+		if resource == "pxc" {
+			resources = append(resources,
+				"perconaxtradbbackups",
+				"perconaxtradbclusterbackups",
+				"perconaxtradbclusterrestores",
+				"perconaxtradbclusters")
+		}
 	}
 	return Dumper{
 		cmd:       "kubectl",


### PR DESCRIPTION
https://jira.percona.com/browse/PT-1930

Removed PXC resources to collect while running with `--resource psmdb`