### PR TITLE
PT-2023 Set out mode to utf8

### DIFF
--- a/bin/pt-upgrade
+++ b/bin/pt-upgrade
@@ -9386,6 +9386,7 @@ use Percona::Toolkit;
 use constant PTDEBUG => $ENV{PTDEBUG} || 0;
 
 use sigtrap 'handler', \&sig_int, 'normal-signals';
+binmode(STDOUT, "encoding(UTF-8)");
 
 # Global variables.  Only really essential variables should be here.
 my $oktorun     = 1;


### PR DESCRIPTION
There are no tests because we cannot set the required encryption environment in our sandboxes.