### PR TITLE
War on typos Act 3

### DIFF
--- a/util/NaturalDocs/Info/HTMLTestCases.pm
+++ b/util/NaturalDocs/Info/HTMLTestCases.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/JavaScript/GooglePrettify.js
+++ b/util/NaturalDocs/JavaScript/GooglePrettify.js
@@ -1,5 +1,5 @@
 
-// This code comes from the December 2009 release of Google Prettify, which is Copyright © 2006 Google Inc.
+// This code comes from the December 2009 release of Google Prettify, which is Copyright (c) 2006 Google Inc.
 // Minor modifications are marked with "ND Change" comments.
 // As part of Natural Docs, this code is licensed under version 3 of the GNU Affero General Public License (AGPL.)
 // However, it may also be obtained separately under version 2.0 of the Apache License.

--- a/util/NaturalDocs/JavaScript/NaturalDocs.js
+++ b/util/NaturalDocs/JavaScript/NaturalDocs.js
@@ -1,4 +1,4 @@
-// This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+// This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 // Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 // Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/License.txt
+++ b/util/NaturalDocs/License.txt
@@ -3,7 +3,7 @@ Title: License
 Natural Docs is Copyright © 2003-2010 Greg Valure.  Natural Docs is licensed under version 3 of the GNU
 Affero General Public License (AGPL).
 
-Natural Docs incorporates code from Google Prettify, which is Copyright © 2006 Google Inc.  Google Prettify
+Natural Docs incorporates code from Google Prettify, which is Copyright (c) 2006 Google Inc.  Google Prettify
 may be obtained separately under version 2.0 of the Apache License.  However, this combined product is still
 licensed under the terms of the AGPLv3.
 

--- a/util/NaturalDocs/Modules/NaturalDocs/BinaryFile.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/BinaryFile.pm
@@ -13,7 +13,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Builder.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Builder.pm
@@ -18,7 +18,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Builder/Base.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Builder/Base.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Builder/FramedHTML.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Builder/FramedHTML.pm
@@ -10,7 +10,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Builder/HTML.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Builder/HTML.pm
@@ -10,7 +10,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Builder/HTMLBase.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Builder/HTMLBase.pm
@@ -9,7 +9,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/ClassHierarchy.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/ClassHierarchy.pm
@@ -25,7 +25,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/ClassHierarchy/Class.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/ClassHierarchy/Class.pm
@@ -9,7 +9,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/ClassHierarchy/File.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/ClassHierarchy/File.pm
@@ -9,7 +9,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/ConfigFile.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/ConfigFile.pm
@@ -13,7 +13,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Constants.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Constants.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/DefineMembers.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/DefineMembers.pm
@@ -31,7 +31,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Error.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Error.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/File.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/File.pm
@@ -16,7 +16,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/ImageReferenceTable.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/ImageReferenceTable.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/ImageReferenceTable/Reference.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/ImageReferenceTable/Reference.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/ImageReferenceTable/String.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/ImageReferenceTable/String.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Languages.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Languages.pm
@@ -12,7 +12,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Languages/ActionScript.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Languages/ActionScript.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Languages/Ada.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Languages/Ada.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Languages/Advanced.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Languages/Advanced.pm
@@ -9,7 +9,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Languages/Advanced/Scope.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Languages/Advanced/Scope.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Languages/Advanced/ScopeChange.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Languages/Advanced/ScopeChange.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Languages/Base.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Languages/Base.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Languages/CSharp.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Languages/CSharp.pm
@@ -31,7 +31,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Languages/PLSQL.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Languages/PLSQL.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Languages/Pascal.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Languages/Pascal.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Languages/Perl.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Languages/Perl.pm
@@ -22,7 +22,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Languages/Prototype.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Languages/Prototype.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Languages/Prototype/Parameter.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Languages/Prototype/Parameter.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Languages/Simple.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Languages/Simple.pm
@@ -10,7 +10,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Languages/Tcl.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Languages/Tcl.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/LineReader.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/LineReader.pm
@@ -15,7 +15,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Menu.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Menu.pm
@@ -20,7 +20,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Menu/Entry.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Menu/Entry.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/NDMarkup.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/NDMarkup.pm
@@ -12,7 +12,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Parser.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Parser.pm
@@ -18,7 +18,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Parser/JavaDoc.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Parser/JavaDoc.pm
@@ -60,7 +60,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Parser/Native.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Parser/Native.pm
@@ -9,7 +9,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Parser/ParsedTopic.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Parser/ParsedTopic.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Project.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Project.pm
@@ -24,7 +24,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Project/ImageFile.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Project/ImageFile.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Project/SourceFile.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Project/SourceFile.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/ReferenceString.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/ReferenceString.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Settings.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Settings.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Settings/BuildTarget.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Settings/BuildTarget.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/SourceDB.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/SourceDB.pm
@@ -63,7 +63,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/SourceDB/Extension.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/SourceDB/Extension.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/SourceDB/File.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/SourceDB/File.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/SourceDB/Item.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/SourceDB/Item.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/SourceDB/ItemDefinition.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/SourceDB/ItemDefinition.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/SourceDB/WatchedFileDefinitions.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/SourceDB/WatchedFileDefinitions.pm
@@ -9,7 +9,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/StatusMessage.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/StatusMessage.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/SymbolString.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/SymbolString.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/SymbolTable.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/SymbolTable.pm
@@ -28,7 +28,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/SymbolTable/File.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/SymbolTable/File.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/SymbolTable/IndexElement.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/SymbolTable/IndexElement.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/SymbolTable/Reference.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/SymbolTable/Reference.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/SymbolTable/ReferenceTarget.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/SymbolTable/ReferenceTarget.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/SymbolTable/Symbol.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/SymbolTable/Symbol.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/SymbolTable/SymbolDefinition.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/SymbolTable/SymbolDefinition.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Topics.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Topics.pm
@@ -9,7 +9,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Topics/Type.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Topics/Type.pm
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Modules/NaturalDocs/Version.pm
+++ b/util/NaturalDocs/Modules/NaturalDocs/Version.pm
@@ -10,7 +10,7 @@
 #
 ###############################################################################
 
-# This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure
+# This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure
 # Natural Docs is licensed under version 3 of the GNU Affero General Public License (AGPL)
 # Refer to License.txt for the complete details
 

--- a/util/NaturalDocs/Styles/Default.css
+++ b/util/NaturalDocs/Styles/Default.css
@@ -10,7 +10,7 @@
    directory, the changes will automatically be applied to all your projects
    that use this style the next time Natural Docs is run on them.
 
-   This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure.
+   This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure.
    Natural Docs is licensed under version 3 of the GNU Affero General Public
    License (AGPL).  Refer to License.txt for the complete details.
 

--- a/util/NaturalDocs/Styles/Roman.css
+++ b/util/NaturalDocs/Styles/Roman.css
@@ -10,7 +10,7 @@
    directory, the changes will automatically be applied to all your projects
    that use this style the next time Natural Docs is run on them.
 
-   This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure.
+   This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure.
    Natural Docs is licensed under version 3 of the GNU Affero General Public
    License (AGPL).  Refer to License.txt for the complete details.
 

--- a/util/NaturalDocs/Styles/Small.css
+++ b/util/NaturalDocs/Styles/Small.css
@@ -10,7 +10,7 @@
    directory, the changes will automatically be applied to all your projects
    that use this style the next time Natural Docs is run on them.
 
-   This file is part of Natural Docs, which is Copyright © 2003-2010 Greg Valure.
+   This file is part of Natural Docs, which is Copyright (c) 2003-2010 Greg Valure.
    Natural Docs is licensed under version 3 of the GNU Affero General Public
    License (AGPL).  Refer to License.txt for the complete details.
 


### PR DESCRIPTION
- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documention updated
- [ ] Test suite update

Fix 0xA9 (and UNICODE) characters in copyright message.
In source code the `[ -~]` (from space to tilde) ASCII range is enough.
```ascii
 !"#$%&'()*+,-./0123456789:;<=>?
@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_
`abcdefghijklmnopqrstuvwxyz{|}~
```

Although I see artistic intentions in the wild.
