### PR TITLE
PT-2128 Updated version to 3.5.0

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,7 +2,7 @@ use ExtUtils::MakeMaker;
 
 WriteMakefile(
     NAME      => 'Percona::Toolkit',
-    VERSION   => '3.4.0',
+    VERSION   => '3.5.0',
     EXE_FILES => [ <bin/*> ],
     MAN1PODS  => {
       'docs/percona-toolkit.pod' => 'blib/man1/percona-toolkit.1p',

--- a/bin/pt-align
+++ b/bin/pt-align
@@ -1364,6 +1364,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-align 3.4.0
+pt-align 3.5.0
 
 =cut

--- a/bin/pt-archiver
+++ b/bin/pt-archiver
@@ -37,15 +37,15 @@ BEGIN {
 # ###########################################################################
 # Percona::Toolkit package
 # This package is a copy without comments from the original.  The original
-# with comments and its test file can be found in the Bazaar repository at,
+# with comments and its test file can be found in the GitHub repository at,
 #   lib/Percona/Toolkit.pm
 #   t/lib/Percona/Toolkit.t
-# See https://launchpad.net/percona-toolkit for more information.
+# See https://github.com/percona/percona-toolkit for more information.
 # ###########################################################################
 {
 package Percona::Toolkit;
 
-our $VERSION = '3.3.2';
+our $VERSION = '3.5.0';
 
 use strict;
 use warnings FATAL => 'all';
@@ -8661,6 +8661,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-archiver 3.4.0
+pt-archiver 3.5.0
 
 =cut

--- a/bin/pt-config-diff
+++ b/bin/pt-config-diff
@@ -35,15 +35,15 @@ BEGIN {
 # ###########################################################################
 # Percona::Toolkit package
 # This package is a copy without comments from the original.  The original
-# with comments and its test file can be found in the Bazaar repository at,
+# with comments and its test file can be found in the GitHub repository at,
 #   lib/Percona/Toolkit.pm
 #   t/lib/Percona/Toolkit.t
-# See https://launchpad.net/percona-toolkit for more information.
+# See https://github.com/percona/percona-toolkit for more information.
 # ###########################################################################
 {
 package Percona::Toolkit;
 
-our $VERSION = '3.3.2';
+our $VERSION = '3.5.0';
 
 use strict;
 use warnings FATAL => 'all';
@@ -5917,6 +5917,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-config-diff 3.4.0
+pt-config-diff 3.5.0
 
 =cut

--- a/bin/pt-deadlock-logger
+++ b/bin/pt-deadlock-logger
@@ -34,15 +34,15 @@ BEGIN {
 # ###########################################################################
 # Percona::Toolkit package
 # This package is a copy without comments from the original.  The original
-# with comments and its test file can be found in the Bazaar repository at,
+# with comments and its test file can be found in the GitHub repository at,
 #   lib/Percona/Toolkit.pm
 #   t/lib/Percona/Toolkit.t
-# See https://launchpad.net/percona-toolkit for more information.
+# See https://github.com/percona/percona-toolkit for more information.
 # ###########################################################################
 {
 package Percona::Toolkit;
 
-our $VERSION = '3.3.2';
+our $VERSION = '3.5.0';
 
 use strict;
 use warnings FATAL => 'all';
@@ -5710,6 +5710,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-deadlock-logger 3.4.0
+pt-deadlock-logger 3.5.0
 
 =cut

--- a/bin/pt-diskstats
+++ b/bin/pt-diskstats
@@ -30,15 +30,15 @@ BEGIN {
 # ###########################################################################
 # Percona::Toolkit package
 # This package is a copy without comments from the original.  The original
-# with comments and its test file can be found in the Bazaar repository at,
+# with comments and its test file can be found in the GitHub repository at,
 #   lib/Percona/Toolkit.pm
 #   t/lib/Percona/Toolkit.t
-# See https://launchpad.net/percona-toolkit for more information.
+# See https://github.com/percona/percona-toolkit for more information.
 # ###########################################################################
 {
 package Percona::Toolkit;
 
-our $VERSION = '3.3.2';
+our $VERSION = '3.5.0';
 
 use strict;
 use warnings FATAL => 'all';
@@ -5684,6 +5684,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-diskstats 3.4.0
+pt-diskstats 3.5.0
 
 =cut

--- a/bin/pt-duplicate-key-checker
+++ b/bin/pt-duplicate-key-checker
@@ -31,15 +31,15 @@ BEGIN {
 # ###########################################################################
 # Percona::Toolkit package
 # This package is a copy without comments from the original.  The original
-# with comments and its test file can be found in the Bazaar repository at,
+# with comments and its test file can be found in the GitHub repository at,
 #   lib/Percona/Toolkit.pm
 #   t/lib/Percona/Toolkit.t
-# See https://launchpad.net/percona-toolkit for more information.
+# See https://github.com/percona/percona-toolkit for more information.
 # ###########################################################################
 {
 package Percona::Toolkit;
 
-our $VERSION = '3.3.2';
+our $VERSION = '3.5.0';
 
 use strict;
 use warnings FATAL => 'all';
@@ -5771,6 +5771,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-duplicate-key-checker 3.4.0
+pt-duplicate-key-checker 3.5.0
 
 =cut

--- a/bin/pt-fifo-split
+++ b/bin/pt-fifo-split
@@ -1653,6 +1653,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-fifo-split 3.4.0
+pt-fifo-split 3.5.0
 
 =cut

--- a/bin/pt-find
+++ b/bin/pt-find
@@ -27,15 +27,15 @@ BEGIN {
 # ###########################################################################
 # Percona::Toolkit package
 # This package is a copy without comments from the original.  The original
-# with comments and its test file can be found in the Bazaar repository at,
+# with comments and its test file can be found in the GitHub repository at,
 #   lib/Percona/Toolkit.pm
 #   t/lib/Percona/Toolkit.t
-# See https://launchpad.net/percona-toolkit for more information.
+# See https://github.com/percona/percona-toolkit for more information.
 # ###########################################################################
 {
 package Percona::Toolkit;
 
-our $VERSION = '3.3.2';
+our $VERSION = '3.5.0';
 
 use strict;
 use warnings FATAL => 'all';
@@ -5132,6 +5132,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-find 3.4.0
+pt-find 3.5.0
 
 =cut

--- a/bin/pt-fingerprint
+++ b/bin/pt-fingerprint
@@ -2262,6 +2262,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-fingerprint 3.4.0
+pt-fingerprint 3.5.0
 
 =cut

--- a/bin/pt-fk-error-logger
+++ b/bin/pt-fk-error-logger
@@ -29,15 +29,15 @@ BEGIN {
 # ###########################################################################
 # Percona::Toolkit package
 # This package is a copy without comments from the original.  The original
-# with comments and its test file can be found in the Bazaar repository at,
+# with comments and its test file can be found in the GitHub repository at,
 #   lib/Percona/Toolkit.pm
 #   t/lib/Percona/Toolkit.t
-# See https://launchpad.net/percona-toolkit for more information.
+# See https://github.com/percona/percona-toolkit for more information.
 # ###########################################################################
 {
 package Percona::Toolkit;
 
-our $VERSION = '3.3.2';
+our $VERSION = '3.5.0';
 
 use strict;
 use warnings FATAL => 'all';
@@ -4693,6 +4693,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-fk-error-logger 3.4.0
+pt-fk-error-logger 3.5.0
 
 =cut

--- a/bin/pt-heartbeat
+++ b/bin/pt-heartbeat
@@ -36,15 +36,15 @@ BEGIN {
 # ###########################################################################
 # Percona::Toolkit package
 # This package is a copy without comments from the original.  The original
-# with comments and its test file can be found in the Bazaar repository at,
+# with comments and its test file can be found in the GitHub repository at,
 #   lib/Percona/Toolkit.pm
 #   t/lib/Percona/Toolkit.t
-# See https://launchpad.net/percona-toolkit for more information.
+# See https://github.com/percona/percona-toolkit for more information.
 # ###########################################################################
 {
 package Percona::Toolkit;
 
-our $VERSION = '3.3.2';
+our $VERSION = '3.5.0';
 
 use strict;
 use warnings FATAL => 'all';
@@ -7394,6 +7394,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-heartbeat 3.4.0
+pt-heartbeat 3.5.0
 
 =cut

--- a/bin/pt-index-usage
+++ b/bin/pt-index-usage
@@ -37,15 +37,15 @@ BEGIN {
 # ###########################################################################
 # Percona::Toolkit package
 # This package is a copy without comments from the original.  The original
-# with comments and its test file can be found in the Bazaar repository at,
+# with comments and its test file can be found in the GitHub repository at,
 #   lib/Percona/Toolkit.pm
 #   t/lib/Percona/Toolkit.t
-# See https://launchpad.net/percona-toolkit for more information.
+# See https://github.com/percona/percona-toolkit for more information.
 # ###########################################################################
 {
 package Percona::Toolkit;
 
-our $VERSION = '3.3.2';
+our $VERSION = '3.5.0';
 
 use strict;
 use warnings FATAL => 'all';
@@ -7705,6 +7705,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-index-usage 3.4.0
+pt-index-usage 3.5.0
 
 =cut

--- a/bin/pt-ioprofile
+++ b/bin/pt-ioprofile
@@ -1133,7 +1133,7 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-ioprofile 3.4.0
+pt-ioprofile 3.5.0
 
 =cut
 

--- a/bin/pt-kill
+++ b/bin/pt-kill
@@ -39,15 +39,15 @@ BEGIN {
 # ###########################################################################
 # Percona::Toolkit package
 # This package is a copy without comments from the original.  The original
-# with comments and its test file can be found in the Bazaar repository at,
+# with comments and its test file can be found in the GitHub repository at,
 #   lib/Percona/Toolkit.pm
 #   t/lib/Percona/Toolkit.t
-# See https://launchpad.net/percona-toolkit for more information.
+# See https://github.com/percona/percona-toolkit for more information.
 # ###########################################################################
 {
 package Percona::Toolkit;
 
-our $VERSION = '3.3.2';
+our $VERSION = '3.5.0';
 
 use strict;
 use warnings FATAL => 'all';
@@ -8666,6 +8666,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-kill 3.4.0
+pt-kill 3.5.0
 
 =cut

--- a/bin/pt-mext
+++ b/bin/pt-mext
@@ -809,7 +809,7 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-mext 3.4.0
+pt-mext 3.5.0
 
 =cut
 

--- a/bin/pt-mysql-summary
+++ b/bin/pt-mysql-summary
@@ -3296,7 +3296,7 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-mysql-summary 3.4.0
+pt-mysql-summary 3.5.0
 
 =cut
 

--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -48,15 +48,15 @@ BEGIN {
 # ###########################################################################
 # Percona::Toolkit package
 # This package is a copy without comments from the original.  The original
-# with comments and its test file can be found in the Bazaar repository at,
+# with comments and its test file can be found in the GitHub repository at,
 #   lib/Percona/Toolkit.pm
 #   t/lib/Percona/Toolkit.t
-# See https://launchpad.net/percona-toolkit for more information.
+# See https://github.com/percona/percona-toolkit for more information.
 # ###########################################################################
 {
 package Percona::Toolkit;
 
-our $VERSION = '3.3.2';
+our $VERSION = '3.5.0';
 
 use strict;
 use warnings FATAL => 'all';
@@ -13469,6 +13469,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-online-schema-change 3.4.0
+pt-online-schema-change 3.5.0
 
 =cut

--- a/bin/pt-pmp
+++ b/bin/pt-pmp
@@ -901,7 +901,7 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-pmp 3.4.0
+pt-pmp 3.5.0
 
 =cut
 

--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -56,15 +56,15 @@ BEGIN {
 # ###########################################################################
 # Percona::Toolkit package
 # This package is a copy without comments from the original.  The original
-# with comments and its test file can be found in the Bazaar repository at,
+# with comments and its test file can be found in the GitHub repository at,
 #   lib/Percona/Toolkit.pm
 #   t/lib/Percona/Toolkit.t
-# See https://launchpad.net/percona-toolkit for more information.
+# See https://github.com/percona/percona-toolkit for more information.
 # ###########################################################################
 {
 package Percona::Toolkit;
 
-our $VERSION = '3.3.2';
+our $VERSION = '3.5.0';
 
 use strict;
 use warnings FATAL => 'all';
@@ -16977,6 +16977,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-query-digest 3.4.0
+pt-query-digest 3.5.0
 
 =cut

--- a/bin/pt-show-grants
+++ b/bin/pt-show-grants
@@ -2618,6 +2618,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-show-grants 3.4.0
+pt-show-grants 3.5.0
 
 =cut

--- a/bin/pt-sift
+++ b/bin/pt-sift
@@ -1250,7 +1250,7 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-sift 3.4.0
+pt-sift 3.5.0
 
 =cut
 

--- a/bin/pt-slave-delay
+++ b/bin/pt-slave-delay
@@ -32,15 +32,15 @@ BEGIN {
 # ###########################################################################
 # Percona::Toolkit package
 # This package is a copy without comments from the original.  The original
-# with comments and its test file can be found in the Bazaar repository at,
+# with comments and its test file can be found in the GitHub repository at,
 #   lib/Percona/Toolkit.pm
 #   t/lib/Percona/Toolkit.t
-# See https://launchpad.net/percona-toolkit for more information.
+# See https://github.com/percona/percona-toolkit for more information.
 # ###########################################################################
 {
 package Percona::Toolkit;
 
-our $VERSION = '3.3.2';
+our $VERSION = '3.5.0';
 
 use strict;
 use warnings FATAL => 'all';
@@ -4993,6 +4993,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-slave-delay 3.4.0
+pt-slave-delay 3.5.0
 
 =cut

--- a/bin/pt-slave-find
+++ b/bin/pt-slave-find
@@ -4528,6 +4528,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-slave-find 3.4.0
+pt-slave-find 3.5.0
 
 =cut

--- a/bin/pt-slave-restart
+++ b/bin/pt-slave-restart
@@ -33,15 +33,15 @@ BEGIN {
 # ###########################################################################
 # Percona::Toolkit package
 # This package is a copy without comments from the original.  The original
-# with comments and its test file can be found in the Bazaar repository at,
+# with comments and its test file can be found in the GitHub repository at,
 #   lib/Percona/Toolkit.pm
 #   t/lib/Percona/Toolkit.t
-# See https://launchpad.net/percona-toolkit for more information.
+# See https://github.com/percona/percona-toolkit for more information.
 # ###########################################################################
 {
 package Percona::Toolkit;
 
-our $VERSION = '3.3.2';
+our $VERSION = '3.5.0';
 
 use strict;
 use warnings FATAL => 'all';
@@ -6164,6 +6164,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-slave-restart 3.4.0
+pt-slave-restart 3.5.0
 
 =cut

--- a/bin/pt-stalk
+++ b/bin/pt-stalk
@@ -2552,7 +2552,7 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-stalk 3.4.0
+pt-stalk 3.5.0
 
 =cut
 

--- a/bin/pt-summary
+++ b/bin/pt-summary
@@ -2769,7 +2769,7 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-summary 3.4.0
+pt-summary 3.5.0
 
 =cut
 

--- a/bin/pt-table-checksum
+++ b/bin/pt-table-checksum
@@ -11,7 +11,6 @@ use warnings FATAL => 'all';
 # in this file.  Setting %INC to this file for each module makes Perl aware
 # of this so it will not try to load the module from @INC.  See the tool's
 # documentation for a full list of dependencies.
-
 BEGIN {
    $INC{$_} = __FILE__ for map { (my $pkg = "$_.pm") =~ s!::!/!g; $pkg } (qw(
       Percona::Toolkit
@@ -51,15 +50,15 @@ BEGIN {
 # ###########################################################################
 # Percona::Toolkit package
 # This package is a copy without comments from the original.  The original
-# with comments and its test file can be found in the Bazaar repository at,
+# with comments and its test file can be found in the GitHub repository at,
 #   lib/Percona/Toolkit.pm
 #   t/lib/Percona/Toolkit.t
-# See https://launchpad.net/percona-toolkit for more information.
+# See https://github.com/percona/percona-toolkit for more information.
 # ###########################################################################
 {
 package Percona::Toolkit;
 
-our $VERSION = '3.3.2';
+our $VERSION = '3.5.0';
 
 use strict;
 use warnings FATAL => 'all';
@@ -14197,6 +14196,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-table-checksum 3.4.0
+pt-table-checksum 3.5.0
 
 =cut

--- a/bin/pt-table-sync
+++ b/bin/pt-table-sync
@@ -47,15 +47,15 @@ BEGIN {
 # ###########################################################################
 # Percona::Toolkit package
 # This package is a copy without comments from the original.  The original
-# with comments and its test file can be found in the Bazaar repository at,
+# with comments and its test file can be found in the GitHub repository at,
 #   lib/Percona/Toolkit.pm
 #   t/lib/Percona/Toolkit.t
-# See https://launchpad.net/percona-toolkit for more information.
+# See https://github.com/percona/percona-toolkit for more information.
 # ###########################################################################
 {
 package Percona::Toolkit;
 
-our $VERSION = '3.3.2';
+our $VERSION = '3.5.0';
 
 use strict;
 use warnings FATAL => 'all';
@@ -13101,6 +13101,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-table-sync 3.4.0
+pt-table-sync 3.5.0
 
 =cut

--- a/bin/pt-table-usage
+++ b/bin/pt-table-usage
@@ -8519,6 +8519,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-table-usage 3.4.0
+pt-table-usage 3.5.0
 
 =cut

--- a/bin/pt-upgrade
+++ b/bin/pt-upgrade
@@ -53,15 +53,15 @@ BEGIN {
 # ###########################################################################
 # Percona::Toolkit package
 # This package is a copy without comments from the original.  The original
-# with comments and its test file can be found in the Bazaar repository at,
+# with comments and its test file can be found in the GitHub repository at,
 #   lib/Percona/Toolkit.pm
 #   t/lib/Percona/Toolkit.t
-# See https://launchpad.net/percona-toolkit for more information.
+# See https://github.com/percona/percona-toolkit for more information.
 # ###########################################################################
 {
 package Percona::Toolkit;
 
-our $VERSION = '3.3.2';
+our $VERSION = '3.5.0';
 
 use strict;
 use warnings FATAL => 'all';
@@ -11454,6 +11454,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-upgrade 3.4.0
+pt-upgrade 3.5.0
 
 =cut

--- a/bin/pt-variable-advisor
+++ b/bin/pt-variable-advisor
@@ -36,15 +36,15 @@ BEGIN {
 # ###########################################################################
 # Percona::Toolkit package
 # This package is a copy without comments from the original.  The original
-# with comments and its test file can be found in the Bazaar repository at,
+# with comments and its test file can be found in the GitHub repository at,
 #   lib/Percona/Toolkit.pm
 #   t/lib/Percona/Toolkit.t
-# See https://launchpad.net/percona-toolkit for more information.
+# See https://github.com/percona/percona-toolkit for more information.
 # ###########################################################################
 {
 package Percona::Toolkit;
 
-our $VERSION = '3.3.2';
+our $VERSION = '3.5.0';
 
 use strict;
 use warnings FATAL => 'all';
@@ -6262,6 +6262,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-variable-advisor 3.4.0
+pt-variable-advisor 3.5.0
 
 =cut

--- a/bin/pt-visual-explain
+++ b/bin/pt-visual-explain
@@ -3308,6 +3308,6 @@ Place, Suite 330, Boston, MA  02111-1307  USA.
 
 =head1 VERSION
 
-pt-visual-explain 3.4.0
+pt-visual-explain 3.5.0
 
 =cut

--- a/lib/Percona/Toolkit.pm
+++ b/lib/Percona/Toolkit.pm
@@ -18,7 +18,7 @@
 # ###########################################################################
 package Percona::Toolkit;
 
-our $VERSION = '3.4.0';
+our $VERSION = '3.5.0';
 
 use strict;
 use warnings FATAL => 'all';

--- a/src/go/mongolib/proto/profiler_status.go
+++ b/src/go/mongolib/proto/profiler_status.go
@@ -1,8 +1,9 @@
 package proto
 
 // ProfilerStatus is a struct to hold the results of db.getProfilingLevel()
-//		var ps proto.ProfilerStatus
-//		err := db.Run(bson.M{"profile": -1}, &ps)
+//
+//	var ps proto.ProfilerStatus
+//	err := db.Run(bson.M{"profile": -1}, &ps)
 type ProfilerStatus struct {
 	Was      int64 `bson:"was"`
 	SlowMs   int64 `bson:"slowms"`

--- a/src/go/mongolib/util/util.go
+++ b/src/go/mongolib/util/util.go
@@ -184,21 +184,22 @@ func GetHostnames(ctx context.Context, client *mongo.Client) ([]string, error) {
 }
 
 /*
-   "members" : [
-            {
-                    "_id" : 0,
-                    "name" : "localhost:17001",
-                    "health" : 1,
-                    "state" : 1,
-                    "stateStr" : "PRIMARY",
-                    "uptime" : 4700,
-                    "optime" : Timestamp(1486554836, 1),
-                    "optimeDate" : ISODate("2017-02-08T11:53:56Z"),
-                    "electionTime" : Timestamp(1486651810, 1),
-                    "electionDate" : ISODate("2017-02-09T14:50:10Z"),
-                    "configVersion" : 1,
-                    "self" : true
-            },
+"members" : [
+
+	{
+	        "_id" : 0,
+	        "name" : "localhost:17001",
+	        "health" : 1,
+	        "state" : 1,
+	        "stateStr" : "PRIMARY",
+	        "uptime" : 4700,
+	        "optime" : Timestamp(1486554836, 1),
+	        "optimeDate" : ISODate("2017-02-08T11:53:56Z"),
+	        "electionTime" : Timestamp(1486651810, 1),
+	        "electionDate" : ISODate("2017-02-09T14:50:10Z"),
+	        "configVersion" : 1,
+	        "self" : true
+	},
 */
 func buildHostsListFromReplStatus(replStatus proto.ReplicaSetStatus) []string {
 	hostnames := []string{}
@@ -211,17 +212,20 @@ func buildHostsListFromReplStatus(replStatus proto.ReplicaSetStatus) []string {
 	return hostnames
 }
 
-/* Example
+/*
+	Example
+
 mongos> db.getSiblingDB('admin').runCommand('getShardMap')
-{
-  "map" : {
-    "config" : "localhost:19001,localhost:19002,localhost:19003",
-    "localhost:17001" : "r1/localhost:17001,localhost:17002,localhost:17003",
-    "r1" : "r1/localhost:17001,localhost:17002,localhost:17003",
-    "r1/localhost:17001,localhost:17002,localhost:17003" : "r1/localhost:17001,localhost:17002,localhost:17003",
-  },
-  "ok" : 1
-}.
+
+	{
+	  "map" : {
+	    "config" : "localhost:19001,localhost:19002,localhost:19003",
+	    "localhost:17001" : "r1/localhost:17001,localhost:17002,localhost:17003",
+	    "r1" : "r1/localhost:17001,localhost:17002,localhost:17003",
+	    "r1/localhost:17001,localhost:17002,localhost:17003" : "r1/localhost:17001,localhost:17002,localhost:17003",
+	  },
+	  "ok" : 1
+	}.
 */
 func buildHostsListFromShardMap(shardsMap proto.ShardsMap) []string {
 	hostnames := []string{}

--- a/src/go/pt-k8s-debug-collector/dumper/dumper.go
+++ b/src/go/pt-k8s-debug-collector/dumper/dumper.go
@@ -316,7 +316,6 @@ type crSecrets struct {
 func (d *Dumper) getIndividualFiles(resource, namespace string, podName, path, location string, tw *tar.Writer) error {
 	args := []string{"-n", namespace, "cp", podName + ":" + path, "/dev/stdout"}
 	output, err := d.runCmd(args...)
-
 	if err != nil {
 		d.logError(err.Error(), args...)
 		log.Printf("Error: get path %s for resource %s in namespace %s: %v", path, resource, d.namespace, err)

--- a/src/go/pt-k8s-debug-collector/main_test.go
+++ b/src/go/pt-k8s-debug-collector/main_test.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"bytes"
-	"golang.org/x/exp/slices"
 	"os/exec"
 	"path"
 	"strings"
 	"testing"
+
+	"golang.org/x/exp/slices"
 )
 
 /*

--- a/src/go/pt-mongodb-index-check/main.go
+++ b/src/go/pt-mongodb-index-check/main.go
@@ -48,7 +48,7 @@ const (
 var (
 	Build     string = "2020-04-23" //nolint
 	GoVersion string = "1.14.1"     //nolint
-	Version   string = "3.4.0"      //nolint
+	Version   string = "3.5.0"      //nolint
 	Commit    string                //nolint
 )
 

--- a/src/go/pt-mongodb-query-digest/main.go
+++ b/src/go/pt-mongodb-query-digest/main.go
@@ -41,7 +41,7 @@ const (
 var (
 	Build     string = "2020-04-23" //nolint
 	GoVersion string = "1.14.1"     //nolint
-	Version   string = "3.4.0"      //nolint
+	Version   string = "3.5.0"      //nolint
 	Commit    string                //nolint
 )
 

--- a/src/go/pt-mongodb-summary/main.go
+++ b/src/go/pt-mongodb-summary/main.go
@@ -57,7 +57,7 @@ const (
 var (
 	Build     string = "2020-04-23"
 	GoVersion string = "1.14.1"
-	Version   string = "3.4.0"
+	Version   string = "3.5.0"
 	Commit    string
 
 	defaultConnectionTimeout = 3 * time.Second

--- a/src/go/pt-pg-summary/main.go
+++ b/src/go/pt-pg-summary/main.go
@@ -10,8 +10,8 @@ import (
 	"github.com/alecthomas/kingpin"
 	_ "github.com/lib/pq"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/percona/percona-toolkit/src/go/lib/pginfo"
 	"github.com/percona/percona-toolkit/src/go/pt-pg-summary/templates"
@@ -21,7 +21,7 @@ var (
 	Build     string = "2020-04-23" //nolint
 	Commit    string                //nolint
 	GoVersion string = "1.14.1"     //nolint
-	Version   string = "3.4.0"      //nolint
+	Version   string = "3.5.0"      //nolint
 )
 
 type connOpts struct {

--- a/src/go/pt-secure-collect/main.go
+++ b/src/go/pt-secure-collect/main.go
@@ -15,8 +15,8 @@ import (
 	"github.com/alecthomas/kingpin"
 	"github.com/go-ini/ini"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -86,7 +86,7 @@ var (
 
 	Build     string = "2020-04-23" //nolint
 	GoVersion string = "1.14.1"     //nolint
-	Version   string = "3.4.0"      //nolint
+	Version   string = "3.5.0"      //nolint
 	Commit    string                //nolint
 )
 

--- a/util/build-packages
+++ b/util/build-packages
@@ -482,6 +482,13 @@ VERSION=$1
 REL_NOTES=$2
 OS_ARCH=${3:-linux-amd64}
 
+ONLY_UPDATE_VERSION=${ONLY_UPDATE_VERSION:-0}
+
+if [ $ONLY_UPDATE_VERSION -eq 1 ]; then
+   update_version
+   exit
+fi
+
 if [ $OS_ARCH != "linux-amd64" ] && [ $OS_ARCH != "linux-386" ] && [ $OS_ARCH != "darwin-amd64" ]; then
    die "Valid OS-ARCH combinations are: linux-amd64, linux-386, darwin-amd64"
 fi


### PR DESCRIPTION
- Updated version in Perl files to 3.5.0
- Updated Perl module `Percona::Toolkit` to version 3.5.0 and updated all scripts using this module.
- Manually updated all Go programs.
- Added a new parameter to the build script to make it able to **ONLY** update version without creating packages nor updating the docs. 