### PR TITLE
PT-2277 - fix pt-visual-explain for 'Impossible ON condition' case

### DIFF
--- a/bin/pt-visual-explain
+++ b/bin/pt-visual-explain
@@ -330,7 +330,7 @@ sub transform {
    # Dispatch to a class method to generate the tree.
    # ##################################################################
    my $no_matching_row = join('|',
-      "Impossible (?:WHERE|HAVING)(?: noticed after reading const tables)?",
+      "Impossible (?:WHERE|HAVING|ON)(?: noticed after reading const tables| condition)?",
       'No matching.*row',
       '(?:unique|const) row not found',
    );
@@ -499,6 +499,13 @@ sub ref_or_null {
 
 sub const {
    my ( $self, $row ) = @_;
+   if ( !$row->{key} ) {
+      return {
+         type => 'Constant table access',
+         rows => $row->{rows},
+         children => [$self->table($row)]
+      }
+   }
    return $self->index_access($row, 'Constant index lookup');
 }
 

--- a/t/pt-visual-explain/explain-to-tree.t
+++ b/t/pt-visual-explain/explain-to-tree.t
@@ -9,7 +9,7 @@ BEGIN {
 use strict;
 use warnings FATAL => 'all';
 use English qw(-no_match_vars);
-use Test::More tests => 60;
+use Test::More tests => 61;
 
 use PerconaTest;
 require "$trunk/bin/pt-visual-explain";
@@ -70,6 +70,45 @@ is_deeply(
       warning => 'Impossible HAVING',
    },
    'Impossible HAVING',
+);
+
+$t = $e->parse( load_file("t/pt-visual-explain/samples/impossible_on_condition.sql") );
+is_deeply(
+   $t,
+   {  type     => 'JOIN',
+      children => [
+         {  type     => 'Constant table access',
+            id       => 1,
+            rowid    => 0,
+            rows     => undef,
+            warning  => 'Impossible ON condition',
+            children => [
+               {  type           => 'Table',
+                  table          => 't',
+                  possible_keys  => 't_id',
+                  partitions     => undef
+               }
+            ]
+         },
+         {  type     => 'Filter with WHERE',
+            id       => 1,
+            rowid    => 1,
+            children => [
+               {  type     => 'Table scan',
+                  rows     => 1,
+                  children => [
+                     {  type           => 'Table',
+                        table          => 't2',
+                        possible_keys  => undef,
+                        partitions     => undef
+                     }
+                  ]
+               }
+            ]
+         }
+      ]
+   },
+   "Impossible ON condition"
 );
 
 $t = $e->parse( load_file("t/pt-visual-explain/samples/const_row_not_found.sql") );

--- a/t/pt-visual-explain/samples/impossible_on_condition.sql
+++ b/t/pt-visual-explain/samples/impossible_on_condition.sql
@@ -1,0 +1,7 @@
+explain select * from t2 LEFT JOIN t on t2.id = t.id AND 1 = 0 WHERE t2.id = 1;
++------+-------------+-------+-------+---------------+------+---------+------+------+-------------------------+
+| id   | select_type | table | type  | possible_keys | key  | key_len | ref  | rows | Extra                   |
++------+-------------+-------+-------+---------------+------+---------+------+------+-------------------------+
+|    1 | SIMPLE      | t     | const | t_id          | NULL | NULL    | NULL | 0    | Impossible ON condition |
+|    1 | SIMPLE      | t2    | ALL   | NULL          | NULL | NULL    | NULL | 1    | Using where             |
++------+-------------+-------+-------+---------------+------+---------+------+------+-------------------------+


### PR DESCRIPTION
Currently The "Impossible ON condition" explain row (row with `const` as type and `NULL` as key) breaks `pt-visual-explain`, as described in [PT-2277](https://jira.percona.com/browse/PT-2277), this PR is for fixing this.

@gordan-bobic

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documentation updated
- [x] Test suite update
