### PR TITLE
PT-1887: Fixed `pt-diskstats` to work on 5.x kernels

### DIFF
--- a/bin/pt-diskstats
+++ b/bin/pt-diskstats
@@ -2243,8 +2243,10 @@ sub parse_diskstats_line {
    # linux kernel source => Documentation/iostats.txt
    # 2.6+   => 14 fields
    # 4.18+  => 18 fields
+   # 5.x+   => 20 fields (PT-1887)
+   my @num_fields = (14, 18, 20);
    my @dev_stats = split ' ', $line;
-   return unless @dev_stats == 14 or @dev_stats == 18;
+   return unless grep {$_ == scalar(@dev_stats)} @num_fields;
 
    my $read_bytes    = $dev_stats[READ_SECTORS]    * $block_size;
    my $written_bytes = $dev_stats[WRITTEN_SECTORS] * $block_size;


### PR DESCRIPTION
The amount of fields returned for disk statistics changed in newer Linux kernel versions to 20 and caused `pt-diskstat` to simply not provide any output on these systems.

Updated the check in the diskstats parsing code to proceed with 20 fields as well.

Signed-off-by: Lenz Grimmer <lenz.grimmer@percona.com>