### PR TITLE
Fix sphinx error that crashes the docs build

### DIFF
--- a/requirements-docbuild.txt
+++ b/requirements-docbuild.txt
@@ -1,4 +1,4 @@
-Sphinx==4.2.0
+Sphinx==5.0
 sphinx-copybutton
 sphinx-gitstamp
 sphinx-material


### PR DESCRIPTION
modified:   requirements-docbuild.txt

Fixing the following error that crashes the docs build:

Running Sphinx v4.2.0
Jan 15 09:08:08 AM
Jan 15 09:08:08 AMSphinx version error:
Jan 15 09:08:08 AMThe sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.

- [ ] The contributed code is licensed under GPL v2.0
- [ ] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [x] Documentation updated
- [ ] Test suite update
