### PR TITLE
fix Cannot find encoding "utf8mb4"

### DIFF
--- a/bin/pt-archiver
+++ b/bin/pt-archiver
@@ -6709,6 +6709,9 @@ sub main {
       require File::Temp;
       $bulkins_file = File::Temp->new( SUFFIX => 'pt-archiver' )
          or die "Cannot open temp file: $OS_ERROR\n";
+      if ( $charset eq ":encoding(utf8mb4)" ) {
+          $charset = ":encoding(utf8)";
+      }
       binmode($bulkins_file, $charset)
          or die "Cannot set $charset as an encoding for the bulk-insert "
               . "file: $OS_ERROR";
@@ -6942,6 +6945,9 @@ sub main {
          if ( $o->get('bulk-insert') ) {
             $bulkins_file = File::Temp->new( SUFFIX => 'pt-archiver' )
                or die "Cannot open temp file: $OS_ERROR\n";
+            if ( $charset eq ":encoding(utf8mb4)" ) {
+               $charset = ":encoding(utf8)";
+            }
             binmode($bulkins_file, $charset)
                or die "Cannot set $charset as an encoding for the bulk-insert "
                     . "file: $OS_ERROR";


### PR DESCRIPTION
Here is a test case.

`
mysql> select @@version;
+------------+
| @@version  |
+------------+
| 5.7.36-log |
+------------+
1 row in set (0.00 sec)

mysql> show create table sbtest.t1\G
*************************** 1. row ***************************
       Table: t1
Create Table: CREATE TABLE `t1` (
  `id` int(11) NOT NULL,
  `c1` varchar(10) DEFAULT NULL,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
1 row in set (0.00 sec)

mysql> show create table sbtest.t2\G
*************************** 1. row ***************************
       Table: t2
Create Table: CREATE TABLE `t2` (
  `id` int(11) NOT NULL,
  `c1` varchar(10) DEFAULT NULL,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
1 row in set (0.00 sec)

mysql> select * from sbtest.t1;
+----+--------------+
| id | c1           |
+----+--------------+
|  1 | slowtech😊     |
+----+--------------+
1 row in set (0.00 sec)
`
then we archive data from t1 to t2.

./pt-archiver --source h=127.0.0.1,P=3307,u=root,p=123456,D=sbtest,t=t1 --dest h=127.0.0.1,P=3307,u=root,p=123456,D=sbtest,t=t2 --bulk-insert --limit 10 --where '1=1' --bulk-delete --charset utf8mb4
Cannot find encoding "utf8mb4" at ./pt-archiver line 6712.

The essential reason is that the file encoding cann't be ut8mb4.