### PR TITLE
build Go tools from top Makefile

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,20 +1,38 @@
 use ExtUtils::MakeMaker;
+use ExtUtils::MY;
+
+sub MY::postamble {
+    return <<'MAKE_GOTOOLS';
+gotools:
+	cd src/go && $(MAKE) build
+
+MAKE_GOTOOLS
+}
 
 WriteMakefile(
     NAME      => 'Percona::Toolkit',
     VERSION   => '3.5.5',
-    EXE_FILES => [ <bin/*> ],
+    EXE_FILES => [
+      map {
+         (my $name = $_) =~ s/^bin.//;
+         my $file_name = $_;
+         if ( ( $file_name !~ m/mongo/ ) || ( $file_name !~ m/pg/ ) || ( $file_name !~ m/pt-stalk/ )  || ( $file_name !~ m/pt-k8s/ )  ) {
+	     $_;
+         }
+      } <bin/*>
+    ],
     MAN1PODS  => {
       'docs/percona-toolkit.pod' => 'blib/man1/percona-toolkit.1p',
       map {
          (my $name = $_) =~ s/^bin.//;
          my $file_name = $_;
-         if ( ( $file_name !~ m/mongo/ ) || ( $file_name !~ m/pg/ ) || ( $file_name !~ m/pt-stalk/ ) ) {
+         if ( ( $file_name !~ m/mongo/ ) || ( $file_name !~ m/pg/ ) || ( $file_name !~ m/pt-stalk/ )  || ( $file_name !~ m/pt-k8s/ )  ) {
              $_ => "blib/man1/$name.1p";
          }
       } <bin/*>
     },
     MAN3PODS     => {}, # man(3) pages are for C libs
+    depend => {manifypods => gotools},
     PREREQ_PM    => {
         DBI           => 1.46,
         DBD::mysql    => 3.0000_0,

--- a/src/go/Makefile
+++ b/src/go/Makefile
@@ -151,6 +151,12 @@ darwin-arm64:               ## Build Go tools for darwin-arm64 (MacOS)
 	@$(foreach pkg,$(pkgs),rm -f ${BIN_DIR}/$(pkg) 2> /dev/null;)
 	@$(foreach pkg,$(pkgs),GOOS=darwin GOARCH=arm64 go build -ldflags ${LDFLAGS} -o ${BIN_DIR}/$(pkg) ./$(pkg);)
 
+build:
+	@echo "Building binaries in ${BIN_DIR} as version ${VERSION}"
+	@cd ${TOP_DIR} && go get ./...
+	@$(foreach pkg,$(pkgs),rm -f ${BIN_DIR}/$(pkg) 2> /dev/null;)
+	@$(foreach pkg,$(pkgs),go build -ldflags ${LDFLAGS} -o ${BIN_DIR}/$(pkg) ./$(pkg);)
+
 style:						## Check code style
 	@echo ">> checking code style"
 	@! gofmt -d $(shell find . -path ./vendor -prune -o -name '*.go' -print) | grep '^'


### PR DESCRIPTION
Automatically build tools written in Go (from src/go) when running `make` on top-level.

- [X] The contributed code is licensed under GPL v2.0
- [X] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documentation updated
- [ ] Test suite update
