### PR TITLE
PT-1700 pt-table-checksum REPLICATION_STOPPED exit status not documented

### DIFF
--- a/bin/pt-table-checksum
+++ b/bin/pt-table-checksum
@@ -13010,6 +13010,7 @@ with these flags:
    TABLE_DIFF               16  At least one diff was found
    SKIP_CHUNK               32  At least one chunk was skipped
    SKIP_TABLE               64  At least one table was skipped
+   REPLICATION_STOPPED     128  Replica is down or stopped
 
 If any flag is set, the exit status will be non-zero.  Use the bitwise C<AND>
 operation to check for a particular flag.  For example, if C<$exit_status & 16>


### PR DESCRIPTION
Fixed documntaiton in bin/pt-table-checksum

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] util/update-modules has been ran
- [x] Documention updated
- [x] Test suite update
