### PR TITLE
PT-1218: pt-stalk ominous open_tables function

### DIFF
--- a/bin/pt-stalk
+++ b/bin/pt-stalk
@@ -1084,7 +1084,7 @@ open_tables() {
    if [ -n "$open_tables" -a $open_tables -le 1000 ]; then
       $CMD_MYSQL $EXT_ARGV -e 'SHOW OPEN TABLES' &
    else
-      log "Too many open tables: $open_tables"
+      log "Logging disabled due to having over 1000 tables open. Number of tables currently open: $open_tables"
    fi
 }
 

--- a/lib/bash/collect.sh
+++ b/lib/bash/collect.sh
@@ -382,7 +382,7 @@ open_tables() {
    if [ -n "$open_tables" -a $open_tables -le 1000 ]; then
       $CMD_MYSQL $EXT_ARGV -e 'SHOW OPEN TABLES' &
    else
-      log "Too many open tables: $open_tables"
+      log "Logging disabled due to having over 1000 tables open. Number of tables currently open: $open_tables"
    fi
 }
 


### PR DESCRIPTION
After discussion change only affects error message that is more user-friendly now.
I also added two tests that check how open_tables function works in both cases:
with number of open tables less tha 1000 and greater than 1000