### PR TITLE
Fix the error 'sql syntax' was reported during migration

### DIFF
--- a/bin/pt-archiver
+++ b/bin/pt-archiver
@@ -1923,13 +1923,13 @@ sub get_create_table {
    eval { $href = $dbh->selectrow_hashref($show_sql); };
    if ( my $e = $EVAL_ERROR ) {
       PTDEBUG && _d($old_sql_mode);
-      $dbh->do($old_sql_mode);
+      eval {  $dbh->do($old_sql_mode); };
 
       die $e;
    }
 
    PTDEBUG && _d($old_sql_mode);
-   $dbh->do($old_sql_mode);
+   eval { $dbh->do($old_sql_mode); };
 
    my ($key) = grep { m/create (?:table|view)/i } keys %$href;
    if ( !$key ) {


### PR DESCRIPTION
fix the Error 'SQL syntax' was reported during migration.

An error occurred when I migrated data from MySQL to OceanBase:【 DBD::mysql::db do failed: You have an error in your SQL syntax; check the manual that corresponds to your OceanBase version for the right syntax to use near ':= @OLD_SQL_MODE, @@SQL_QUOTE_SHOW_CREATE := @OLD_QUOTE */' at line 1 [for Statement "/*!40101 SET @@SQL_MODE := @OLD_SQL_MODE, @@SQL_QUOTE_SHOW_CREATE := @OLD_QUOTE */"] at /usr/bin/pt-archiver line 1932.】

I'm not a Perl programmer. But by reading the source code and making some changes, the migration was done successfully, so I submit this report


- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] util/update-modules has been ran
- [x] *Not involved* Documention updated 
- [x] *Not involved* Test suite update 
