### PR TITLE
Update toolkit.yml

### DIFF
--- a/.github/workflows/toolkit.yml
+++ b/.github/workflows/toolkit.yml
@@ -17,8 +17,6 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: '1.20'
-    - name: Install make
-      run:  sudo apt-get update && sudo apt-get -y install make
     - name: Build
       run: cd src/go; make linux-amd64; cd ../../
       

--- a/.github/workflows/toolkit.yml
+++ b/.github/workflows/toolkit.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.20
+        go-version: '1.20'
     - name: Install make
       run:  sudo apt-get update && sudo apt-get -y install make
     - name: Build

--- a/.github/workflows/toolkit.yml
+++ b/.github/workflows/toolkit.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.19
+        go-version: 1.20
     - name: Install make
       run:  sudo apt-get update && sudo apt-get -y install make
     - name: Build


### PR DESCRIPTION
Bumped Go version to 1.20 for GitHub actions, so it is same as in our build machines.

- [ ] The contributed code is licensed under GPL v2.0
- [ ] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documention updated
- [ ] Test suite update
