### PR TITLE
Configure pt-archiver to archive the last row of a table

### DIFF
--- a/bin/pt-archiver
+++ b/bin/pt-archiver
@@ -6260,7 +6260,7 @@ sub main {
 
    # Remove sentinel file.
    if ( $o->get('unstop') ) {
-      unlink $sentinel 
+      unlink $sentinel
          or die "Cannot unlink sentinel file ${sentinel}: $OS_ERROR\n";
       print STDOUT "Successfully removed file $sentinel\n"
          unless $quiet;
@@ -6613,7 +6613,7 @@ sub main {
    ) {
       my $col = $q->quote($sel_stmt->{scols}->[0]);
       my ($val) = $dbh->selectrow_array("SELECT MAX($col) FROM $src->{db_tbl}");
-      $first_sql .= " AND ($col < " . $q->quote_val($val) . ")";
+      $first_sql .= " AND ($col <= " . $q->quote_val($val) . ")";
    }
 
    $next_sql = $first_sql;


### PR DESCRIPTION
 - Now pt-archiver can archive all but one row from a table. With this small fix it is able to archive all data from a table

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [x] Documentation updated
- [ ] Test suite update
