### PR TITLE
PT-1683 List of supported distributions in the docs is outdated

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -41,10 +41,10 @@ You can also download the packages from the
 `Percona web site <https://www.percona.com/downloads/percona-toolkit/>`_
 and install it using tools like ``dpkg`` and ``rpm``,
 depending on your system.
-For example, to download the package for Debian 8 ("jessie"),
+For example, to download the package for Debian 11 ("bullseye"),
 run the following::
 
- wget https://www.percona.com/downloads/percona-toolkit/3.0.3/binary/debian/jessie/x86_64/percona-toolkit_3.0.3-1.jessie_amd64.deb
+ wget https://downloads.percona.com/downloads/percona-toolkit/3.5.1/binary/debian/bullseye/x86_64/percona-toolkit_3.5.1-2.bullseye_amd64.deb
 
 If you want to download a specific tool, use the following address:
 http://www.percona.com/get


### PR DESCRIPTION
Bug itself is fixed by commits 7eaca8a98e961bdbd2fd11dbc9f3322120e6b4d0 and ee6a9da43801239cb69e79b89c2f93f3aed7b0d0 But the documentation still listed Debian 8 (jessie) which is, again, outdated. So I adopted example for Percona 3.5.1 on Debian 11 (bullseye)

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] util/update-modules has been ran
- [x] Documention updated
- [x] Test suite update
