### PR TITLE
PT-2116 pt-osc --null-to-not-null description is wrong

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -12759,9 +12759,9 @@ exist.
 =item --null-to-not-null
 
 Allows MODIFYing a column that allows NULL values to one that doesn't allow
-them. The rows which contain NULL values will be converted to the defined
-default value. If no explicit DEFAULT value is given MySQL will assign a default
-value based on datatype, e.g. 0 for number datatypes, '' for string datatypes.
+them. The existing rows which contain NULL values will be converted to the default value
+based on datatype, e.g. 0 for number datatypes, '' for string datatypes.
+New rows will use the user defined default value if specified for the column.
 
 =item --only-same-schema-fks
 


### PR DESCRIPTION
Old documentation was incomplete: old rows would not use the new user defined default value for the altered column. Only new rows inserted after pt-osc would use the user defined default value. Existing rows would only be converted to a default value derived from the datatype, as it used to be the case with mysql 5.6

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [x] Documention updated
- [ ] Test suite update
