### PR TITLE
Remove $has_child_tables var

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -9149,13 +9149,6 @@ sub main {
    # ########################################################################
    my $child_tables;
 
-   my $have_child_tables = find_child_tables(
-         tbl    => $orig_tbl,
-         Cxn    => $cxn,
-         Quoter => $q,
-         only_same_schema_fks => $o->get('only-same-schema-fks'),
-      );
-
    my $vp = VersionParser->new($cxn->dbh());
    if (($vp->cmp('8.0.14') >= 0 && $vp->cmp('8.0.17') <= 0) && $vp->flavor() !~ m/maria/i) {
        my $msg = "There is an error in MySQL that makes the server to die when trying to ".


### PR DESCRIPTION
Remove $has_child_tables check as this seems a duplicate of the check within the alter_fk_method block.

I may be wrong here, please advise.
We do this on our production migrations as this check is very very slow as we have lots of tables in single instance. Seems its duplicated in the check just a few lines lower, I can not find any use of $has_child_tables anywhere in the code.

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documention updated
- [ ] Test suite update
