### PR TITLE
Add after nibble hook to pt-online-schema-change

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -10022,6 +10022,11 @@ sub main {
             sleep $sleep;
          }
 
+         # --plugin hook
+         if ( $plugin && $plugin->can('on_copy_rows_after_nibble') ) {
+             $plugin->on_copy_rows_after_nibble();
+         }
+
          return;
       },
       done => sub {
@@ -13102,6 +13107,7 @@ These hooks, in this order, are called if defined:
    before_create_triggers
    after_create_triggers
    before_copy_rows
+   on_copy_rows_after_nibble
    after_copy_rows
    before_swap_tables
    after_swap_tables
@@ -13179,6 +13185,11 @@ Here's a plugin file template for all hooks:
    sub before_copy_rows {
       my ($self, %args) = @_;
       print "PLUGIN before_copy_rows\n";
+   }
+
+   sub on_copy_rows_after_nibble {
+      my ($self, %args) = @_;
+      print "PLUGIN on_copy_rows_after_nibble\n";
    }
 
    sub after_copy_rows {

--- a/t/pt-online-schema-change/plugin.t
+++ b/t/pt-online-schema-change/plugin.t
@@ -65,6 +65,7 @@ is_deeply(
       'PLUGIN before_create_triggers',
       'PLUGIN after_create_triggers',
       'PLUGIN before_copy_rows',
+      'PLUGIN on_copy_rows_after_nibble',
       'PLUGIN after_copy_rows',
       'PLUGIN before_swap_tables',
       'PLUGIN after_swap_tables',

--- a/t/pt-online-schema-change/samples/plugins/all_hooks.pm
+++ b/t/pt-online-schema-change/samples/plugins/all_hooks.pm
@@ -51,6 +51,11 @@ sub before_copy_rows {
    print "PLUGIN before_copy_rows\n";
 }
  
+sub on_copy_rows_after_nibble {
+   my ($self, %args) = @_;
+   print "PLUGIN on_copy_rows_after_nibble\n";
+}
+ 
 sub after_copy_rows {
    my ($self, %args) = @_;
    print "PLUGIN after_copy_rows\n";


### PR DESCRIPTION
- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] util/update-modules has been ran
- [x] Documention updated
- [x] Test suite update
----
## Problem

The current progress resource only outputs information as text and it is rather limited in the information it gives. It is only possible to choose between percentage, time or iterations. Besides that, the Progress class is also shared between many workflows to output the current status of the OSC (and other module). Running the module in debug mode generates extra output with meaningful information, although it is not as handy as a metric.

I want to export metrics of the internals of the running OSC so I have better visibility over the dynamic configurations, speed and progress. It helps on troubleshoots for long-running OSCs (more than a day).
Some useful metrics:

* current copy rate;
* each # rows per nibble
* each run time per nibble
* chunk size (when using dynamic chunks)
* current status

## Proposed solution

This change adds a new hook to the pt-online-schema-change script. The hook is between the `before_copy_rows` and after_copy_rows. I named it `on_copy_rows_after_nibble`.

That new hook allows users to write a custom code to get information from table row_cnt, nibble_time, progress and rate. Metrics can be submitted from that hook without further changes to the shared Progress class.

The current position of `on_copy_rows_after_nibble` is at the end so all other checks has finished (catch up of replicas, load, flow control).

This change don't solve the problem for publishing current state of the script is not available (running, replica catch up, paused, ...). I'm open to suggestions for further changes.