### PR TITLE
sphinx-build errors

### DIFF
--- a/config/sphinx-build/conf.py
+++ b/config/sphinx-build/conf.py
@@ -86,8 +86,8 @@ pygments_style = 'sphinx'
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 
-extlinks = {'jirabug': ('https://jira.percona.com/browse/%s', ''),
-'lpbug': ('https://bugs.launchpad.net/percona-toolkit/+bug/%s', '#')}
+extlinks = {'jirabug': ('https://jira.percona.com/browse/%s', '%s'),
+'lpbug': ('https://bugs.launchpad.net/percona-toolkit/+bug/%s', '#%s')}
 # -- Options for HTML output ---------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for


### PR DESCRIPTION
- Updated deprecated format in extlinks.

./util/write-user-docs fails with sphinx-build 7.2.6. This happens due to https://github.com/sphinx-doc/sphinx/issues/11094#issuecomment-1372994091 This PR updates deprecated syntax for extlinks.

- [ ] The contributed code is licensed under GPL v2.0
- [ ] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documentation updated
- [ ] Test suite update
