### PR TITLE
PT-2048 - pt-osc spans excessive connections to the replica when executing in the source

### DIFF
--- a/t/pt-online-schema-change/pt-2048.t
+++ b/t/pt-online-schema-change/pt-2048.t
@@ -1,0 +1,59 @@
+#!/usr/bin/env perl
+
+BEGIN {
+    die "The PERCONA_TOOLKIT_BRANCH environment variable is not set.\n"
+    unless $ENV{PERCONA_TOOLKIT_BRANCH} && -d $ENV{PERCONA_TOOLKIT_BRANCH};
+    unshift @INC, "$ENV{PERCONA_TOOLKIT_BRANCH}/lib";
+};
+
+use strict;
+use warnings FATAL => 'all';
+
+use English qw(-no_match_vars);
+use Test::More;
+
+use Data::Dumper;
+use PerconaTest;
+use Sandbox;
+
+require "$trunk/bin/pt-online-schema-change";
+
+my $dp = new DSNParser(opts=>$dsn_opts);
+my $sb = new Sandbox(basedir => '/tmp', DSNParser => $dp);
+
+my $dbh = $sb->get_dbh_for('master');
+my $slave_dbh  = $sb->get_dbh_for('slave1');
+my $dsn = $sb->dsn_for("master");
+
+# The sandbox servers run with lock_wait_timeout=3 and it's not dynamic
+# so we need to specify --set-vars innodb_lock_wait_timeout=3 else the
+# tool will die.
+my @args = (qw(--set-vars innodb_lock_wait_timeout=3));
+my $output;
+my $exit_status;
+
+$sb->load_file('master', "t/pt-online-schema-change/samples/pt-2048.sql");
+
+my $rows_before = $slave_dbh->selectrow_arrayref("select total_connections from performance_schema.users where user like 'msandbox';");
+
+($output, $exit_status) = full_output(
+    sub { pt_online_schema_change::main(@args, "$dsn,D=test,t=joinit",
+            '--execute', '--charset=utf8', '--chunk-size', '2', '--alter', 'engine=innodb',
+        ),
+    },
+    stderr => 1,
+);
+
+my $rows_after = $slave_dbh->selectrow_arrayref("select total_connections from performance_schema.users where user like 'msandbox';");
+
+cmp_ok(
+   $rows_after->[0] - $rows_before->[0], '<', 10, 
+   "pt-2048 reasonable number of connections"
+);
+
+# #############################################################################
+# Done.
+# #############################################################################
+$sb->wipe_clean($dbh);
+ok($sb->ok(), "Sandbox servers") or BAIL_OUT(__FILE__ . " broke the sandbox");
+done_testing;

--- a/t/pt-online-schema-change/pt-2048.t
+++ b/t/pt-online-schema-change/pt-2048.t
@@ -12,7 +12,6 @@ use warnings FATAL => 'all';
 use English qw(-no_match_vars);
 use Test::More;
 
-use Data::Dumper;
 use PerconaTest;
 use Sandbox;
 
@@ -22,8 +21,18 @@ my $dp = new DSNParser(opts=>$dsn_opts);
 my $sb = new Sandbox(basedir => '/tmp', DSNParser => $dp);
 
 my $dbh = $sb->get_dbh_for('master');
-my $slave_dbh  = $sb->get_dbh_for('slave1');
+my $slave_dbh = $sb->get_dbh_for('slave1');
 my $dsn = $sb->dsn_for("master");
+
+if ( !dbh ) {
+   plan skip_all => 'Cannot connect to sandbox master';
+}
+elsif ( !$slave_dbh ) {
+   plan skip_all => 'Cannot connect to sandbox slave';
+}
+else {
+   plan tests => 3;
+}
 
 # The sandbox servers run with lock_wait_timeout=3 and it's not dynamic
 # so we need to specify --set-vars innodb_lock_wait_timeout=3 else the

--- a/t/pt-online-schema-change/pt-2048.t
+++ b/t/pt-online-schema-change/pt-2048.t
@@ -24,14 +24,14 @@ my $dbh = $sb->get_dbh_for('master');
 my $slave_dbh = $sb->get_dbh_for('slave1');
 my $dsn = $sb->dsn_for("master");
 
-if ( !dbh ) {
+if ( !$dbh ) {
    plan skip_all => 'Cannot connect to sandbox master';
 }
 elsif ( !$slave_dbh ) {
    plan skip_all => 'Cannot connect to sandbox slave';
 }
 else {
-   plan tests => 3;
+   plan tests => 2;
 }
 
 # The sandbox servers run with lock_wait_timeout=3 and it's not dynamic

--- a/t/pt-online-schema-change/samples/pt-2048.sql
+++ b/t/pt-online-schema-change/samples/pt-2048.sql
@@ -1,0 +1,25 @@
+DROP DATABASE IF EXISTS test;
+CREATE DATABASE test;
+
+USE test;
+
+DROP TABLE IF EXISTS `joinit`;
+
+CREATE TABLE `joinit` (
+  `i` int(11) NOT NULL AUTO_INCREMENT,
+  `s` varchar(64) DEFAULT NULL,
+  `t` time NOT NULL,
+  `g` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) ENGINE=InnoDB  DEFAULT CHARSET=latin1;
+
+INSERT INTO joinit VALUES (NULL, uuid(), time(now()),  (FLOOR( 1 + RAND( ) *60 )));
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  (FLOOR( 1 + RAND( ) *60 )) FROM joinit;


### PR DESCRIPTION
The bug itself is fixed by PT-2160: 'fix tests for pt online schema change'

This PR adds a regression test.

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documention updated
- [x] Test suite update
