### PR TITLE
PT-2307 include last inactive check mesages on pt-galera-log-explainer

### DIFF
--- a/src/go/pt-galera-log-explainer/regex/views.go
+++ b/src/go/pt-galera-log-explainer/regex/views.go
@@ -117,6 +117,15 @@ var ViewsMap = types.RegexMap{
 		},
 	},
 
+	"RegexLastInactiveCheck": &types.LogRegex{
+		Regex:         regexp.MustCompile("last inactive check more than"),
+		InternalRegex: regexp.MustCompile("last inactive check more than PT(?P<configuredValue>.*)S (\\(3\\*evs.inactive_check_period\\) )?ago \\(PT(?P<inactiveTime>.*)S\\),"),
+		Handler: func(submatches map[string]string, logCtx types.LogCtx, log string, date time.Time) (types.LogCtx, types.LogDisplayer) {
+
+			return logCtx, types.SimpleDisplayer(utils.Paint(utils.YellowText, "inactive check more than "+submatches["configuredValue"]+"s ("+submatches["inactiveTime"]+"s)"))
+		},
+	},
+
 	"RegexWsrepUnsafeBootstrap": &types.LogRegex{
 		Regex: regexp.MustCompile("ERROR.*not be safe to bootstrap"),
 		Handler: func(submatches map[string]string, logCtx types.LogCtx, log string, date time.Time) (types.LogCtx, types.LogDisplayer) {

--- a/src/go/pt-galera-log-explainer/regex/views_test.go
+++ b/src/go/pt-galera-log-explainer/regex/views_test.go
@@ -192,6 +192,18 @@ func TestViewsRegex(t *testing.T) {
 		},
 
 		{
+			log:         "2001-01-01T01:01:01.000000Z [Warning] WSREP: last inactive check more than PT1.5S (3*evs.inactive_check_period) ago (PT4.51947S), skipping check",
+			expectedOut: "inactive check more than 1.5s (4.51947s)",
+			key:         "RegexLastInactiveCheck",
+		},
+		{
+			name:        "mariadb variation",
+			log:         "2001-01-01T01:01:01.000000Z [Warning] WSREP: last inactive check more than PT1.5S ago (PT4.51947S), skipping check",
+			expectedOut: "inactive check more than 1.5s (4.51947s)",
+			key:         "RegexLastInactiveCheck",
+		},
+
+		{
 			log:         "2001-01-01  5:06:12 47285568576576 [Note] WSREP: gcomm: bootstrapping new group 'cluster'",
 			expectedOut: "bootstrapping",
 			key:         "RegexBootstrap",

--- a/src/go/pt-galera-log-explainer/tests/expected/operator_ambiguous_ips_list_all_no_color
+++ b/src/go/pt-galera-log-explainer/tests/expected/operator_ambiguous_ips_list_all_no_color
@@ -504,6 +504,7 @@ mysql version                 8.0.31                                        8.0.
 2023-05-16T07:51:58.379294Z   |                                             recovering gcache                             |                                             
 2023-05-16T07:52:26.431252Z   |                                             CLOSED -> OPEN                                |                                             
 2023-05-16T07:52:26.431427Z   |                                             NON-PRIMARY(n=1)                              |                                             
+2023-05-16T07:52:26.931116Z   |                                             inactive check more than 1.5s (3.50171s)      |                                             
 2023-05-16T10:03:18.655740Z   starting(8.0.31)                              |                                             |                                             
 2023-05-16T10:03:18.658268Z   started(cluster)                              |                                             |                                             
 2023-05-16T10:03:18.659239Z   no grastate.dat file                          |                                             |                                             


### PR DESCRIPTION
- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] Test suite update
