### PR TITLE
PT-1642-Update PT docs to reference bug reporting location as Percona…

### DIFF
--- a/bin/pt-align
+++ b/bin/pt-align
@@ -1285,7 +1285,7 @@ reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-align>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-archiver
+++ b/bin/pt-archiver
@@ -8655,7 +8655,7 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-archiver>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-config-diff
+++ b/bin/pt-config-diff
@@ -5926,7 +5926,7 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-config-diff>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-deadlock-logger
+++ b/bin/pt-deadlock-logger
@@ -5702,7 +5702,7 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-deadlock-logger>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-diskstats
+++ b/bin/pt-diskstats
@@ -5618,7 +5618,7 @@ reading from files.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-diskstats>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-duplicate-key-checker
+++ b/bin/pt-duplicate-key-checker
@@ -5713,7 +5713,7 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-duplicate-key-checker>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-fifo-split
+++ b/bin/pt-fifo-split
@@ -1634,7 +1634,7 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-fifo-split>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-find
+++ b/bin/pt-find
@@ -5128,7 +5128,7 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-find>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-fingerprint
+++ b/bin/pt-fingerprint
@@ -2198,7 +2198,7 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-fingerprint>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-fk-error-logger
+++ b/bin/pt-fk-error-logger
@@ -4690,7 +4690,7 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-fk-error-logger>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-heartbeat
+++ b/bin/pt-heartbeat
@@ -7384,7 +7384,7 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-heartbeat>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-index-usage
+++ b/bin/pt-index-usage
@@ -7658,7 +7658,7 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-index-usage>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-ioprofile
+++ b/bin/pt-ioprofile
@@ -1053,7 +1053,7 @@ This tool requires the Bourne shell (F</bin/sh>).
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-ioprofile>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-kill
+++ b/bin/pt-kill
@@ -8660,7 +8660,7 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-kill>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-mext
+++ b/bin/pt-mext
@@ -729,7 +729,7 @@ This tool requires the Bourne shell (F</bin/sh>) and the seq program.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-mext>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-mysql-summary
+++ b/bin/pt-mysql-summary
@@ -3221,7 +3221,7 @@ On BSD systems, it may require a mounted procfs.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-mysql-summary>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -13385,9 +13385,9 @@ REPLICATION SLAVE and REPLICATION CLIENT privileges.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-online-schema-change>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
-Please report bugs at L<https://bugs.launchpad.net/percona-toolkit>.
+Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:
 
 =over

--- a/bin/pt-pmp
+++ b/bin/pt-pmp
@@ -822,7 +822,7 @@ on the command line.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-pmp>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -16775,7 +16775,7 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-query-digest>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-show-grants
+++ b/bin/pt-show-grants
@@ -2599,9 +2599,9 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-show-grants>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
-Please report bugs at L<https://bugs.launchpad.net/percona-toolkit>.
+Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:
 
 =over

--- a/bin/pt-sift
+++ b/bin/pt-sift
@@ -1170,7 +1170,7 @@ they will be fetched from the Internet if curl is available.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-sift>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-slave-delay
+++ b/bin/pt-slave-delay
@@ -4987,7 +4987,7 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-slave-delay>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-slave-find
+++ b/bin/pt-slave-find
@@ -4507,7 +4507,7 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-slave-find>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-slave-restart
+++ b/bin/pt-slave-restart
@@ -6158,7 +6158,7 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-slave-restart>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-stalk
+++ b/bin/pt-stalk
@@ -2477,7 +2477,7 @@ This tool requires Bash v3 or newer.  Certain options require other programs:
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-stalk>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-summary
+++ b/bin/pt-summary
@@ -2690,7 +2690,7 @@ This tool requires the Bourne shell (F</bin/sh>).
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-summary>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-table-checksum
+++ b/bin/pt-table-checksum
@@ -14050,7 +14050,7 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-table-checksum>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-table-sync
+++ b/bin/pt-table-sync
@@ -13039,7 +13039,7 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-table-sync>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-table-usage
+++ b/bin/pt-table-usage
@@ -8446,7 +8446,7 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-table-usage>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-upgrade
+++ b/bin/pt-upgrade
@@ -11442,7 +11442,7 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-upgrade>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-variable-advisor
+++ b/bin/pt-variable-advisor
@@ -6253,7 +6253,7 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-variable-advisor>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/bin/pt-visual-explain
+++ b/bin/pt-visual-explain
@@ -699,7 +699,7 @@ sub index_access {
 # with comments and its test file can be found in the Bazaar repository at,
 #   lib/OptionParser.pm
 #   t/lib/OptionParser.t
-# See https://launchpad.net/percona-toolkit for more information.
+# See https://github.com/percona/percona-toolkit for more information.
 # ###########################################################################
 {
 package OptionParser;
@@ -1810,7 +1810,7 @@ if ( PTDEBUG ) {
 # with comments and its test file can be found in the Bazaar repository at,
 #   lib/DSNParser.pm
 #   t/lib/DSNParser.t
-# See https://launchpad.net/percona-toolkit for more information.
+# See https://github.com/percona/percona-toolkit for more information.
 # ###########################################################################
 {
 package DSNParser;
@@ -2255,7 +2255,7 @@ sub _d {
 # with comments and its test file can be found in the Bazaar repository at,
 #   lib/Daemon.pm
 #   t/lib/Daemon.t
-# See https://launchpad.net/percona-toolkit for more information.
+# See https://github.com/percona/percona-toolkit for more information.
 # ###########################################################################
 {
 package Daemon;
@@ -3234,7 +3234,7 @@ installed in any reasonably new version of Perl.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-visual-explain>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
 Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:

--- a/t/lib/samples/bash/po001.sh
+++ b/t/lib/samples/bash/po001.sh
@@ -227,9 +227,9 @@ This tool requires Bash v3 or newer.
 
 =head1 BUGS
 
-For a list of known bugs, see L<http://www.percona.com/bugs/pt-stalk>.
+For a list of known bugs, see L<https://jira.percona.com/projects/PT/issues>.
 
-Please report bugs at L<https://bugs.launchpad.net/percona-toolkit>.
+Please report bugs at L<https://jira.percona.com/projects/PT>.
 Include the following information in your bug report:
 
 =over


### PR DESCRIPTION
… JIRA

Updated bug tracker URL and also changed "open issues" list to https://jira.percona.com/projects/PT/issues

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] util/update-modules has been ran
- [x] Documention updated
- [x] Test suite update
