### PR TITLE
PT-2207 - pt-archiver doesn't work when ANSI_QUOTES is set in sql_mode

### DIFF
--- a/bin/pt-archiver
+++ b/bin/pt-archiver
@@ -6401,7 +6401,7 @@ sub main {
          $tp->get_create_table( $dbh, $table->{D}, $table->{t} ));
 
       if ( $o->get('check-charset') ) {
-         my $sql = 'SELECT CONCAT(/*!40100 @@session.character_set_connection, */ "")';
+         my $sql = 'SELECT CONCAT(/*!40100 @@session.character_set_connection, */ \'\')';
          PTDEBUG && _d($sql);
          my ($dbh_charset) =  $table->{dbh}->selectrow_array($sql);
 

--- a/t/pt-archiver/pt-2207.t
+++ b/t/pt-archiver/pt-2207.t
@@ -1,0 +1,67 @@
+#!/usr/bin/env perl
+
+BEGIN {
+   die "The PERCONA_TOOLKIT_BRANCH environment variable is not set.\n"
+      unless $ENV{PERCONA_TOOLKIT_BRANCH} && -d $ENV{PERCONA_TOOLKIT_BRANCH};
+   unshift @INC, "$ENV{PERCONA_TOOLKIT_BRANCH}/lib";
+};
+
+use strict;
+use warnings FATAL => 'all';
+use English qw(-no_match_vars);
+use Test::More;
+
+use PerconaTest;
+use Sandbox;
+require "$trunk/bin/pt-archiver";
+
+my $dp  = new DSNParser(opts=>$dsn_opts);
+my $sb  = new Sandbox(basedir => '/tmp', DSNParser => $dp);
+my $dbh = $sb->get_dbh_for('master');
+
+if ( !$dbh ) {
+   plan skip_all => 'Cannot connect to sandbox master';
+}
+
+my $output;
+my $exit_val;
+my $rows;
+my $cnf = "/tmp/12345/my.sandbox.cnf";
+my $cmd = "$trunk/bin/pt-archiver";
+
+$sb->create_dbs($dbh, ['test']);
+$sb->load_file('master', 't/pt-archiver/samples/table1.sql');
+
+# Archive to a file.
+`rm -f archive.test.table_1`;
+($output, $exit_val) = full_output(
+   sub { pt_archiver::main(qw(--where 1=1), "--source", "D=test,t=table_1,F=$cnf", "--file", 'archive.%D.%t', "--set-vars", "sql_mode=ANSI_QUOTES") },
+);
+
+is($exit_val,
+   0,
+   "SQL Mode ANSI_QUOTES works"
+) or diag($output);
+
+is($output, '', 'No output for archiving to a file');
+$output = `/tmp/12345/use -N -e "select count(*) from test.table_1"`;
+is($output + 0, 0, 'Purged all rows ok');
+ok(-f 'archive.test.table_1', 'Archive file written OK');
+$output = `cat archive.test.table_1`;
+is($output, <<EOF
+1\t2\t3\t4
+2\t\\N\t3\t4
+3\t2\t3\t\\\t
+4\t2\t3\t\\
+EOF
+, 'File has the right stuff');
+`rm -f archive.test.table_1`;
+
+# #############################################################################
+# Done.
+# #############################################################################
+diag(`rm -f /tmp/*.table_1`);
+$sb->wipe_clean($dbh);
+ok($sb->ok(), "Sandbox servers") or BAIL_OUT(__FILE__ . " broke the sandbox");
+
+done_testing;


### PR DESCRIPTION
- Implemented suggestion from the bug report
- Added test case

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documentation updated
- [x] Test suite update
