### PR TITLE
PT-2084 show slave status

### DIFF
--- a/bin/pt-stalk
+++ b/bin/pt-stalk
@@ -1272,11 +1272,11 @@ slave_status() {
    local outfile=$1
    local mysql_version=$2
 
-   if [ "${mysql_version}" '<' "5.7" ]; then
-      local sql="SHOW SLAVE STATUS\G"  
-      echo -e "\n$sql\n" >> $outfile
-      $CMD_MYSQL $EXT_ARGV -e "$sql" >> $outfile
-   else
+   local sql="SHOW SLAVE STATUS\G"
+   echo -e "\n$sql\n" >> $outfile
+   $CMD_MYSQL $EXT_ARGV -e "$sql" >> $outfile
+
+   if [ "${mysql_version}" '>' "5.6" ]; then
       local sql="SELECT * FROM performance_schema.replication_connection_configuration JOIN performance_schema.replication_applier_configuration USING(channel_name)\G"
       echo -e "\n$sql\n" >> $outfile
       $CMD_MYSQL $EXT_ARGV -e "$sql" >> $outfile

--- a/bin/pt-stalk
+++ b/bin/pt-stalk
@@ -1272,7 +1272,12 @@ slave_status() {
    local outfile=$1
    local mysql_version=$2
 
-   local sql="SHOW SLAVE STATUS\G"
+   if [ "${mysql_version}" '<' "8.1" ]; then
+      local sql="SHOW SLAVE STATUS\G"
+   else
+      local sql="SHOW REPLICA STATUS\G"
+   fi
+
    echo -e "\n$sql\n" >> $outfile
    $CMD_MYSQL $EXT_ARGV -e "$sql" >> $outfile
 

--- a/lib/bash/collect.sh
+++ b/lib/bash/collect.sh
@@ -576,7 +576,12 @@ slave_status() {
    local outfile=$1
    local mysql_version=$2
 
-   local sql="SHOW SLAVE STATUS\G"
+   if [ "${mysql_version}" '<' "8.1" ]; then
+      local sql="SHOW SLAVE STATUS\G"
+   else
+      local sql="SHOW REPLICA STATUS\G"
+   fi
+
    echo -e "\n$sql\n" >> $outfile
    $CMD_MYSQL $EXT_ARGV -e "$sql" >> $outfile
 

--- a/lib/bash/collect.sh
+++ b/lib/bash/collect.sh
@@ -576,11 +576,11 @@ slave_status() {
    local outfile=$1
    local mysql_version=$2
 
-   if [ "${mysql_version}" '<' "5.7" ]; then
-      local sql="SHOW SLAVE STATUS\G"  
-      echo -e "\n$sql\n" >> $outfile
-      $CMD_MYSQL $EXT_ARGV -e "$sql" >> $outfile
-   else
+   local sql="SHOW SLAVE STATUS\G"
+   echo -e "\n$sql\n" >> $outfile
+   $CMD_MYSQL $EXT_ARGV -e "$sql" >> $outfile
+
+   if [ "${mysql_version}" '>' "5.6" ]; then
       local sql="SELECT * FROM performance_schema.replication_connection_configuration JOIN performance_schema.replication_applier_configuration USING(channel_name)\G"
       echo -e "\n$sql\n" >> $outfile
       $CMD_MYSQL $EXT_ARGV -e "$sql" >> $outfile

--- a/t/pt-stalk/pt-stalk-replication.t
+++ b/t/pt-stalk/pt-stalk-replication.t
@@ -78,5 +78,5 @@ is(
 
 
 cleanup();
-#ok($sb->ok(), "Sandbox servers") or BAIL_OUT(__FILE__ . " broke the sandbox");
+ok($sb->ok(), "Sandbox servers") or BAIL_OUT(__FILE__ . " broke the sandbox");
 done_testing;

--- a/t/pt-stalk/pt-stalk-replication.t
+++ b/t/pt-stalk/pt-stalk-replication.t
@@ -1,0 +1,82 @@
+#!/usr/bin/env perl
+
+BEGIN {
+   die "The PERCONA_TOOLKIT_BRANCH environment variable is not set.\n"
+      unless $ENV{PERCONA_TOOLKIT_BRANCH} && -d $ENV{PERCONA_TOOLKIT_BRANCH};
+   unshift @INC, "$ENV{PERCONA_TOOLKIT_BRANCH}/lib";
+};
+
+use strict;
+use warnings FATAL => 'all';
+use threads;
+use English qw(-no_match_vars);
+use Test::More;
+use Time::HiRes qw(sleep);
+
+use PerconaTest;
+use DSNParser;
+use Sandbox;
+
+my $dp = new DSNParser(opts=>$dsn_opts);
+my $sb = new Sandbox(basedir => '/tmp', DSNParser => $dp);
+my $dbh = $sb->get_dbh_for('master');
+
+if ( !$dbh ) {
+   plan skip_all => 'Cannot connect to sandbox master';
+}
+
+my $cnf      = "/tmp/12345/my.sandbox.cnf";
+my $replicacnf = "/tmp/12346/my.sandbox.cnf";
+my $pid_file = "/tmp/pt-stalk.pid.$PID";
+my $log_file = "/tmp/pt-stalk.log.$PID";
+my $dest     = "/tmp/pt-stalk.collect.$PID";
+my $int_file = "/tmp/pt-stalk-after-interval-sleep";
+my $pid;
+
+sub cleanup {
+   diag(`rm $pid_file $log_file $int_file 2>/dev/null`);
+   diag(`rm -rf $dest 2>/dev/null`);
+}
+
+sub wait_n_cycles {
+   my ($n) = @_;
+   PerconaTest::wait_until(
+      sub {
+         return 0 unless -f "$dest/after_interval_sleep";
+         my $n_cycles = `wc -l "$dest/after_interval_sleep"  | awk '{print \$1}'`;
+         $n_cycles ||= '';
+         chomp($n_cycles);
+         return ($n_cycles || 0) >= $n; 
+      },
+      1.5,
+      15
+   );
+}
+
+# ###########################################################################
+# Test that SHOW SLAVE STATUS outputs are captured
+# ###########################################################################
+
+my $retval = system("$trunk/bin/pt-stalk --no-stalk --run-time 1 --dest $dest --prefix nostalk --pid $pid_file --iterations 1 -- --defaults-file=$cnf --socket=/tmp/12346/mysql_sandbox12346.sock >$log_file 2>&1");
+my $output = `cat $dest/nostalk-slave-status|grep Slave_IO_Running`;
+
+like(
+   $output,
+   qr/Slave_IO_Running: Yes/,
+   "SHOW SLAVE STATUS outputs gathered."
+);
+
+is(
+   $retval >> 8,
+   0,
+   "Exit 0"
+);
+
+# #############################################################################
+# Done.
+# #############################################################################
+
+
+cleanup();
+#ok($sb->ok(), "Sandbox servers") or BAIL_OUT(__FILE__ . " broke the sandbox");
+done_testing;


### PR DESCRIPTION
PT-2084 -- Re-adding show slave status outputs to pt-stalk.

Work done on PT-80 removed these outputs for versions 5.7+, which is not desirable (and the P_S outputs we get in them are not enough to get all data we have in slave status outputs).

Additionally, I'm adding a conditional for checking versions 8.1+ if they decide to remove the "slave" syntax:

https://dev.mysql.com/doc/refman/8.0/en/show-replica-status.html
>From MySQL 8.0.22, use [SHOW REPLICA STATUS](https://dev.mysql.com/doc/refman/8.0/en/show-replica-status.html) in place of [SHOW SLAVE STATUS](https://dev.mysql.com/doc/refman/8.0/en/show-slave-status.html), which is deprecated from that release.

Since ${mysql_version} is not using patch number, we can't compare on 8.0.22, but using 8.1 is a good workaround that will make this patch work in future releases too.

Let me know what you think.