### PR TITLE
Bugfix - caching_sha2_passwords non-printable characters

### DIFF
--- a/bin/pt-show-grants
+++ b/bin/pt-show-grants
@@ -2037,6 +2037,12 @@ sub main {
          PTDEBUG && _d('Checking user', $user_host);
       }
 
+      # If MySQL 8.0+ then caching_sha2_passwords could contain non-printable chars
+      if (( VersionCompare::cmp($version, '8.0.0') >= 0 ) &&
+          ( VersionCompare::cmp($version, '10.0.0') <= 0 )) {
+         $dbh->do("SET print_identified_with_as_hex = ON")
+      }
+
       # If MySQL 5.7.6+ then we need to use SHOW CREATE USER
       my @create_user;
       if (( VersionCompare::cmp($version, '5.7.6') >= 0 ) &&


### PR DESCRIPTION
Authentication string for caching_sha2_passwords can contain non-printable characters, to generate a safe string is recommended to use always the binary representation of it.

More information:
https://lefred.be/content/cut-paste-a-user-creation-statement-with-mysql-8/

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] util/update-modules has been ran
- [x] Documentation updated
- [x] Test suite update
