### PR TITLE
PT-2161 - Fix tests for pt-slave-restart

### DIFF
--- a/t/pt-slave-restart/gtid.t
+++ b/t/pt-slave-restart/gtid.t
@@ -20,7 +20,7 @@ if ( $sandbox_version lt '5.6' ) {
 }
 
 diag('Restarting the sandbox');
-diag(`SAKILA=0 GTID=1 $trunk/sandbox/test-env restart`);
+diag(`SAKILA=0 REPLICATION_THREADS=0 GTID=1 $trunk/sandbox/test-env restart`);
 diag("Sandbox restarted");
 
 my $dp = new DSNParser(opts=>$dsn_opts);

--- a/t/pt-slave-restart/pt-slave-restart.t
+++ b/t/pt-slave-restart/pt-slave-restart.t
@@ -15,6 +15,10 @@ use PerconaTest;
 use Sandbox;
 require "$trunk/bin/pt-slave-restart";
 
+diag('Restarting the sandbox');
+diag(`SAKILA=0 REPLICATION_THREADS=0 GTID=1 $trunk/sandbox/test-env restart`);
+diag("Sandbox restarted");
+
 my $dp = new DSNParser(opts=>$dsn_opts);
 my $sb = new Sandbox(basedir => '/tmp', DSNParser => $dp);
 my $master_dbh = $sb->get_dbh_for('master');
@@ -137,7 +141,6 @@ is(
 # Done.
 # #############################################################################
 diag(`rm -f /tmp/pt-slave-re*`);
-$sb->wipe_clean($master_dbh);
-$sb->wipe_clean($slave_dbh);
+diag(`$trunk/sandbox/test-env restart`);
 ok($sb->ok(), "Sandbox servers") or BAIL_OUT(__FILE__ . " broke the sandbox");
 done_testing;


### PR DESCRIPTION
Added REPLICATION_THREADS=0 to tests which suppose that replication is single-threaded, because new default in 8.0 is 4 replication threads. Fixed clean up code in t/pt-slave-restart/pt-slave-restart.t

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] util/update-modules has been ran
- [x] Documention updated
- [x] Test suite update
