### PR TITLE
PT-2169 - pt-k8s-debug-collector integration of pg_gather requires croping first line of the output file

### DIFF
--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -17,9 +17,10 @@ else
 endif
 
 GO := go
+CP := )
 pkgs = $(shell find . -type d -name "pt-*" -exec basename {} \;)
 # VERSION ?=$(shell git describe --abbrev=0) doesn't always work here, need to use git log
-VERSION ?=$(shell git log --no-walk --tags --pretty="%H %d" --decorate=short | head -n1 | awk  -F'[, ]' '{ print $$4; }')
+VERSION ?=$(shell git log --no-walk --tags --pretty="%H %d" --decorate=short | head -n1 | awk  -F'[, $(CP)]' '{ print $$4; }')
 BUILD=$(BUILD_DATE)
 GOVERSION=$(shell go version | cut --delimiter=" " -f3)
 GOUTILSDIR ?= $(GOPATH)/bin

--- a/src/go/pt-k8s-debug-collector/dumper/dumper.go
+++ b/src/go/pt-k8s-debug-collector/dumper/dumper.go
@@ -6,7 +6,6 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -309,7 +308,7 @@ func (d *Dumper) getResource(name, namespace string, ignoreNotFound bool, tw *ta
 }
 
 func (d *Dumper) logError(err string, args ...string) {
-	d.errors += d.cmd + " " + strings.Join(args, " ") + ": " + err + "\n"
+	d.errors += d.cmd + " " + strings.Join(args, " ") + "\n" + err + "\n\n"
 }
 
 func addToArchive(location string, mode int64, content []byte, tw *tar.Writer) error {
@@ -463,10 +462,10 @@ func (d *Dumper) getPodSummary(resource, podName, crName string, namespace strin
 	cmd.Stderr = &errb
 	err := cmd.Run()
 	if err != nil {
-		return nil, errors.Errorf("error: %v, stderr: %s, stdout: %s", err, errb.String(), outb.String())
+		return nil, errors.Errorf("error: %v\nstderr: %sstdout: %s", err, errb.String(), outb.String())
+	} else {
+		return outb.Bytes(), nil
 	}
-
-	return []byte(fmt.Sprintf("stderr: %s, stdout: %s", errb.String(), outb.String())), nil
 }
 
 func (d *Dumper) getCR(crName string, namespace string) (crSecrets, error) {

--- a/src/go/pt-k8s-debug-collector/dumper/dumper.go
+++ b/src/go/pt-k8s-debug-collector/dumper/dumper.go
@@ -463,9 +463,8 @@ func (d *Dumper) getPodSummary(resource, podName, crName string, namespace strin
 	err := cmd.Run()
 	if err != nil {
 		return nil, errors.Errorf("error: %v\nstderr: %sstdout: %s", err, errb.String(), outb.String())
-	} else {
-		return outb.Bytes(), nil
 	}
+	return outb.Bytes(), nil
 }
 
 func (d *Dumper) getCR(crName string, namespace string) (crSecrets, error) {


### PR DESCRIPTION
Modified pt-k8s-debug-collector so it redirects only STDOUT to summary.txt STDERR is stored in the logs and recorded in summary.txt only if summary fails with the error Modified Makefile, so it does not include closing bracket into the version string Created test case for the fix

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documentation updated
- [x] Test suite update
