### PR TITLE
Fixing Readme

### DIFF
--- a/src/go/pt-k8s-debug-collector/README.md
+++ b/src/go/pt-k8s-debug-collector/README.md
@@ -12,7 +12,6 @@ Collects debug data (logs, resource statuses etc.) from a k8s/OpenShift cluster.
 "replicationcontrollers",
 "events",
 "configmaps",
-"secrets",
 "cronjobs",
 "jobs",
 "podsecuritypolicies",


### PR DESCRIPTION
As per the [fix](https://github.com/percona/percona-toolkit/commit/1114eb4dadab973d24dec7a8dd582937beb46abc#diff-9afffdfb6b9f5651e33006604310d54cbcbc9a20f61c9b26cdec5c9b007cab69) secrets are not collected.
Readme in GitHub and [Percona website](https://www.percona.com/doc/percona-toolkit/LATEST/pt-k8s-debug-collector.html) should be updated.