### PR TITLE
PT-2159 - Fix tests for pt-duplicate-key-checker

### DIFF
--- a/t/pt-duplicate-key-checker/issue_1192.t
+++ b/t/pt-duplicate-key-checker/issue_1192.t
@@ -33,6 +33,17 @@ my $cmd = "$trunk/bin/pt-duplicate-key-checker -F $cnf -h 127.1";
 $sb->wipe_clean($dbh);
 $sb->create_dbs($dbh, ['issue_1192']);
 
+my $transform_int = undef;
+# In version 8.0 integer display width is deprecated and not shown in the outputs.
+# So we need to transform our samples.
+if ($sandbox_version ge '8.0') {
+   $transform_int = sub {
+      my $txt = slurp_file(shift);
+      $txt =~ s/int\(\d{1,2}\)/int/g;
+      print $txt;
+   };
+}
+
 # #############################################################################
 # Issue 1192: DROP/ADD leaves structure unchanged
 # #############################################################################
@@ -43,6 +54,7 @@ ok(
       "$cmd -d issue_1192 --no-summary",
       "t/pt-duplicate-key-checker/samples/issue_1192.txt",
       sed => ["'s/  (/ (/g'"],
+      transform_sample => $transform_int
    ),
    "Keys are sorted lc so left-prefix magic works (issue 1192)"
 );

--- a/t/pt-duplicate-key-checker/issue_331.t
+++ b/t/pt-duplicate-key-checker/issue_331.t
@@ -33,6 +33,17 @@ my @args   = ('-F', $cnf, qw(-h 127.1));
 $sb->wipe_clean($dbh);
 $sb->create_dbs($dbh, ['test']);
 
+my $transform_int = undef;
+# In version 8.0 integer display width is deprecated and not shown in the outputs.
+# So we need to transform our samples.
+if ($sandbox_version ge '8.0') {
+   $transform_int = sub {
+      my $txt = slurp_file(shift);
+      $txt =~ s/int\(\d{1,2}\)/int/g;
+      print $txt;
+   };
+}
+
 # #############################################################################
 # Issue 331: mk-duplicate-key-checker crashes getting size of foreign keys
 # #############################################################################
@@ -41,7 +52,8 @@ $sb->load_file('master', 't/pt-duplicate-key-checker/samples/issue_331.sql', 'te
 ok(
    no_diff(
       sub { pt_duplicate_key_checker::main(@args, qw(-d issue_331)) },
-      't/pt-duplicate-key-checker/samples/issue_331.txt'
+      't/pt-duplicate-key-checker/samples/issue_331.txt',
+      transform_sample => $transform_int
    ),
    'Issue 331 crash on fks'
 ) or diag($test_diff);

--- a/t/pt-duplicate-key-checker/samples/simple_dupe_bug_1217013_80.txt
+++ b/t/pt-duplicate-key-checker/samples/simple_dupe_bug_1217013_80.txt
@@ -12,7 +12,7 @@
 #   UNIQUE KEY `domain` (`domain`),
 #   UNIQUE KEY `unique_key_domain` (`domain`)
 # Column types:
-#	  `domain` varchar(175) character set utf8 collate utf8_bin not null
+#	  `domain` varchar(175) character set utf8mb3 collate utf8mb3_bin not null
 # To remove this duplicate index, execute:
 ALTER TABLE `test`.`domains` DROP INDEX `domain`;
 

--- a/t/pt-duplicate-key-checker/samples/simple_dupe_bug_1402730_80.txt
+++ b/t/pt-duplicate-key-checker/samples/simple_dupe_bug_1402730_80.txt
@@ -12,7 +12,7 @@
 #   UNIQUE KEY `domain` (`domain`),
 #   UNIQUE KEY `unique_key_domain` (`domain`)
 # Column types:
-#	  `domain` varchar(175) character set utf8 collate utf8_bin not null
+#	  `domain` varchar(175) character set utf8mb3 collate utf8mb3_bin not null
 # To remove this duplicate index, execute:
 ALTER TABLE `test`.`domains` DROP INDEX `domain`;
 


### PR DESCRIPTION
Added transformation to test results, so they work with deprecations, introduced in 8.0

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] util/update-modules has been ran
- [x] Documention updated
- [x] Test suite update
