### PR TITLE
BUGFIX: do collect the last row in the source table with pt-archiver

### DIFF
--- a/bin/pt-archiver
+++ b/bin/pt-archiver
@@ -6446,7 +6446,7 @@ sub main {
    ) {
       my $col = $q->quote($sel_stmt->{scols}->[0]);
       my ($val) = $dbh->selectrow_array("SELECT MAX($col) FROM $src->{db_tbl}");
-      $first_sql .= " AND ($col < " . $q->quote_val($val) . ")";
+      $first_sql .= " AND ($col <= " . $q->quote_val($val) . ")";
    }
 
    $next_sql = $first_sql;


### PR DESCRIPTION
1. When I archive source table to dest table using pt-archiver, I find that the last row is always missing, which means "last row is lost in the archive"
2. I think that we could keep the last row in the dest table/file when using pt-archiver