### PR TITLE
Fix broken --output-file

### DIFF
--- a/src/go/pt-secure-collect/sanitize.go
+++ b/src/go/pt-secure-collect/sanitize.go
@@ -22,7 +22,7 @@ func sanitizeFile(opts *cliOptions) error {
 	}
 
 	if *opts.SanitizeOutputFile != "" {
-		ifh, err = os.Create(*opts.SanitizeOutputFile)
+		ofh, err = os.Create(*opts.SanitizeOutputFile)
 		if err != nil {
 			return errors.Wrapf(err, "Cannot create output file %q", *opts.SanitizeOutputFile)
 		}


### PR DESCRIPTION
Fixes the broken write to output file option, --output-file.

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] util/update-modules has been ran
- [x] Documention updated
- [x] Test suite update
