### PR TITLE
PT-1931: pt-k8s-debug-collector does not gather summaries for PSMDB

### DIFF
--- a/src/go/pt-k8s-debug-collector/dumper/dumper.go
+++ b/src/go/pt-k8s-debug-collector/dumper/dumper.go
@@ -166,12 +166,12 @@ func (d *Dumper) DumpCluster() error {
 				continue
 			}
 			location = filepath.Join(d.location, ns.Name, pod.Name, "/pt-summary.txt")
-			component := d.crType
-			if d.crType == "psmdb" {
+			component := resourceType(d.crType)
+			if component == "psmdb" {
 				component = "mongod"
 			}
 			if pod.Labels["app.kubernetes.io/component"] == component {
-				output, err = d.getPodSummary(d.crType, pod.Name, pod.Labels["app.kubernetes.io/instance"], tw)
+				output, err = d.getPodSummary(resourceType(d.crType), pod.Name, pod.Labels["app.kubernetes.io/instance"], tw)
 				if err != nil {
 					d.logError(err.Error(), d.crType, pod.Name)
 					err = addToArchive(location, d.mode, []byte(err.Error()), tw)
@@ -352,4 +352,13 @@ func (d *Dumper) getDataFromSecret(secretName, dataName string) (string, error) 
 	}
 
 	return string(pass), nil
+}
+
+func resourceType(s string) string {
+	if s == "pxc" || strings.HasPrefix(s, "pxc/") {
+		return "pxc"
+	} else if s == "psmdb" || strings.HasPrefix(s, "psmdb/") {
+		return "psmdb"
+	}
+	return s
 }


### PR DESCRIPTION
https://jira.percona.com/browse/PT-1931

When I tried to reproduce the bug, `pt-mongodb-summary` didn't launch only when option `--cluster` was specified. This PR fixes this behavior and also fixes https://jira.percona.com/browse/PT-1932