### PR TITLE
PT-2149 - Fix tests for pt-mext

### DIFF
--- a/t/pt-mext/pt-mext.t
+++ b/t/pt-mext/pt-mext.t
@@ -26,7 +26,7 @@ ok(
    no_diff(
       "$cmd -- cat $sample/mext-001.txt",
       "t/pt-mext/samples/mext-001-result.txt",
-      post_pipe => "LANG=C sort -k1,1",
+      post_pipe => "LOCALE=C sort -k1,1",
    ),
    "mext-001"
 ) or diag($test_diff);
@@ -35,7 +35,7 @@ ok(
    no_diff(
       "$cmd -r -- cat $sample/mext-002.txt",
       "t/pt-mext/samples/mext-002-result.txt",
-      post_pipe => "LANG=C sort -k1,1",
+      post_pipe => "LOCALE=C sort -k1,1",
    ),
    "mext-002 -r"
 ) or diag($test_diff);


### PR DESCRIPTION
Changed LANG=C to LOCALE=C, because only LANG does not change sort order properly in tr_TR.UTF8 environment

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] util/update-modules has been ran
- [x] Documention updated
- [x] Test suite update
