### PR TITLE
Fix newly discovered typos

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -11175,7 +11175,7 @@ sub determine_alter_fk_method {
       return '';  # $alter_fk_method can't be undef
    }
 
-   # The rebuild_constraints method is the default becuase it's safer
+   # The rebuild_constraints method is the default because it's safer
    # and doesn't cause the orig table to go missing for a moment.
    my $method = 'rebuild_constraints';
 
@@ -11630,7 +11630,7 @@ sub random_suffix {
 # duplicate_trigger: If set, it will create the trigger on the new table
 #                    with a random string as a trigger name suffix.
 #                    It will also not drop the original trigger.
-#                    This is usefull when creating a temporary trigger for testing
+#                    This is useful when creating a temporary trigger for testing
 #                    purposes or if --no-swap-tables AND --no-drop-new-table was
 #                    specified along with --preserve-triggers. In this case,
 #                    since the original table and triggers are not going to be

--- a/bin/pt-table-checksum
+++ b/bin/pt-table-checksum
@@ -10955,11 +10955,11 @@ sub main {
    # the user does --chunk-size-limit=0 to disable the 1st, documented
    # purpose because, apparently, they're using non-unique indexes and
    # they don't care about potentially large chunks.  But disabling the
-   # 1st purpose adversely affects the 2nd purpose becuase 0 * the chunk size
+   # 1st purpose adversely affects the 2nd purpose because 0 * the chunk size
    # will always be zero, so tables will only be single-chunked if EXPLAIN
    # says there are 0 rows, but sometimes EXPLAIN says there is 1 row
    # even when the table is empty.  This wouldn't matter except that nibbling
-   # an empty table doesn't currently work becuase there are no boundaries,
+   # an empty table doesn't currently work because there are no boundaries,
    # so no checksum is written for the empty table.  To fix this and
    # preserve the two purposes of this option, usages of the 2nd purpose
    # do || 1 so the limit is never 0 and empty tables are single-chunked.


### PR DESCRIPTION
- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documentation updated
- [ ] Test suite update

These misspellings were only in `bin/`.
