### PR TITLE
PT-2254 pt-k8s-debug-collector: -resource=auto should get every possi…

### DIFF
--- a/src/go/pt-k8s-debug-collector/dumper/resources.go
+++ b/src/go/pt-k8s-debug-collector/dumper/resources.go
@@ -1,0 +1,82 @@
+package dumper
+
+import "regexp"
+
+var resourcesRe = regexp.MustCompile(`(\w+).percona\.com`)
+
+type resourceCompilation struct {
+	k8sResources []string
+	filePaths    []string
+}
+
+var resourcesMapping = map[string]resourceCompilation{
+	"common": resourceCompilation{
+		k8sResources: []string{
+			"pods",
+			"replicasets",
+			"deployments",
+			"statefulsets",
+			"replicationcontrollers",
+			"events",
+			"configmaps",
+			"cronjobs",
+			"jobs",
+			"poddisruptionbudgets",
+			"clusterrolebindings",
+			"clusterroles",
+			"rolebindings",
+			"roles",
+			"storageclasses",
+			"persistentvolumeclaims",
+			"persistentvolumes",
+		},
+	},
+
+	"pg": resourceCompilation{
+		k8sResources: []string{
+			"perconapgclusters",
+			"pgclusters",
+			"pgpolicies",
+			"pgreplicas",
+			"pgtasks",
+		},
+	},
+	"pgv2": resourceCompilation{
+		k8sResources: []string{
+			"perconapgbackups",
+			"perconapgclusters",
+			"perconapgrestores",
+		},
+	},
+	"pxc": resourceCompilation{
+		k8sResources: []string{
+			"perconaxtradbclusterbackups",
+			"perconaxtradbclusterrestores",
+			"perconaxtradbclusters",
+		},
+		filePaths: []string{
+			"var/lib/mysql/mysqld-error.log",
+			"var/lib/mysql/innobackup.backup.log",
+			"var/lib/mysql/innobackup.move.log",
+			"var/lib/mysql/innobackup.prepare.log",
+			"var/lib/mysql/grastate.dat",
+			"var/lib/mysql/gvwstate.dat",
+			"var/lib/mysql/mysqld.post.processing.log",
+			"var/lib/mysql/auto.cnf",
+		},
+	},
+	"ps": resourceCompilation{
+		k8sResources: []string{
+			"perconaservermysqlbackups",
+			"perconaservermysqlrestores",
+			"perconaservermysqls",
+		},
+	},
+	"psmdb": resourceCompilation{
+		k8sResources: []string{
+			"perconaservermongodbbackups",
+			"perconaservermongodbrestores",
+			"perconaservermongodbs",
+		},
+	},
+}


### PR DESCRIPTION
…ble resources at once

Instead of relying on a "passthrough" mechanism on switch case, declaring a mapping between api and linked resources is easier and enable to iterate easily. It also ease contributions, as adding files/resources would not touch code anymore

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documentation updated
- [ ] Test suite update
