### PR TITLE
pt-galera-log-explainer: improvments from feedbacks

### DIFF
--- a/docs/pt-galera-log-explainer.rst
+++ b/docs/pt-galera-log-explainer.rst
@@ -134,15 +134,15 @@ Available flags
     It is useful when logs are very sparse and already organized by nodes.
 
 ``--skip-merge``
-    Disable the ability to merge log files together. Can be used when every nodes have the same wsrep_node_name
+    Disable the ability to merge log files together. Can be used when every nodes have the same ``wsrep_node_name``
 
 ``-v``, ``--verbosity``        
     ``-v``: display in the timeline every mysql info the tool used
     ``-vv``: internal tool debug
 
 ``--pxc-operator``       
-    Analyze logs from Percona PXC operator. Operator logs should be automatically detected (see --skip-operator-detection).
-    It will prevent logs from being merged together, add operator specific regexes, and fine-tune regexes for logs taken from pt-k8s-debug-collector
+    Analyze logs from Percona PXC operator. Operator logs should be automatically detected (see ``--skip-operator-detection``).
+    It will prevent logs from being merged together, add operator specific regexes, and fine-tune regexes for logs taken from ``pt-k8s-debug-collector``.
     Off by default because it negatively impacts performance for non-k8s setups.
 
 ``--skip-operator-detection``

--- a/docs/pt-galera-log-explainer.rst
+++ b/docs/pt-galera-log-explainer.rst
@@ -133,14 +133,21 @@ Available flags
     Instead of relying on extracted information, logs will be merged by their base directory 
     It is useful when logs are very sparse and already organized by nodes.
 
+``--skip-merge``
+    Disable the ability to merge log files together. Can be used when every nodes have the same wsrep_node_name
+
 ``-v``, ``--verbosity``        
     ``-v``: display in the timeline every mysql info the tool used
     ``-vv``: internal tool debug
 
 ``--pxc-operator``       
-    Analyze logs from Percona PXC operator. 
+    Analyze logs from Percona PXC operator. Operator logs should be automatically detected (see --skip-operator-detection).
     It will prevent logs from being merged together, add operator specific regexes, and fine-tune regexes for logs taken from pt-k8s-debug-collector
     Off by default because it negatively impacts performance for non-k8s setups.
+
+``--skip-operator-detection``
+    Disable automatic detection of PXC operator logs. When detected, a message will be shown.
+    Detection is done using a prefix regex.
 
 ``--exclude-regexes``
     Remove regexes from analysis. Use 'pt-galera-log-explainer regex-list | jq .' to have the list
@@ -229,5 +236,4 @@ Known issues
   This is mainly when the log file does not contain enough information.
 * Some information will seems missed. Depending on the case, it may be simply unimplemented yet, or it was disabled later because it was found to be unreliable (node index numbers are not reliable for example)
 * Columns width are sometimes too large to be easily readable. This usually happens when printing SST events with long node names
-* Using ``list`` on PXC operator logs can silently lead to broken results, ``--pxc-operator`` should be used
 * When some display corner-cases seems broken (events not deduplicated, ...), it is because of extra hidden internal events.

--- a/src/go/pt-galera-log-explainer/README.rst
+++ b/src/go/pt-galera-log-explainer/README.rst
@@ -133,14 +133,21 @@ Available flags
     Instead of relying on extracted information, logs will be merged by their base directory 
     It is useful when logs are very sparse and already organized by nodes.
 
+``--skip-merge``
+    Disable the ability to merge log files together. Can be used when every nodes have the same ``wsrep_node_name``
+
 ``-v``, ``--verbosity``        
     ``-v``: display in the timeline every mysql info the tool used
     ``-vv``: internal tool debug
 
 ``--pxc-operator``       
-    Analyze logs from Percona PXC operator. 
-    It will prevent logs from being merged together, add operator specific regexes, and fine-tune regexes for logs taken from pt-k8s-debug-collector
+    Analyze logs from Percona PXC operator. Operator logs should be automatically detected (see ``--skip-operator-detection``).
+    It will prevent logs from being merged together, add operator specific regexes, and fine-tune regexes for logs taken from ``pt-k8s-debug-collector``.
     Off by default because it negatively impacts performance for non-k8s setups.
+
+``--skip-operator-detection``
+    Disable automatic detection of PXC operator logs. When detected, a message will be shown.
+    Detection is done using a prefix regex.
 
 ``--exclude-regexes``
     Remove regexes from analysis. Use 'pt-galera-log-explainer regex-list | jq .' to have the list
@@ -229,5 +236,4 @@ Known issues
   This is mainly when the log file does not contain enough information.
 * Some information will seems missed. Depending on the case, it may be simply unimplemented yet, or it was disabled later because it was found to be unreliable (node index numbers are not reliable for example)
 * Columns width are sometimes too large to be easily readable. This usually happens when printing SST events with long node names
-* Using ``list`` on PXC operator logs can silently lead to broken results, ``--pxc-operator`` should be used
 * When some display corner-cases seems broken (events not deduplicated, ...), it is because of extra hidden internal events.

--- a/src/go/pt-galera-log-explainer/detect_operator.go
+++ b/src/go/pt-galera-log-explainer/detect_operator.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"os/exec"
+
+	"github.com/percona/percona-toolkit/src/go/pt-galera-log-explainer/types"
+	"github.com/rs/zerolog/log"
+)
+
+// areOperatorFiles will assume every files are from k8s if one is found
+func areOperatorFiles(paths []string) bool {
+
+	for _, path := range paths {
+
+		cmd := exec.Command(CLI.GrepCmd, "-q", "-a", "-m", "1", "^"+types.OperatorLogPrefix, path)
+		err := cmd.Run()
+		if err == nil {
+			return true
+		}
+		log.Debug().Err(err).Str("path", path).Msg("operator detection result")
+	}
+	return false
+}

--- a/src/go/pt-galera-log-explainer/internal.go
+++ b/src/go/pt-galera-log-explainer/internal.go
@@ -95,7 +95,7 @@ func prepareGrepArgument(regexes types.RegexMap) string {
 		// I'm not adding pxcoperator map the same way others are used, because they do not have the same formats and same place
 		// it needs to be put on the front so that it's not 'merged' with the '{"log":"' json prefix
 		// this is to keep things as close as '^' as possible to keep doing prefix searches
-		grepRegex += "((" + strings.Join(regex.PXCOperatorMap.Compile(), "|") + ")|^{\"log\":\""
+		grepRegex += "((" + strings.Join(regex.PXCOperatorMap.Compile(), "|") + ")|^" + types.OperatorLogPrefix
 		regexes.Merge(regex.PXCOperatorMap)
 	}
 	if CLI.Since != nil {

--- a/src/go/pt-galera-log-explainer/internal.go
+++ b/src/go/pt-galera-log-explainer/internal.go
@@ -12,13 +12,14 @@ import (
 	"github.com/percona/percona-toolkit/src/go/pt-galera-log-explainer/types"
 	"github.com/percona/percona-toolkit/src/go/pt-galera-log-explainer/utils"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
-var logger = log.With().Str("component", "extractor").Logger()
+var logger zerolog.Logger
 
-func init() {
-
+func initComponentLogger() {
+	logger = log.With().Str("component", "extractor").Logger()
 	if CLI.Since != nil {
 		logger = logger.With().Time("since", *CLI.Since).Logger()
 	}

--- a/src/go/pt-galera-log-explainer/internal.go
+++ b/src/go/pt-galera-log-explainer/internal.go
@@ -69,7 +69,7 @@ func timelineFromPaths(paths []string, regexes types.RegexMap) (types.Timeline, 
 		// Why it should not just identify using the file path:
 		// so that we are able to merge files that belong to the same nodes
 		// we wouldn't want them to be shown as from different nodes
-		if CLI.PxcOperator {
+		if CLI.PxcOperator || CLI.SkipMerge {
 			timeline[path] = localTimeline
 		} else if CLI.MergeByDirectory {
 			timeline.MergeByDirectory(path, localTimeline)
@@ -129,7 +129,7 @@ func execGrepAndIterate(path, compiledRegex string, stdout chan<- string) error 
 		logger.Warn().Msg("On Darwin systems, use 'pt-galera-log-explainer --grep-cmd=ggrep' as it requires grep v3")
 	}
 
-	cmd := exec.Command(CLI.GrepCmd, "-P", compiledRegex, path)
+	cmd := exec.Command(CLI.GrepCmd, "-a", "-P", compiledRegex, path)
 
 	out, err := cmd.StdoutPipe()
 	if err != nil {

--- a/src/go/pt-galera-log-explainer/internal.go
+++ b/src/go/pt-galera-log-explainer/internal.go
@@ -69,8 +69,10 @@ func timelineFromPaths(paths []string, regexes types.RegexMap) (types.Timeline, 
 		// Why it should not just identify using the file path:
 		// so that we are able to merge files that belong to the same nodes
 		// we wouldn't want them to be shown as from different nodes
-		if CLI.PxcOperator || CLI.SkipMerge {
+		if CLI.SkipMerge {
 			timeline[path] = localTimeline
+		} else if CLI.PxcOperator {
+			timeline.MergeByPodnameElsePath(path, localTimeline)
 		} else if CLI.MergeByDirectory {
 			timeline.MergeByDirectory(path, localTimeline)
 		} else {

--- a/src/go/pt-galera-log-explainer/main.go
+++ b/src/go/pt-galera-log-explainer/main.go
@@ -35,9 +35,10 @@ var CLI struct {
 	PxcOperator      bool            `default:"false" help:"Analyze logs from Percona PXC operator. Off by default because it negatively impacts performance for non-k8s setups"`
 	ExcludeRegexes   []string        `help:"Remove regexes from analysis. List regexes using 'pt-galera-log-explainer regex-list'"`
 	MergeByDirectory bool            `help:"Instead of relying on identification, merge contexts and columns by base directory. Very useful when dealing with many small logs organized per directories."`
+	SkipMerge        bool            `help:"Disable the ability to merge log files together. Can be used when every nodes have the same wsrep_node_name"`
 
 	List list `cmd:""`
-	//Whois     whois     `cmd:""`
+	//Whois whois `cmd:""`
 	//	Sed       sed       `cmd:""`
 	Ctx       ctx       `cmd:""`
 	RegexList regexList `cmd:""`

--- a/src/go/pt-galera-log-explainer/main.go
+++ b/src/go/pt-galera-log-explainer/main.go
@@ -62,6 +62,7 @@ func main() {
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	log.Logger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr, NoColor: CLI.NoColor, FormatTimestamp: func(_ interface{}) string { return "" }})
+	initComponentLogger()
 	if CLI.Verbosity == types.Debug {
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	}

--- a/src/go/pt-galera-log-explainer/main.go
+++ b/src/go/pt-galera-log-explainer/main.go
@@ -70,20 +70,14 @@ func main() {
 
 	utils.SkipColor = CLI.NoColor
 
-	var paths []string
-	switch kongcli.Command() {
-	case "list <paths>":
-		paths = CLI.List.Paths
-	case "ctx <paths>":
-		paths = CLI.Ctx.Paths
-	case "conflicts <paths>":
-		paths = CLI.Conflicts.Paths
-	}
-
-	if !CLI.PxcOperator && !CLI.SkipOperatorDetection && areOperatorFiles(paths) {
-		CLI.PxcOperator = true
-		log.Info().Msg("Detected logs coming from Percona XtraDB Cluster Operator, enabling --pxc-operator")
-
+	for _, path := range kongcli.Path {
+		if path.Positional != nil && path.Positional.Name == "paths" {
+			paths, ok := path.Positional.Target.Interface().([]string)
+			if ok && !CLI.PxcOperator && !CLI.SkipOperatorDetection && areOperatorFiles(paths) {
+				CLI.PxcOperator = true
+				log.Info().Msg("Detected logs coming from Percona XtraDB Cluster Operator, enabling --pxc-operator")
+			}
+		}
 	}
 
 	translate.AssumeIPStable = !CLI.PxcOperator

--- a/src/go/pt-galera-log-explainer/main_test.go
+++ b/src/go/pt-galera-log-explainer/main_test.go
@@ -105,6 +105,12 @@ func TestMain(t *testing.T) {
 		},
 
 		{
+			name: "operator_auto_ambiguous_ips_list_all_no_color",
+			cmd:  []string{"list", "--all", "--no-color"},
+			path: "tests/logs/operator_ambiguous_ips/*",
+		},
+
+		{
 			name: "conflict_conflicts",
 			cmd:  []string{"conflicts"},
 			path: "tests/logs/conflict/*",

--- a/src/go/pt-galera-log-explainer/main_test.go
+++ b/src/go/pt-galera-log-explainer/main_test.go
@@ -99,6 +99,12 @@ func TestMain(t *testing.T) {
 		},
 
 		{
+			name: "operator_split_list_all_no_color",
+			cmd:  []string{"list", "--all", "--pxc-operator", "--no-color"},
+			path: "tests/logs/operator_split/*",
+		},
+
+		{
 			name: "conflict_conflicts",
 			cmd:  []string{"conflicts"},
 			path: "tests/logs/conflict/*",

--- a/src/go/pt-galera-log-explainer/regex/date.go
+++ b/src/go/pt-galera-log-explainer/regex/date.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/percona/percona-toolkit/src/go/pt-galera-log-explainer/types"
 	"github.com/percona/percona-toolkit/src/go/pt-galera-log-explainer/utils"
 	"github.com/rs/zerolog/log"
 )
@@ -93,11 +94,9 @@ func NoDatesRegex(skipLeadingCircumflex bool) string {
 	return "^(?![0-9]{4})"
 }
 
-const k8sprefix = `{"log":"`
-
 func SearchDateFromLog(logline string) (time.Time, string, bool) {
-	if logline[:len(k8sprefix)] == k8sprefix {
-		logline = logline[len(k8sprefix):]
+	if logline[:len(types.OperatorLogPrefix)] == types.OperatorLogPrefix {
+		logline = logline[len(types.OperatorLogPrefix):]
 	}
 	for _, layout := range DateLayouts {
 		if len(logline) < len(layout) {

--- a/src/go/pt-galera-log-explainer/regex/operator.go
+++ b/src/go/pt-galera-log-explainer/regex/operator.go
@@ -50,7 +50,7 @@ var PXCOperatorMap = types.RegexMap{
 	"RegexGcacheScan": &types.LogRegex{
 		// those "operators" regexes do not have the log prefix added implicitly. It's not strictly needed, but
 		// it will help to avoid catching random piece of log out of order
-		Regex: regexp.MustCompile(k8sprefix + ".*GCache::RingBuffer initial scan"),
+		Regex: regexp.MustCompile(types.OperatorLogPrefix + ".*GCache::RingBuffer initial scan"),
 		Handler: func(submatches map[string]string, logCtx types.LogCtx, log string, date time.Time) (types.LogCtx, types.LogDisplayer) {
 			return logCtx, types.SimpleDisplayer("recovering gcache")
 		},

--- a/src/go/pt-galera-log-explainer/regex/operator.go
+++ b/src/go/pt-galera-log-explainer/regex/operator.go
@@ -1,6 +1,7 @@
 package regex
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -43,8 +44,9 @@ var PXCOperatorMap = types.RegexMap{
 	},
 
 	// Why is it not in regular "views" regexes:
-	// it could have been useful as an "verbosity=types.Detailed" regexes, very rarely
-	// but in context of operators, it is actually a very important information
+	// it would have been useful very rarely for on-premise setups but in context of operators,
+	// it is actually an important info because gcache recovery can provoke out of memories due to
+	// filecache counting against memory usage
 	"RegexGcacheScan": &types.LogRegex{
 		// those "operators" regexes do not have the log prefix added implicitly. It's not strictly needed, but
 		// it will help to avoid catching random piece of log out of order
@@ -82,6 +84,22 @@ var PXCOperatorMap = types.RegexMap{
 				msg += displayer(logCtx) + "; "
 			}
 			return logCtx, types.SimpleDisplayer(msg)
+		},
+		Verbosity: types.DebugMySQL,
+	},
+
+	"RegexPodName": &types.LogRegex{
+		Regex:         regexp.MustCompile("^wsrep_node_incoming_address="),
+		InternalRegex: regexp.MustCompile("^wsrep_node_incoming_address=(?P<podname>[a-zA-Z0-9-]*)\\.(?P<deployment>[a-zA-Z0-9-]*)\\.(?P<namespace>[a-zA-Z0-9-]*)\\."),
+		Handler: func(submatches map[string]string, logCtx types.LogCtx, log string, date time.Time) (types.LogCtx, types.LogDisplayer) {
+
+			logCtx.OperatorMetadata = &types.OperatorMetadata{
+				PodName:    submatches["podname"],
+				Deployment: submatches["deployment"],
+				Namespace:  submatches["namespace"],
+			}
+
+			return logCtx, types.SimpleDisplayer(fmt.Sprintf("podname: %s, dep: %s, namespace: %s", submatches["podname"], submatches["deployment"], submatches["namespace"]))
 		},
 		Verbosity: types.DebugMySQL,
 	},

--- a/src/go/pt-galera-log-explainer/regex/operator_test.go
+++ b/src/go/pt-galera-log-explainer/regex/operator_test.go
@@ -56,6 +56,21 @@ func TestPXCOperatorRegex(t *testing.T) {
 			expectedOut: "recovering gcache",
 			key:         "RegexGcacheScan",
 		},
+
+		{
+			log: "wsrep_node_incoming_address=cluster1-0.cluster1.pxc.svc.cluster.local:3306",
+			expected: regexTestState{
+				LogCtx: types.LogCtx{
+					OperatorMetadata: &types.OperatorMetadata{
+						PodName:    "cluster1-0",
+						Deployment: "cluster1",
+						Namespace:  "pxc",
+					},
+				},
+			},
+			expectedOut: "podname: cluster1-0, dep: cluster1, namespace: pxc",
+			key:         "RegexPodName",
+		},
 	}
 
 	iterateRegexTest(t, PXCOperatorMap, tests)

--- a/src/go/pt-galera-log-explainer/tests/expected/operator_ambiguous_ips_list_all_no_color
+++ b/src/go/pt-galera-log-explainer/tests/expected/operator_ambiguous_ips_list_all_no_color
@@ -1,4 +1,4 @@
-identifier                    tests/logs/operator_ambiguous_ips/node1.log   tests/logs/operator_ambiguous_ips/node2.log   tests/logs/operator_ambiguous_ips/node3.log   
+identifier                    cluster1-0                                    cluster1-1                                    cluster1-2                                    
 current path                  tests/logs/operator_ambiguous_ips/node1.log   tests/logs/operator_ambiguous_ips/node2.log   tests/logs/operator_ambiguous_ips/node3.log   
 last known ip                 10.16.29.34                                   10.16.27.98                                   10.16.28.213                                  
 last known name               cluster1-0                                    cluster1-1                                    cluster1-2                                    
@@ -2323,7 +2323,7 @@ mysql version                 8.0.31                                        8.0.
 2023-05-29T08:45:21.454564Z   |                                             |                                             garb left                                     
 2023-05-29T08:45:21.454608Z   |                                             |                                             PRIMARY(n=3)                                  
                                                                                                                                                                         
-identifier                    tests/logs/operator_ambiguous_ips/node1.log   tests/logs/operator_ambiguous_ips/node2.log   tests/logs/operator_ambiguous_ips/node3.log   
+identifier                    cluster1-0                                    cluster1-1                                    cluster1-2                                    
 current path                  tests/logs/operator_ambiguous_ips/node1.log   tests/logs/operator_ambiguous_ips/node2.log   tests/logs/operator_ambiguous_ips/node3.log   
 last known ip                 10.16.29.34                                   10.16.27.98                                   10.16.28.213                                  
 last known name               cluster1-0                                    cluster1-1                                    cluster1-2                                    

--- a/src/go/pt-galera-log-explainer/tests/expected/operator_auto_ambiguous_ips_list_all_no_color
+++ b/src/go/pt-galera-log-explainer/tests/expected/operator_auto_ambiguous_ips_list_all_no_color
@@ -1,0 +1,2331 @@
+INF Detected logs coming from Percona XtraDB Cluster Operator, enabling --pxc-operator
+identifier                    cluster1-0                                    cluster1-1                                    cluster1-2                                    
+current path                  tests/logs/operator_ambiguous_ips/node1.log   tests/logs/operator_ambiguous_ips/node2.log   tests/logs/operator_ambiguous_ips/node3.log   
+last known ip                 10.16.29.34                                   10.16.27.98                                   10.16.28.213                                  
+last known name               cluster1-0                                    cluster1-1                                    cluster1-2                                    
+mysql version                 8.0.31                                        8.0.31                                        8.0.31                                        
+                                                                                                                                                                        
+2023-05-10T09:06:21.282700Z   |                                             starting(8.0.31)                              |                                             
+2023-05-10T09:06:21.286713Z   |                                             started(cluster)                              |                                             
+2023-05-10T09:06:21.287690Z   |                                             no grastate.dat file                          |                                             
+2023-05-10T09:06:21.287698Z   |                                             bootstrapping(empty grastate)                 |                                             
+2023-05-10T09:06:21.287729Z   |                                             safe_to_bootstrap: 1                          |                                             
+                                                                            10.16.27.98                                                                                 
+                                                                            (node ip)                                                                                   
+                                                                             V                                                                                          
+                                                                            10.16.27.195                                                                                
+2023-05-10T09:06:21.805629Z   |                                             cluster1-0 joined                             |                                             
+2023-05-10T09:06:22.304843Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-10T09:06:22.305137Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-10T09:06:22.306346Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-10T09:06:22.908357Z   |                                             will receive SST                              |                                             
+2023-05-10T09:06:22.909183Z   |                                             cluster1-0 will resync local node             |                                             
+2023-05-10T09:06:22.909264Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-10T09:06:23.728522Z   |                                             receiving SST                                 |                                             
+2023-05-10T09:41:07.257241Z   |                                             cluster1-0 failed to sync cluster1-1          |                                             
+2023-05-10T09:41:07.257343Z   |                                             will never receive SST, aborting              |                                             
+2023-05-10T09:41:08.259656Z   |                                             terminated                                    |                                             
+2023-05-10T09:41:08.259664Z   |                                             former SST cancelled                          |                                             
+2023-05-10T09:41:08Z          |                                             crash: got signal 11                          |                                             
+2023-05-10T09:41:48.083981Z   |                                             starting(8.0.31)                              |                                             
+2023-05-10T09:41:48.086499Z   |                                             started(cluster)                              |                                             
+2023-05-10T09:41:48.087403Z   |                                             safe_to_bootstrap: 1                          |                                             
+2023-05-10T09:41:48.087529Z   |                                             recovering gcache                             |                                             
+2023-05-10T09:41:57.935555Z   |                                             recovering gcache                             |                                             
+2023-05-10T09:42:20.265286Z   |                                             cluster1-0 joined                             |                                             
+2023-05-10T09:42:20.592086Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-10T09:42:20.592348Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-10T09:42:20.594549Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-10T09:42:21.259393Z   |                                             will receive SST                              |                                             
+2023-05-10T09:42:21.260025Z   |                                             cluster1-0 will resync local node             |                                             
+2023-05-10T09:42:21.260093Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-10T09:42:22.066358Z   |                                             receiving SST                                 |                                             
+2023-05-10T10:12:45.191674Z   |                                             10.16.26.202 joined                           |                                             
+2023-05-10T10:12:45.191779Z   |                                             cluster1-0 joined                             |                                             
+2023-05-10T10:12:45.193317Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-10T10:12:46.370533Z   |                                             cluster1-2 cannot find donor                  |                                             
+2023-05-10T10:12:47.371783Z   |                                             cluster1-2 cannot find donor                  |                                             
+2023-05-10T10:12:48.373115Z   |                                             (repeated x85)cluster1-2 cannot find donor    |                                             
+2023-05-10T10:14:14.479756Z   |                                             cluster1-2 cannot find donor                  |                                             
+2023-05-10T10:14:14.784317Z   |                                             SST error                                     |                                             
+2023-05-10T10:14:14.786328Z   |                                             NON-PRIMARY(n=1)                              |                                             
+2023-05-10T10:14:14.786496Z   |                                             JOINER -> OPEN                                |                                             
+2023-05-10T10:14:14.786591Z   |                                             OPEN -> CLOSED                                |                                             
+2023-05-10T10:14:14.786750Z   |                                             terminated                                    |                                             
+2023-05-10T10:14:14.786767Z   |                                             former SST cancelled                          |                                             
+2023-05-10T10:14:14Z          |                                             crash: got signal 11                          |                                             
+2023-05-10T10:48:43.442930Z   |                                             starting(8.0.31)                              |                                             
+2023-05-10T10:48:43.445605Z   |                                             started(cluster)                              |                                             
+2023-05-10T10:48:43.446512Z   |                                             safe_to_bootstrap: 1                          |                                             
+2023-05-10T10:48:43.446635Z   |                                             recovering gcache                             |                                             
+2023-05-10T10:48:53.296174Z   |                                             recovering gcache                             |                                             
+                                                                            10.16.27.195                                                                                
+                                                                            (node ip)                                                                                   
+                                                                             V                                                                                          
+                                                                            10.16.27.93                                                                                 
+2023-05-10T10:49:16.479739Z   |                                             10.16.26.202 joined                           |                                             
+2023-05-10T10:49:16.479769Z   |                                             cluster1-0 joined                             |                                             
+2023-05-10T10:49:16.978527Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-10T10:49:16.978767Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-10T10:49:16.980011Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-10T10:49:17.553352Z   |                                             will receive SST                              |                                             
+2023-05-10T10:49:17.554588Z   |                                             cluster1-0 will resync local node             |                                             
+2023-05-10T10:49:17.554657Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-10T10:49:18.376721Z   |                                             receiving SST                                 |                                             
+2023-05-10T11:17:13.326901Z   |                                             cluster1-0 joined                             |                                             
+2023-05-10T11:17:13.327013Z   |                                             10.16.26.202 left                             |                                             
+2023-05-10T11:17:13.329192Z   |                                             10.16.26.202 left                             |                                             
+2023-05-10T11:17:13.329351Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-10T11:21:49.944419Z   |                                             got SST from cluster1-0                       |                                             
+2023-05-10T11:25:02.889253Z   |                                             preparing SST backup                          |                                             
+2023-05-10T11:25:38.882276Z   |                                             wsrep recovery                                |                                             
+2023-05-10T11:25:38.892098Z   |                                             JOINER -> JOINED                              |                                             
+2023-05-10T11:25:38.892510Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-10T11:26:23.849947Z   |                                             cluster1-0 joined                             |                                             
+2023-05-10T11:26:23.850027Z   |                                             cluster1-2 joined                             |                                             
+2023-05-10T11:26:23.851581Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-10T11:26:25.061573Z   |                                             local node will resync cluster1-2             |                                             
+2023-05-10T11:26:25.061656Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-10T11:26:25.078648Z   |                                             IST to cluster1-2(seqno:158423)               |                                             
+2023-05-10T11:26:25.503200Z   |                                             IST will be used                              |                                             
+2023-05-10T11:26:26.522634Z   |                                             finished sending IST to cluster1-2            |                                             
+2023-05-10T11:26:26.522704Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-10T11:26:26.523402Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-10T11:38:13.551353Z   |                                             cluster1-0 joined                             |                                             
+2023-05-10T11:38:13.551487Z   |                                             cluster1-2 left                               |                                             
+2023-05-10T11:38:13.553356Z   |                                             cluster1-2 left                               |                                             
+2023-05-10T11:38:13.553425Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-10T11:38:45.653905Z   |                                             cluster1-0 joined                             |                                             
+2023-05-10T11:38:45.653982Z   |                                             cluster1-2 joined                             |                                             
+2023-05-10T11:38:45.655569Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-10T11:38:46.845794Z   |                                             local node will resync cluster1-2             |                                             
+2023-05-10T11:38:46.845896Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-10T11:38:46.858192Z   |                                             IST to cluster1-2(seqno:158425)               |                                             
+2023-05-10T11:38:47.296230Z   |                                             IST will be used                              |                                             
+2023-05-10T11:38:48.315759Z   |                                             finished sending IST to cluster1-2            |                                             
+2023-05-10T11:38:48.315831Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-10T11:38:48.316431Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-10T11:42:43.168023Z   |                                             received shutdown                             |                                             
+2023-05-10T11:42:53.170702Z   |                                             NON-PRIMARY(n=1)                              |                                             
+2023-05-10T11:42:53.170909Z   |                                             SYNCED -> OPEN                                |                                             
+2023-05-10T11:42:53.171012Z   |                                             OPEN -> CLOSED                                |                                             
+2023-05-10T11:43:00.138274Z   |                                             shutdown complete                             |                                             
+2023-05-10T11:43:19.833967Z   |                                             starting(8.0.31)                              |                                             
+2023-05-10T11:43:19.836876Z   |                                             started(cluster)                              |                                             
+2023-05-10T11:43:19.838004Z   |                                             recovering gcache                             |                                             
+2023-05-10T11:43:19.838234Z   |                                             recovering gcache                             |                                             
+                                                                            10.16.27.93                                                                                 
+                                                                            (node ip)                                                                                   
+                                                                             V                                                                                          
+                                                                            10.16.27.67                                                                                 
+2023-05-10T11:43:20.356002Z   |                                             cluster1-0 joined                             |                                             
+2023-05-10T11:43:20.356029Z   |                                             cluster1-2 joined                             |                                             
+2023-05-10T11:43:20.855036Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-10T11:43:20.855274Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-10T11:43:20.856511Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-10T11:43:21.550734Z   |                                             will receive IST(seqno:158427)                |                                             
+2023-05-10T11:43:21.551987Z   |                                             cluster1-2 will resync local node             |                                             
+2023-05-10T11:43:21.552057Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-10T11:43:23.035052Z   |                                             got IST from cluster1-2                       |                                             
+2023-05-10T11:43:28.800847Z   |                                             wsrep recovery                                |                                             
+2023-05-10T11:43:28.813599Z   |                                             IST received(seqno:158427)                    |                                             
+2023-05-10T11:43:28.814872Z   |                                             JOINER -> JOINED                              |                                             
+2023-05-10T11:43:28.815566Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-10T11:44:38.663126Z   |                                             cluster1-0 joined                             |                                             
+2023-05-10T11:44:38.663269Z   |                                             cluster1-2 left                               |                                             
+2023-05-10T11:44:38.665063Z   |                                             cluster1-2 left                               |                                             
+2023-05-10T11:44:38.665206Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-10T11:45:09.238513Z   |                                             cluster1-2 joined                             |                                             
+2023-05-10T11:45:09.238600Z   |                                             cluster1-0 joined                             |                                             
+2023-05-10T11:45:09.240227Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-10T11:45:10.423899Z   |                                             local node will resync cluster1-2             |                                             
+2023-05-10T11:45:10.423967Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-10T11:45:10.438294Z   |                                             IST to cluster1-2(seqno:158429)               |                                             
+2023-05-10T11:45:10.874534Z   |                                             IST will be used                              |                                             
+2023-05-10T11:45:11.893200Z   |                                             finished sending IST to cluster1-2            |                                             
+2023-05-10T11:45:11.893227Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-10T11:45:11.893759Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-10T11:50:01.194159Z   |                                             cluster1-0 joined                             |                                             
+2023-05-10T11:50:01.194272Z   |                                             cluster1-2 left                               |                                             
+2023-05-10T11:50:01.196426Z   |                                             cluster1-2 left                               |                                             
+2023-05-10T11:50:01.196471Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-10T11:50:33.633947Z   |                                             cluster1-0 joined                             |                                             
+2023-05-10T11:50:33.634035Z   |                                             cluster1-2 joined                             |                                             
+2023-05-10T11:50:33.635507Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-10T11:50:34.853691Z   |                                             local node will resync cluster1-2             |                                             
+2023-05-10T11:50:34.853767Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-10T11:50:34.867076Z   |                                             IST to cluster1-2(seqno:158431)               |                                             
+2023-05-10T11:50:35.286248Z   |                                             IST will be used                              |                                             
+2023-05-10T11:50:36.307974Z   |                                             finished sending IST to cluster1-2            |                                             
+2023-05-10T11:50:36.308059Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-10T11:50:36.308683Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-10T11:51:03.499185Z   |                                             cluster1-2 joined                             |                                             
+2023-05-10T11:51:03.499279Z   |                                             cluster1-0 left                               |                                             
+2023-05-10T11:51:03.500648Z   |                                             cluster1-0 left                               |                                             
+2023-05-10T11:51:03.500731Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-10T11:51:16.356400Z   |                                             received shutdown                             |                                             
+2023-05-10T11:51:27.360309Z   |                                             NON-PRIMARY(n=1)                              |                                             
+2023-05-10T11:51:27.360500Z   |                                             SYNCED -> OPEN                                |                                             
+2023-05-10T11:51:27.360599Z   |                                             OPEN -> CLOSED                                |                                             
+2023-05-10T11:51:34.025938Z   |                                             shutdown complete                             |                                             
+2023-05-10T11:51:58.584894Z   |                                             starting(8.0.31)                              |                                             
+2023-05-10T11:51:58.587873Z   |                                             started(cluster)                              |                                             
+2023-05-10T11:51:58.589002Z   |                                             recovering gcache                             |                                             
+2023-05-10T11:51:58.589835Z   |                                             recovering gcache                             |                                             
+                                                                            10.16.27.67                                                                                 
+                                                                            (node ip)                                                                                   
+                                                                             V                                                                                          
+                                                                            10.16.27.98                                                                                 
+2023-05-10T11:51:59.105411Z   |                                             cluster1-0 joined                             |                                             
+2023-05-10T11:51:59.105437Z   |                                             cluster1-2 joined                             |                                             
+2023-05-10T11:51:59.604194Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-10T11:51:59.604435Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-10T11:51:59.605624Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-10T11:52:00.261139Z   |                                             will receive IST(seqno:158435)                |                                             
+2023-05-10T11:52:00.262343Z   |                                             cluster1-2 will resync local node             |                                             
+2023-05-10T11:52:00.262369Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-10T11:52:01.769295Z   |                                             got IST from cluster1-2                       |                                             
+2023-05-10T11:52:07.506267Z   |                                             wsrep recovery                                |                                             
+2023-05-10T11:52:07.520346Z   |                                             IST received(seqno:158435)                    |                                             
+2023-05-10T11:52:07.521397Z   |                                             JOINER -> JOINED                              |                                             
+2023-05-10T11:52:07.521904Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-10T12:56:32.224392Z   |                                             cluster1-0 joined                             |                                             
+2023-05-10T12:56:32.224466Z   |                                             garb joined                                   |                                             
+2023-05-10T12:56:32.224483Z   |                                             cluster1-2 joined                             |                                             
+2023-05-10T12:56:32.225753Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-10T12:56:32.724770Z   |                                             cluster1-2 will resync garb                   |                                             
+2023-05-10T13:35:49.260734Z   |                                             cluster1-2 synced garb                        |                                             
+2023-05-10T13:35:51.219600Z   |                                             cluster1-0 joined                             |                                             
+2023-05-10T13:35:51.219621Z   |                                             cluster1-2 joined                             |                                             
+2023-05-10T13:35:51.219631Z   |                                             garb left                                     |                                             
+2023-05-10T13:35:51.222978Z   |                                             garb left                                     |                                             
+2023-05-10T13:35:51.223173Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-10T13:53:31.446329Z   |                                             cluster1-2 joined                             |                                             
+2023-05-10T13:53:31.446452Z   |                                             cluster1-0 left                               |                                             
+2023-05-10T13:53:31.447668Z   |                                             cluster1-0 left                               |                                             
+2023-05-10T13:53:31.447741Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-10T13:55:45.385943Z   |                                             cluster1-0 joined                             |                                             
+2023-05-10T13:55:45.386029Z   |                                             cluster1-2 joined                             |                                             
+2023-05-10T13:55:45.387576Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-10T13:55:46.518745Z   |                                             local node will resync cluster1-0             |                                             
+2023-05-10T13:55:46.518814Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-10T13:55:46.524750Z   |                                             IST to cluster1-0(seqno:158442)               |                                             
+2023-05-10T13:55:57.967207Z   |                                             SST to cluster1-0                             |                                             
+2023-05-10T14:29:12.924344Z   |                                             finished sending IST to cluster1-0            |                                             
+2023-05-10T14:29:12.924417Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-10T14:29:12.925049Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-11T02:00:39.127163Z   |                                             cluster1-0 joined                             |                                             
+2023-05-11T02:00:39.127261Z   |                                             garb joined                                   |                                             
+2023-05-11T02:00:39.127285Z   |                                             cluster1-2 joined                             |                                             
+2023-05-11T02:00:39.128891Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-11T02:00:39.628105Z   |                                             cluster1-2 will resync garb                   |                                             
+2023-05-11T02:46:06.517307Z   |                                             cluster1-2 synced garb                        |                                             
+2023-05-11T02:46:08.245842Z   |                                             cluster1-0 joined                             |                                             
+2023-05-11T02:46:08.245883Z   |                                             cluster1-2 joined                             |                                             
+2023-05-11T02:46:08.245906Z   |                                             garb left                                     |                                             
+2023-05-11T02:46:08.246895Z   |                                             garb left                                     |                                             
+2023-05-11T02:46:08.246963Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-12T02:00:37.685744Z   |                                             cluster1-0 joined                             |                                             
+2023-05-12T02:00:37.685839Z   |                                             garb joined                                   |                                             
+2023-05-12T02:00:37.685882Z   |                                             cluster1-2 joined                             |                                             
+2023-05-12T02:00:37.687768Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-12T02:00:38.186730Z   |                                             cluster1-2 will resync garb                   |                                             
+2023-05-12T08:55:58.040880Z   |                                             garb suspected to be down                     |                                             
+2023-05-12T08:55:59.042955Z   |                                             cluster1-0 joined                             |                                             
+2023-05-12T08:55:59.043017Z   |                                             cluster1-2 joined                             |                                             
+2023-05-12T08:55:59.044612Z   |                                             garb left                                     |                                             
+2023-05-12T08:55:59.044648Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-12T08:56:23.810378Z   |                                             cluster1-0 joined                             |                                             
+2023-05-12T08:56:23.810472Z   |                                             cluster1-2 joined                             |                                             
+2023-05-12T08:56:23.810496Z   |                                             garb joined                                   |                                             
+2023-05-12T08:56:23.811966Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-12T08:56:24.311102Z   |                                             local node will resync garb                   |                                             
+2023-05-12T08:56:24.311127Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-12T08:56:35.819395Z   |                                             SST to garb                                   |                                             
+2023-05-12T09:42:29.055858Z   |                                             finished sending SST to garb                  |                                             
+2023-05-12T09:42:29.055912Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-12T09:42:29.056654Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-12T09:42:31.373457Z   |                                             cluster1-0 joined                             |                                             
+2023-05-12T09:42:31.373480Z   |                                             cluster1-2 joined                             |                                             
+2023-05-12T09:42:31.373494Z   |                                             garb left                                     |                                             
+2023-05-12T09:42:31.374839Z   |                                             garb left                                     |                                             
+2023-05-12T09:42:31.374912Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-12T18:59:18.005493Z   |                                             received shutdown                             |                                             
+2023-05-12T19:13:56.275184Z   |                                             starting(8.0.31)                              |                                             
+2023-05-12T19:13:56.279645Z   |                                             started(cluster)                              |                                             
+2023-05-12T19:13:56.280946Z   |                                             recovering gcache                             |                                             
+2023-05-12T19:13:56.761747Z   |                                             recovering gcache                             |                                             
+2023-05-12T19:13:56.881098Z   |                                             cluster1-0 joined                             |                                             
+2023-05-12T19:13:56.881130Z   |                                             cluster1-2 joined                             |                                             
+2023-05-12T19:13:57.323577Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-12T19:13:57.323870Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-12T19:13:57.325487Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-12T19:13:57.953877Z   |                                             will receive IST(seqno:2584375)               |                                             
+2023-05-12T19:13:57.954776Z   |                                             cluster1-0 will resync local node             |                                             
+2023-05-12T19:13:57.954842Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-12T19:13:59.540001Z   |                                             got IST from cluster1-0                       |                                             
+2023-05-12T19:14:05.791982Z   |                                             wsrep recovery                                |                                             
+2023-05-12T19:14:07.444245Z   |                                             IST received(seqno:2584375)                   |                                             
+2023-05-12T19:14:07.445205Z   |                                             JOINER -> JOINED                              |                                             
+2023-05-12T19:14:07.445797Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-12T19:18:57.960770Z   |                                             received shutdown                             |                                             
+2023-05-12T19:29:33.473713Z   |                                             starting(8.0.31)                              |                                             
+2023-05-12T19:29:33.477931Z   |                                             started(cluster)                              |                                             
+2023-05-12T19:29:33.479273Z   |                                             recovering gcache                             |                                             
+2023-05-12T19:29:34.017562Z   |                                             recovering gcache                             |                                             
+2023-05-12T19:29:34.105777Z   |                                             cluster1-0 joined                             |                                             
+2023-05-12T19:29:34.105800Z   |                                             cluster1-2 joined                             |                                             
+2023-05-12T19:29:34.597464Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-12T19:29:34.597650Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-12T19:29:34.599141Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-12T19:29:35.197125Z   |                                             will receive IST(seqno:2586360)               |                                             
+2023-05-12T19:29:35.198117Z   |                                             cluster1-0 will resync local node             |                                             
+2023-05-12T19:29:35.198184Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-12T19:29:37.606722Z   |                                             got IST from cluster1-0                       |                                             
+2023-05-12T19:29:44.510160Z   |                                             wsrep recovery                                |                                             
+2023-05-12T19:29:45.181433Z   |                                             IST received(seqno:2586360)                   |                                             
+2023-05-12T19:29:45.181948Z   |                                             JOINER -> JOINED                              |                                             
+2023-05-12T19:29:45.182426Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-13T02:00:39.051996Z   |                                             garb joined                                   |                                             
+2023-05-13T02:00:39.052078Z   |                                             cluster1-0 joined                             |                                             
+2023-05-13T02:00:39.052095Z   |                                             cluster1-2 joined                             |                                             
+2023-05-13T02:00:39.053275Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-13T02:00:39.489721Z   |                                             local node will resync garb                   |                                             
+2023-05-13T02:00:39.489739Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-13T02:00:51.007793Z   |                                             SST to garb                                   |                                             
+2023-05-13T02:45:57.327463Z   |                                             finished sending SST to garb                  |                                             
+2023-05-13T02:45:57.327542Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-13T02:45:57.328249Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-13T02:45:59.525579Z   |                                             cluster1-0 joined                             |                                             
+2023-05-13T02:45:59.525600Z   |                                             cluster1-2 joined                             |                                             
+2023-05-13T02:45:59.525612Z   |                                             garb left                                     |                                             
+2023-05-13T02:45:59.526936Z   |                                             garb left                                     |                                             
+2023-05-13T02:45:59.527009Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-13T06:54:00.143632Z   |                                             cluster1-2 joined                             |                                             
+2023-05-13T06:54:00.143727Z   |                                             cluster1-0 left                               |                                             
+2023-05-13T06:54:00.144901Z   |                                             cluster1-0 left                               |                                             
+2023-05-13T06:54:00.144944Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-13T06:55:57.140277Z   |                                             (repeated x2275)too many connections          |                                             
+2023-05-13T06:56:15.493714Z   |                                             too many connections                          |                                             
+2023-05-18T14:45:40.446083Z   |                                             starting(8.0.31)(post.processing.log)         |                                             
+2023-05-18T14:45:47.537181Z   |                                             started(standalone)(post.processing.log)      |                                             
+2023-05-13T06:56:15.501414Z   |                                             (repeated x3964)too many connections          |                                             
+2023-05-13T06:56:45.240370Z   |                                             too many connections                          |                                             
+2023-05-13T06:57:31.547392Z   |                                             cluster1-0 joined                             |                                             
+2023-05-13T06:57:31.547466Z   |                                             cluster1-2 joined                             |                                             
+2023-05-13T06:57:31.548940Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-13T06:57:32.679563Z   |                                             local node will resync cluster1-0             |                                             
+2023-05-13T06:57:32.679642Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-13T06:57:32.693189Z   |                                             IST to cluster1-0(seqno:2987828)              |                                             
+2023-05-13T06:57:33.097517Z   |                                             IST will be used                              |                                             
+2023-05-13T06:57:59.222707Z   |                                             finished sending IST to cluster1-0            |                                             
+2023-05-13T06:57:59.223896Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-13T06:57:59.224286Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-14T02:00:39.346372Z   |                                             garb joined                                   |                                             
+2023-05-14T02:00:39.346464Z   |                                             cluster1-0 joined                             |                                             
+2023-05-14T02:00:39.346489Z   |                                             cluster1-2 joined                             |                                             
+2023-05-14T02:00:39.348244Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-14T02:00:39.847436Z   |                                             local node will resync garb                   |                                             
+2023-05-14T02:00:39.847459Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-14T02:00:51.320665Z   |                                             SST to garb                                   |                                             
+2023-05-14T02:45:02.456243Z   |                                             finished sending SST to garb                  |                                             
+2023-05-14T02:45:02.456314Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-14T02:45:02.457052Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-14T02:45:04.774986Z   |                                             cluster1-0 joined                             |                                             
+2023-05-14T02:45:04.775082Z   |                                             cluster1-2 joined                             |                                             
+2023-05-14T02:45:04.775109Z   |                                             garb left                                     |                                             
+2023-05-14T02:45:04.776467Z   |                                             garb left                                     |                                             
+2023-05-14T02:45:04.776542Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-15T02:00:37.325176Z   |                                             garb joined                                   |                                             
+2023-05-15T02:00:37.325301Z   |                                             cluster1-0 joined                             |                                             
+2023-05-15T02:00:37.325330Z   |                                             cluster1-2 joined                             |                                             
+2023-05-15T02:00:37.327052Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-15T02:00:37.826406Z   |                                             local node will resync garb                   |                                             
+2023-05-15T02:00:37.826427Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-15T02:00:49.304365Z   |                                             SST to garb                                   |                                             
+2023-05-15T02:43:52.459283Z   |                                             finished sending SST to garb                  |                                             
+2023-05-15T02:43:52.459313Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-15T02:43:52.459898Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-15T02:43:54.313680Z   |                                             cluster1-0 joined                             |                                             
+2023-05-15T02:43:54.313721Z   |                                             cluster1-2 joined                             |                                             
+2023-05-15T02:43:54.313732Z   |                                             garb left                                     |                                             
+2023-05-15T02:43:55.315909Z   |                                             garb left                                     |                                             
+2023-05-15T02:43:55.315972Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-15T05:00:37.943518Z   |                                             cluster1-0 joined                             |                                             
+2023-05-15T05:00:37.943607Z   |                                             garb joined                                   |                                             
+2023-05-15T05:00:37.943631Z   |                                             cluster1-2 joined                             |                                             
+2023-05-15T05:00:37.945220Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-15T05:00:38.387001Z   |                                             local node will resync garb                   |                                             
+2023-05-15T05:00:38.387063Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-15T05:00:49.866151Z   |                                             SST to garb                                   |                                             
+2023-05-15T05:44:06.033520Z   |                                             finished sending SST to garb                  |                                             
+2023-05-15T05:44:06.033594Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-15T05:44:06.034340Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-15T05:44:09.112339Z   |                                             cluster1-0 joined                             |                                             
+2023-05-15T05:44:09.112422Z   |                                             cluster1-2 joined                             |                                             
+2023-05-15T05:44:09.112451Z   |                                             garb left                                     |                                             
+2023-05-15T05:44:09.114037Z   |                                             garb left                                     |                                             
+2023-05-15T05:44:09.114066Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-15T17:18:09.283033Z   |                                             cluster1-2 joined                             |                                             
+2023-05-15T17:18:09.283176Z   |                                             cluster1-0 left                               |                                             
+2023-05-15T17:18:09.284393Z   |                                             cluster1-0 left                               |                                             
+2023-05-15T17:18:09.284417Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-15T17:19:28.022611Z   |                                             cluster1-0 joined                             |                                             
+2023-05-15T17:19:28.022710Z   |                                             cluster1-2 joined                             |                                             
+2023-05-15T17:19:28.023947Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-15T17:19:29.187799Z   |                                             local node will resync cluster1-0             |                                             
+2023-05-15T17:19:29.187866Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-15T17:19:29.201328Z   |                                             IST to cluster1-0(seqno:5408371)              |                                             
+2023-05-15T17:19:29.651209Z   |                                             IST will be used                              |                                             
+2023-05-15T17:19:30.672304Z   |                                             finished sending IST to cluster1-0            |                                             
+2023-05-15T17:19:30.672382Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-15T17:19:30.672874Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-16T02:00:39.155225Z   |                                             garb joined                                   |                                             
+2023-05-16T02:00:39.155270Z   |                                             cluster1-0 joined                             |                                             
+2023-05-16T02:00:39.155278Z   |                                             cluster1-2 joined                             |                                             
+2023-05-16T02:00:39.156563Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-16T02:00:39.393865Z   |                                             local node will resync garb                   |                                             
+2023-05-16T02:00:39.393887Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-16T02:00:50.852843Z   |                                             SST to garb                                   |                                             
+2023-05-16T02:26:01.150948Z   |                                             garb joined                                   |                                             
+2023-05-16T02:26:01.151019Z   |                                             cluster1-2 joined                             |                                             
+2023-05-16T02:26:01.151037Z   |                                             cluster1-0 left                               |                                             
+2023-05-16T02:26:01.152236Z   |                                             cluster1-0 left                               |                                             
+2023-05-16T02:26:01.152322Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-16T02:41:51.091600Z   |                                             finished sending SST to garb                  |                                             
+2023-05-16T02:41:51.091676Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-16T02:41:51.092224Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-16T02:41:53.415858Z   |                                             cluster1-2 joined                             |                                             
+2023-05-16T02:41:53.416002Z   |                                             garb left                                     |                                             
+2023-05-16T02:41:53.417044Z   |                                             garb left                                     |                                             
+2023-05-16T02:41:53.417130Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-16T02:42:36.811151Z   |                                             cluster1-0 joined                             |                                             
+2023-05-16T02:42:36.811232Z   |                                             cluster1-2 joined                             |                                             
+2023-05-16T02:42:36.812646Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-16T02:42:37.922175Z   |                                             local node will resync cluster1-0             |                                             
+2023-05-16T02:42:37.922257Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-16T02:42:37.935365Z   |                                             IST to cluster1-0(seqno:5697478)              |                                             
+2023-05-16T02:42:38.416273Z   |                                             IST will be used                              |                                             
+2023-05-16T02:42:39.440136Z   |                                             finished sending IST to cluster1-0            |                                             
+2023-05-16T02:42:39.440201Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-16T02:42:39.440867Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-16T02:45:10.902553Z   |                                             (repeated x105)too many connections           |                                             
+2023-05-16T02:45:14.464524Z   |                                             too many connections                          |                                             
+2023-05-16T02:46:18.007412Z   |                                             received shutdown                             |                                             
+2023-05-16T02:56:57.328220Z   |                                             starting(8.0.31)                              |                                             
+2023-05-16T02:56:57.339616Z   |                                             started(cluster)                              |                                             
+2023-05-16T02:56:57.340972Z   |                                             recovering gcache                             |                                             
+2023-05-16T02:56:57.994563Z   |                                             recovering gcache                             |                                             
+2023-05-16T02:56:58.598150Z   |                                             cluster1-0 joined                             |                                             
+2023-05-16T02:56:58.598176Z   |                                             cluster1-2 joined                             |                                             
+2023-05-16T02:56:59.096957Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-16T02:56:59.097146Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-16T02:56:59.098728Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-16T02:56:59.754093Z   |                                             will receive IST(seqno:5698287)               |                                             
+2023-05-16T02:56:59.755433Z   |                                             cluster1-0 will resync local node             |                                             
+2023-05-16T02:56:59.755465Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-16T02:56:59.757859Z   |                                             cluster1-0 failed to sync cluster1-1          |                                             
+2023-05-16T02:56:59.757877Z   |                                             will never receive SST, aborting              |                                             
+2023-05-16T02:56:59.758599Z   |                                             terminated                                    |                                             
+2023-05-16T02:56:59.758607Z   |                                             former SST cancelled                          |                                             
+2023-05-16T02:56:59Z          |                                             crash: got signal 11                          |                                             
+2023-05-16T02:58:05.418798Z   |                                             starting(8.0.31)                              |                                             
+2023-05-16T02:58:05.425961Z   |                                             started(cluster)                              |                                             
+2023-05-16T02:58:05.427232Z   |                                             recovering gcache                             |                                             
+2023-05-16T02:58:05.824106Z   |                                             recovering gcache                             |                                             
+2023-05-16T02:58:06.377247Z   |                                             cluster1-0 joined                             |                                             
+2023-05-16T02:58:06.377275Z   |                                             cluster1-2 joined                             |                                             
+2023-05-16T02:58:06.876188Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-16T02:58:06.876404Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-16T02:58:06.877762Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-16T02:58:07.513826Z   |                                             will receive SST                              |                                             
+2023-05-16T02:58:07.514763Z   |                                             cluster1-0 will resync local node             |                                             
+2023-05-16T02:58:07.514835Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-16T02:58:07.522280Z   |                                             cluster1-0 failed to sync cluster1-1          |                                             
+2023-05-16T02:58:07.522334Z   |                                             will never receive SST, aborting              |                                             
+2023-05-16T02:58:07.523605Z   |                                             terminated                                    |                                             
+2023-05-16T02:58:07.523621Z   |                                             former SST cancelled                          |                                             
+2023-05-16T02:58:07Z          |                                             crash: got signal 11                          |                                             
+2023-05-16T02:59:15.251276Z   |                                             starting(8.0.31)                              |                                             
+2023-05-16T02:59:15.257433Z   |                                             started(cluster)                              |                                             
+2023-05-16T02:59:15.258668Z   |                                             recovering gcache                             |                                             
+2023-05-16T02:59:15.688672Z   |                                             recovering gcache                             |                                             
+2023-05-16T02:59:44.719012Z   |                                             cluster1-0 joined                             |                                             
+2023-05-16T02:59:44.719042Z   |                                             cluster1-2 joined                             |                                             
+2023-05-16T02:59:45.218169Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-16T02:59:45.218407Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-16T02:59:45.219528Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-16T02:59:45.884309Z   |                                             will receive SST                              |                                             
+2023-05-16T02:59:45.885230Z   |                                             cluster1-0 will resync local node             |                                             
+2023-05-16T02:59:45.885308Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-16T02:59:45.893113Z   |                                             cluster1-0 failed to sync cluster1-1          |                                             
+2023-05-16T02:59:45.893164Z   |                                             will never receive SST, aborting              |                                             
+2023-05-16T02:59:45.894389Z   |                                             terminated                                    |                                             
+2023-05-16T02:59:45.894407Z   |                                             former SST cancelled                          |                                             
+2023-05-16T02:59:45Z          |                                             crash: got signal 11                          |                                             
+2023-05-16T03:00:01.228500Z   |                                             SST error                                     |                                             
+2023-05-16T03:01:22.029475Z   |                                             starting(8.0.31)                              |                                             
+2023-05-16T03:01:22.036060Z   |                                             started(cluster)                              |                                             
+2023-05-16T03:01:22.037309Z   |                                             (repeated x1)recovering gcache                |                                             
+2023-05-16T03:01:33.094706Z   |                                             recovering gcache                             |                                             
+2023-05-16T03:01:59.670468Z   |                                             cluster1-0 joined                             |                                             
+2023-05-16T03:01:59.670482Z   |                                             cluster1-2 joined                             |                                             
+2023-05-16T03:02:00.169304Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-16T03:02:00.169482Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-16T03:02:00.171272Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-16T03:02:00.814180Z   |                                             will receive SST                              |                                             
+2023-05-16T03:02:00.815258Z   |                                             cluster1-0 will resync local node             |                                             
+2023-05-16T03:02:00.815327Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-16T03:02:00.855489Z   |                                             cluster1-0 failed to sync cluster1-1          |                                             
+2023-05-16T03:02:00.855539Z   |                                             will never receive SST, aborting              |                                             
+2023-05-16T03:02:00.857051Z   |                                             terminated                                    |                                             
+2023-05-16T03:02:00.857070Z   |                                             former SST cancelled                          |                                             
+2023-05-16T03:02:00Z          |                                             crash: got signal 11                          |                                             
+2023-05-16T03:04:16.906158Z   |                                             starting(8.0.31)                              |                                             
+2023-05-16T03:04:16.912054Z   |                                             started(cluster)                              |                                             
+2023-05-16T03:04:16.913132Z   |                                             (repeated x1)recovering gcache                |                                             
+2023-05-16T03:04:27.424753Z   |                                             recovering gcache                             |                                             
+2023-05-16T03:04:51.780849Z   |                                             cluster1-2 joined                             |                                             
+2023-05-16T03:04:52.279974Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-16T03:04:52.280182Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-16T03:04:52.281364Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-16T03:04:52.954535Z   |                                             will receive SST                              |                                             
+2023-05-16T03:04:52.955179Z   |                                             cannot find donor                             |                                             
+2023-05-16T03:04:53.956078Z   |                                             cannot find donor                             |                                             
+2023-05-16T03:04:54.956958Z   |                                             (repeated x97)cannot find donor               |                                             
+2023-05-16T03:06:33.039898Z   |                                             cannot find donor                             |                                             
+2023-05-16T03:06:34.023406Z   |                                             timeout from donor in gtid/keyring stage      |                                             
+2023-05-16T03:06:34.030283Z   |                                             SST error                                     |                                             
+2023-05-16T03:06:34.040289Z   |                                             terminated                                    |                                             
+2023-05-16T03:06:34.040309Z   |                                             former SST cancelled                          |                                             
+2023-05-16T03:06:34Z          |                                             crash: got signal 11                          |                                             
+2023-05-16T07:51:48.142342Z   |                                             starting(8.0.31)                              |                                             
+2023-05-16T07:51:48.148592Z   |                                             started(cluster)                              |                                             
+2023-05-16T07:51:48.149740Z   |                                             (repeated x1)recovering gcache                |                                             
+2023-05-16T07:51:58.379294Z   |                                             recovering gcache                             |                                             
+2023-05-16T07:52:26.431252Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-16T07:52:26.431427Z   |                                             NON-PRIMARY(n=1)                              |                                             
+2023-05-16T10:03:18.655740Z   starting(8.0.31)                              |                                             |                                             
+2023-05-16T10:03:18.658268Z   started(cluster)                              |                                             |                                             
+2023-05-16T10:03:18.659239Z   no grastate.dat file                          |                                             |                                             
+2023-05-16T10:03:18.659248Z   bootstrapping(empty grastate)                 |                                             |                                             
+2023-05-16T10:03:18.659274Z   safe_to_bootstrap: 1                          |                                             |                                             
+2023-05-16T10:03:19.700941Z   cluster1-2 joined                             |                                             |                                             
+2023-05-16T10:03:19.700942Z   |                                             cluster1-2 joined                             |                                             
+2023-05-16T10:03:19.700950Z   cluster1-1 joined                             |                                             |                                             
+2023-05-16T10:03:19.701041Z   |                                             cluster1-0 joined                             |                                             
+2023-05-16T10:03:19.702446Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-16T10:03:20.174154Z   CLOSED -> OPEN                                |                                             |                                             
+2023-05-16T10:03:20.174415Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-16T10:03:20.175471Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-16T10:03:20.175651Z   OPEN -> PRIMARY                               |                                             |                                             
+2023-05-16T10:03:20.825855Z   |                                             will receive SST                              |                                             
+2023-05-16T10:03:20.826785Z   cluster1-2 will resync cluster1-1             |                                             |                                             
+2023-05-16T10:03:20.826808Z   |                                             cluster1-2 will resync local node             |                                             
+2023-05-16T10:03:20.826874Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-16T10:03:20.829695Z   will receive SST                              |                                             |                                             
+2023-05-16T10:03:20.830129Z   |                                             cluster1-0 cannot find donor                  |                                             
+2023-05-16T10:03:20.830169Z   cluster1-0 cannot find donor                  |                                             |                                             
+2023-05-16T10:03:21.636432Z   |                                             receiving SST                                 |                                             
+2023-05-16T10:03:21.831094Z   |                                             (repeated x98)cluster1-0 cannot find donor    |                                             
+2023-05-16T10:03:21.831193Z   cluster1-0 cannot find donor                  |                                             |                                             
+2023-05-16T10:03:22.832160Z   (repeated x97)cluster1-0 cannot find donor    |                                             |                                             
+2023-05-16T10:05:00.937424Z   |                                             cluster1-0 cannot find donor                  |                                             
+2023-05-16T10:05:00.937441Z   cluster1-0 cannot find donor                  |                                             |                                             
+2023-05-16T10:05:01.909476Z   timeout from donor in gtid/keyring stage      |                                             |                                             
+2023-05-16T10:05:01.916956Z   SST error                                     |                                             |                                             
+2023-05-16T10:05:01.918653Z   |                                             cluster1-2 joined                             |                                             
+2023-05-16T10:05:01.918732Z   |                                             cluster1-0 left                               |                                             
+2023-05-16T10:05:01.918737Z   NON-PRIMARY(n=1)                              |                                             |                                             
+2023-05-16T10:05:01.918924Z   PRIMARY -> OPEN                               |                                             |                                             
+2023-05-16T10:05:01.919021Z   OPEN -> CLOSED                                |                                             |                                             
+2023-05-16T10:05:01.919173Z   terminated                                    |                                             |                                             
+2023-05-16T10:05:01.919181Z   former SST cancelled                          |                                             |                                             
+2023-05-16T10:05:01Z          crash: got signal 11                          |                                             |                                             
+2023-05-16T10:05:01.920148Z   |                                             cluster1-0 left                               |                                             
+2023-05-16T10:05:01.920217Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-16T10:47:53.548849Z   |                                             got SST from cluster1-2                       |                                             
+2023-05-16T10:47:53.581506Z   |                                             preparing SST backup                          |                                             
+2023-05-16T10:48:33.507965Z   |                                             wsrep recovery                                |                                             
+2023-05-16T10:48:33.533202Z   |                                             JOINER -> JOINED                              |                                             
+2023-05-16T10:48:34.865824Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-16T10:48:46.119407Z   starting(8.0.31)                              |                                             |                                             
+2023-05-16T10:48:46.121988Z   started(cluster)                              |                                             |                                             
+2023-05-16T10:48:46.122926Z   safe_to_bootstrap: 1                          |                                             |                                             
+2023-05-16T10:48:46.636641Z   |                                             cluster1-2 joined                             |                                             
+2023-05-16T10:48:46.636729Z   |                                             cluster1-0 joined                             |                                             
+2023-05-16T10:48:46.636865Z   cluster1-2 joined                             |                                             |                                             
+2023-05-16T10:48:46.636892Z   cluster1-1 joined                             |                                             |                                             
+2023-05-16T10:48:46.638432Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-16T10:48:47.136082Z   CLOSED -> OPEN                                |                                             |                                             
+2023-05-16T10:48:47.136335Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-16T10:48:47.137440Z   OPEN -> PRIMARY                               |                                             |                                             
+2023-05-16T10:48:47.813851Z   will receive SST                              |                                             |                                             
+2023-05-16T10:48:47.814607Z   |                                             cluster1-2 will resync cluster1-0             |                                             
+2023-05-16T10:48:47.814777Z   cluster1-2 will resync local node             |                                             |                                             
+2023-05-16T10:48:47.814846Z   PRIMARY -> JOINER                             |                                             |                                             
+2023-05-16T10:48:48.623834Z   receiving SST                                 |                                             |                                             
+2023-05-16T11:32:58.984427Z   |                                             cluster1-2 synced cluster1-0                  |                                             
+2023-05-16T11:32:58.984956Z   got SST from cluster1-2                       |                                             |                                             
+2023-05-16T11:32:59.020381Z   preparing SST backup                          |                                             |                                             
+2023-05-16T11:33:35.431876Z   wsrep recovery                                |                                             |                                             
+2023-05-16T11:33:35.443968Z   JOINER -> JOINED                              |                                             |                                             
+2023-05-16T11:33:36.623324Z   JOINED -> SYNCED                              |                                             |                                             
+2023-05-16T12:28:44.905840Z   |                                             cluster1-2 suspected to be down               |                                             
+2023-05-16T12:28:45.406765Z   cluster1-2 suspected to be down               |                                             |                                             
+2023-05-16T12:28:45.907278Z   |                                             cluster1-0 joined                             |                                             
+2023-05-16T12:28:45.907408Z   cluster1-1 joined                             |                                             |                                             
+2023-05-16T12:28:45.908701Z   cluster1-2 left                               |                                             |                                             
+2023-05-16T12:28:45.908766Z   PRIMARY(n=2)                                  |                                             |                                             
+2023-05-16T12:28:45.909369Z   |                                             cluster1-2 left                               |                                             
+2023-05-16T12:28:45.909445Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-16T12:29:33.780957Z   |                                             cluster1-2 joined                             |                                             
+2023-05-16T12:29:33.781003Z   |                                             cluster1-0 joined                             |                                             
+2023-05-16T12:29:33.781162Z   cluster1-2 joined                             |                                             |                                             
+2023-05-16T12:29:33.781197Z   cluster1-1 joined                             |                                             |                                             
+2023-05-16T12:29:33.781849Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-16T12:29:33.782097Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-16T12:29:34.807852Z   |                                             local node will resync cluster1-2             |                                             
+2023-05-16T12:29:34.807945Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-16T12:29:34.808108Z   cluster1-1 will resync cluster1-2             |                                             |                                             
+2023-05-16T12:29:34.826520Z   |                                             IST to cluster1-2(seqno:90134)                |                                             
+2023-05-16T12:29:35.291536Z   |                                             IST will be used                              |                                             
+2023-05-16T12:29:36.348959Z   |                                             finished sending IST to cluster1-2            |                                             
+2023-05-16T12:29:36.349031Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-16T12:29:36.349099Z   cluster1-1 synced cluster1-2                  |                                             |                                             
+2023-05-16T12:29:36.349715Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-17T02:00:38.559825Z   cluster1-2 joined                             |                                             |                                             
+2023-05-17T02:00:38.559903Z   |                                             cluster1-2 joined                             |                                             
+2023-05-17T02:00:38.559921Z   cluster1-1 joined                             |                                             |                                             
+2023-05-17T02:00:38.559947Z   garb joined                                   |                                             |                                             
+2023-05-17T02:00:38.559998Z   |                                             cluster1-0 joined                             |                                             
+2023-05-17T02:00:38.560023Z   |                                             garb joined                                   |                                             
+2023-05-17T02:00:38.561718Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-17T02:00:38.561911Z   PRIMARY(n=4)                                  |                                             |                                             
+2023-05-17T02:00:39.060626Z   cluster1-2 will resync garb                   |                                             |                                             
+2023-05-17T02:00:39.060663Z   |                                             cluster1-2 will resync garb                   |                                             
+2023-05-17T02:42:53.094651Z   |                                             cluster1-2 synced garb                        |                                             
+2023-05-17T02:42:53.094869Z   cluster1-2 synced garb                        |                                             |                                             
+2023-05-17T02:42:55.155501Z   |                                             cluster1-2 joined                             |                                             
+2023-05-17T02:42:55.155542Z   |                                             cluster1-0 joined                             |                                             
+2023-05-17T02:42:55.155565Z   |                                             garb left                                     |                                             
+2023-05-17T02:42:55.155574Z   cluster1-2 joined                             |                                             |                                             
+2023-05-17T02:42:55.155588Z   cluster1-1 joined                             |                                             |                                             
+2023-05-17T02:42:55.155596Z   garb left                                     |                                             |                                             
+2023-05-17T02:42:55.156821Z   |                                             garb left                                     |                                             
+2023-05-17T02:42:55.156903Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-17T02:42:55.156912Z   garb left                                     |                                             |                                             
+2023-05-17T02:42:55.156990Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-18T02:00:38.610721Z   |                                             cluster1-2 joined                             |                                             
+2023-05-18T02:00:38.610738Z   cluster1-2 joined                             |                                             |                                             
+2023-05-18T02:00:38.610778Z   |                                             cluster1-0 joined                             |                                             
+2023-05-18T02:00:38.610794Z   |                                             garb joined                                   |                                             
+2023-05-18T02:00:38.610821Z   cluster1-1 joined                             |                                             |                                             
+2023-05-18T02:00:38.610846Z   garb joined                                   |                                             |                                             
+2023-05-18T02:00:38.612270Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-18T02:00:38.612336Z   PRIMARY(n=4)                                  |                                             |                                             
+2023-05-18T02:00:39.111354Z   |                                             cluster1-2 will resync garb                   |                                             
+2023-05-18T02:00:39.111362Z   cluster1-2 will resync garb                   |                                             |                                             
+2023-05-18T02:43:21.261195Z   |                                             cluster1-2 synced garb                        |                                             
+2023-05-18T02:43:21.261218Z   cluster1-2 synced garb                        |                                             |                                             
+2023-05-18T02:43:23.331315Z   cluster1-2 joined                             |                                             |                                             
+2023-05-18T02:43:23.331333Z   |                                             cluster1-2 joined                             |                                             
+2023-05-18T02:43:23.331355Z   cluster1-1 joined                             |                                             |                                             
+2023-05-18T02:43:23.331373Z   |                                             cluster1-0 joined                             |                                             
+2023-05-18T02:43:23.331414Z   |                                             garb left                                     |                                             
+2023-05-18T02:43:23.331418Z   garb left                                     |                                             |                                             
+2023-05-18T02:43:23.332680Z   |                                             garb left                                     |                                             
+2023-05-18T02:43:23.332740Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-18T02:43:23.333044Z   garb left                                     |                                             |                                             
+2023-05-18T02:43:23.333107Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-18T07:59:17.124743Z   received shutdown                             |                                             |                                             
+2023-05-18T07:59:17.968467Z   |                                             received shutdown                             |                                             
+2023-05-18T07:59:27.128081Z   |                                             cluster1-2 joined                             |                                             
+2023-05-18T07:59:27.128191Z   NON-PRIMARY(n=1)                              |                                             |                                             
+2023-05-18T07:59:27.128200Z   |                                             cluster1-0 left                               |                                             
+2023-05-18T07:59:27.128414Z   SYNCED -> OPEN                                |                                             |                                             
+2023-05-18T07:59:27.128520Z   OPEN -> CLOSED                                |                                             |                                             
+2023-05-18T07:59:27.129727Z   |                                             cluster1-0 left                               |                                             
+2023-05-18T07:59:27.129794Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-18T07:59:28.972265Z   |                                             NON-PRIMARY(n=1)                              |                                             
+2023-05-18T07:59:28.972428Z   |                                             SYNCED -> OPEN                                |                                             
+2023-05-18T07:59:28.972542Z   |                                             OPEN -> CLOSED                                |                                             
+2023-05-18T08:10:55.079377Z   starting(8.0.31)                              |                                             |                                             
+2023-05-18T08:10:55.082696Z   started(cluster)                              |                                             |                                             
+2023-05-18T08:10:55.083755Z   safe_to_bootstrap: 1                          |                                             |                                             
+2023-05-18T08:10:55.084042Z   recovering gcache                             |                                             |                                             
+2023-05-18T08:10:56.027905Z   recovering gcache                             |                                             |                                             
+2023-05-18T08:10:56.234199Z   bootstrapping                                 |                                             |                                             
+2023-05-18T08:10:56.235055Z   CLOSED -> OPEN                                |                                             |                                             
+2023-05-18T08:10:56.235277Z   PRIMARY(n=1)                                  |                                             |                                             
+2023-05-18T08:10:56.235913Z   (restored)OPEN -> JOINED                      |                                             |                                             
+2023-05-18T08:10:56.235984Z   JOINED -> SYNCED                              |                                             |                                             
+2023-05-18T08:12:26.802815Z   cluster1-2 joined                             |                                             |                                             
+2023-05-18T08:12:26.804265Z   PRIMARY(n=2)                                  |                                             |                                             
+2023-05-18T08:12:28.032556Z   local node will resync cluster1-2             |                                             |                                             
+2023-05-18T08:12:28.032650Z   SYNCED -> DONOR                               |                                             |                                             
+2023-05-18T08:12:28.038966Z   IST to cluster1-2(seqno:173)                  |                                             |                                             
+2023-05-18T08:12:39.503380Z   SST to cluster1-2                             |                                             |                                             
+2023-05-18T08:50:05.834112Z   finished sending IST to cluster1-2            |                                             |                                             
+2023-05-18T08:50:05.834143Z   DESYNCED -> JOINED                            |                                             |                                             
+2023-05-18T08:50:05.834494Z   JOINED -> SYNCED                              |                                             |                                             
+2023-05-18T08:51:05.420478Z   |                                             starting(8.0.31)                              |                                             
+2023-05-18T08:51:05.429007Z   |                                             started(cluster)                              |                                             
+2023-05-18T08:51:05.430480Z   |                                             recovering gcache                             |                                             
+2023-05-18T08:51:06.624095Z   |                                             recovering gcache                             |                                             
+2023-05-18T08:51:07.210530Z   cluster1-1 joined                             |                                             |                                             
+2023-05-18T08:51:07.210570Z   cluster1-2 joined                             |                                             |                                             
+2023-05-18T08:51:07.211254Z   |                                             cluster1-0 joined                             |                                             
+2023-05-18T08:51:07.211282Z   |                                             cluster1-2 joined                             |                                             
+2023-05-18T08:51:07.211878Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-18T08:51:07.470375Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-18T08:51:07.470547Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-18T08:51:07.472017Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-18T08:51:08.111952Z   |                                             will receive SST                              |                                             
+2023-05-18T08:51:08.112104Z   local node will resync cluster1-1             |                                             |                                             
+2023-05-18T08:51:08.112226Z   SYNCED -> DONOR                               |                                             |                                             
+2023-05-18T08:51:08.112703Z   |                                             cluster1-0 will resync local node             |                                             
+2023-05-18T08:51:08.112779Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-18T08:51:08.119652Z   IST to cluster1-1(seqno:17135)                |                                             |                                             
+2023-05-18T08:51:08.932698Z   |                                             receiving SST                                 |                                             
+2023-05-18T08:51:19.607014Z   SST to cluster1-1                             |                                             |                                             
+2023-05-18T09:29:06.931404Z   finished sending IST to cluster1-1            |                                             |                                             
+2023-05-18T09:29:06.931474Z   DESYNCED -> JOINED                            |                                             |                                             
+2023-05-18T09:29:06.932023Z   |                                             got SST from cluster1-0                       |                                             
+2023-05-18T09:29:06.932145Z   JOINED -> SYNCED                              |                                             |                                             
+2023-05-18T09:32:43.074179Z   |                                             preparing SST backup                          |                                             
+2023-05-18T09:33:24.024352Z   |                                             wsrep recovery                                |                                             
+2023-05-18T09:33:24.042895Z   |                                             JOINER -> JOINED                              |                                             
+2023-05-18T09:33:25.567760Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-18T11:04:37.966152Z   |                                             received shutdown                             |                                             
+2023-05-18T11:04:47.969182Z   |                                             NON-PRIMARY(n=1)                              |                                             
+2023-05-18T11:04:47.969361Z   |                                             SYNCED -> OPEN                                |                                             
+2023-05-18T11:04:47.969459Z   |                                             OPEN -> CLOSED                                |                                             
+2023-05-18T11:04:47.969461Z   cluster1-2 joined                             |                                             |                                             
+2023-05-18T11:04:47.969598Z   cluster1-1 left                               |                                             |                                             
+2023-05-18T11:04:47.970895Z   cluster1-1 left                               |                                             |                                             
+2023-05-18T11:04:47.971039Z   PRIMARY(n=2)                                  |                                             |                                             
+2023-05-18T11:15:15.567539Z   |                                             starting(8.0.31)                              |                                             
+2023-05-18T11:15:15.575256Z   |                                             started(cluster)                              |                                             
+2023-05-18T11:15:15.576587Z   |                                             recovering gcache                             |                                             
+2023-05-18T11:15:16.671487Z   |                                             recovering gcache                             |                                             
+2023-05-18T11:15:17.018482Z   |                                             cluster1-0 joined                             |                                             
+2023-05-18T11:15:17.018507Z   |                                             cluster1-2 joined                             |                                             
+2023-05-18T11:15:17.018917Z   cluster1-1 joined                             |                                             |                                             
+2023-05-18T11:15:17.019843Z   cluster1-2 joined                             |                                             |                                             
+2023-05-18T11:15:17.020877Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-18T11:15:17.481649Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-18T11:15:17.481816Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-18T11:15:17.483605Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-18T11:15:18.115949Z   |                                             will receive SST                              |                                             
+2023-05-18T11:15:18.116912Z   |                                             cluster1-0 will resync local node             |                                             
+2023-05-18T11:15:18.116942Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-18T11:15:18.117425Z   local node will resync cluster1-1             |                                             |                                             
+2023-05-18T11:15:18.117522Z   SYNCED -> DONOR                               |                                             |                                             
+2023-05-18T11:15:18.124298Z   IST to cluster1-1(seqno:96339)                |                                             |                                             
+2023-05-18T11:15:18.940943Z   |                                             receiving SST                                 |                                             
+2023-05-18T11:15:29.599110Z   SST to cluster1-1                             |                                             |                                             
+2023-05-18T11:48:59.162092Z   cluster1-1 joined                             |                                             |                                             
+2023-05-18T11:48:59.162198Z   |                                             cluster1-0 joined                             |                                             
+2023-05-18T11:48:59.162368Z   |                                             cluster1-2 left                               |                                             
+2023-05-18T11:48:59.162370Z   cluster1-2 left                               |                                             |                                             
+2023-05-18T11:48:59.163992Z   |                                             cluster1-2 left                               |                                             
+2023-05-18T11:48:59.164065Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-18T11:48:59.164368Z   cluster1-2 left                               |                                             |                                             
+2023-05-18T11:48:59.164431Z   PRIMARY(n=2)                                  |                                             |                                             
+2023-05-18T11:52:34.738198Z   finished sending IST to cluster1-1            |                                             |                                             
+2023-05-18T11:52:34.738230Z   DESYNCED -> JOINED                            |                                             |                                             
+2023-05-18T11:52:34.738484Z   |                                             got SST from cluster1-0                       |                                             
+2023-05-18T11:52:34.738535Z   JOINED -> SYNCED                              |                                             |                                             
+2023-05-18T11:56:00.169861Z   |                                             preparing SST backup                          |                                             
+2023-05-18T11:56:41.702322Z   |                                             wsrep recovery                                |                                             
+2023-05-18T11:56:41.711514Z   |                                             JOINER -> JOINED                              |                                             
+2023-05-18T11:56:43.629286Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-18T11:59:36.017025Z   cluster1-1 joined                             |                                             |                                             
+2023-05-18T11:59:36.017115Z   cluster1-2 joined                             |                                             |                                             
+2023-05-18T11:59:36.017290Z   |                                             cluster1-2 joined                             |                                             
+2023-05-18T11:59:36.017369Z   |                                             cluster1-0 joined                             |                                             
+2023-05-18T11:59:36.018723Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-18T11:59:36.018796Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-18T11:59:37.168543Z   cluster1-1 will resync cluster1-2             |                                             |                                             
+2023-05-18T11:59:37.168800Z   |                                             local node will resync cluster1-2             |                                             
+2023-05-18T11:59:37.168859Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-18T11:59:37.175034Z   |                                             IST to cluster1-2(seqno:120925)               |                                             
+2023-05-18T11:59:48.642038Z   |                                             SST to cluster1-2                             |                                             
+2023-05-18T12:38:56.021324Z   |                                             finished sending IST to cluster1-2            |                                             
+2023-05-18T12:38:56.021429Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-18T12:38:56.022044Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-18T12:38:56.022072Z   cluster1-1 synced cluster1-2                  |                                             |                                             
+2023-05-18T13:02:37.116214Z   received shutdown                             |                                             |                                             
+2023-05-18T13:02:37.960715Z   |                                             received shutdown                             |                                             
+2023-05-18T13:02:47.118582Z   |                                             cluster1-2 joined                             |                                             
+2023-05-18T13:02:47.118714Z   |                                             cluster1-0 left                               |                                             
+2023-05-18T13:02:47.119168Z   NON-PRIMARY(n=1)                              |                                             |                                             
+2023-05-18T13:02:47.119351Z   SYNCED -> OPEN                                |                                             |                                             
+2023-05-18T13:02:47.119445Z   OPEN -> CLOSED                                |                                             |                                             
+2023-05-18T13:02:47.120061Z   |                                             cluster1-0 left                               |                                             
+2023-05-18T13:02:47.120131Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-18T13:02:48.963195Z   |                                             NON-PRIMARY(n=1)                              |                                             
+2023-05-18T13:02:48.963269Z   |                                             SYNCED -> OPEN                                |                                             
+2023-05-18T13:02:48.963302Z   |                                             OPEN -> CLOSED                                |                                             
+2023-05-18T13:13:25.811735Z   starting(8.0.31)                              |                                             |                                             
+2023-05-18T13:13:25.815075Z   started(cluster)                              |                                             |                                             
+2023-05-18T13:13:25.816336Z   recovering gcache                             |                                             |                                             
+2023-05-18T13:13:26.080257Z   |                                             starting(8.0.31)                              |                                             
+2023-05-18T13:13:26.089882Z   |                                             started(cluster)                              |                                             
+2023-05-18T13:13:26.091288Z   |                                             recovering gcache                             |                                             
+2023-05-18T13:13:27.262629Z   |                                             recovering gcache                             |                                             
+2023-05-18T13:13:28.077529Z   |                                             cluster1-2 joined                             |                                             
+2023-05-18T13:13:28.576887Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-18T13:13:28.577162Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-18T13:13:28.579204Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-18T13:13:29.235576Z   |                                             will receive SST                              |                                             
+2023-05-18T13:13:29.236168Z   |                                             cluster1-2 will resync local node             |                                             
+2023-05-18T13:13:29.236243Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-18T13:13:29.243896Z   |                                             cluster1-2 failed to sync cluster1-1          |                                             
+2023-05-18T13:13:29.243939Z   |                                             will never receive SST, aborting              |                                             
+2023-05-18T13:13:30.246178Z   |                                             terminated                                    |                                             
+2023-05-18T13:13:30.246186Z   |                                             former SST cancelled                          |                                             
+2023-05-18T13:13:30Z          |                                             crash: got signal 11                          |                                             
+2023-05-18T13:13:35.192700Z   recovering gcache                             |                                             |                                             
+2023-05-18T13:13:35.730381Z   cluster1-2 joined                             |                                             |                                             
+2023-05-18T13:13:36.229634Z   CLOSED -> OPEN                                |                                             |                                             
+2023-05-18T13:13:36.229890Z   PRIMARY(n=2)                                  |                                             |                                             
+2023-05-18T13:13:36.231137Z   OPEN -> PRIMARY                               |                                             |                                             
+2023-05-18T13:13:36.894431Z   will receive SST                              |                                             |                                             
+2023-05-18T13:13:36.894926Z   cluster1-2 will resync local node             |                                             |                                             
+2023-05-18T13:13:36.894974Z   PRIMARY -> JOINER                             |                                             |                                             
+2023-05-18T13:13:36.902951Z   cluster1-2 failed to sync cluster1-0          |                                             |                                             
+2023-05-18T13:13:36.903001Z   will never receive SST, aborting              |                                             |                                             
+2023-05-18T13:13:37.905057Z   terminated                                    |                                             |                                             
+2023-05-18T13:13:37.905067Z   former SST cancelled                          |                                             |                                             
+2023-05-18T13:13:37Z          crash: got signal 11                          |                                             |                                             
+2023-05-18T13:14:38.342757Z   |                                             starting(8.0.31)                              |                                             
+2023-05-18T13:14:38.350243Z   |                                             started(cluster)                              |                                             
+2023-05-18T13:14:38.351647Z   |                                             recovering gcache                             |                                             
+2023-05-18T13:14:39.537857Z   |                                             recovering gcache                             |                                             
+2023-05-18T13:14:53.602717Z   starting(8.0.31)                              |                                             |                                             
+2023-05-18T13:14:53.605732Z   started(cluster)                              |                                             |                                             
+2023-05-18T13:14:53.606850Z   recovering gcache                             |                                             |                                             
+2023-05-18T13:15:01.357286Z   recovering gcache                             |                                             |                                             
+2023-05-18T13:15:19.910425Z   |                                             cluster1-2 joined                             |                                             
+2023-05-18T13:15:20.321473Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-18T13:15:20.321656Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-18T13:15:20.322983Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-18T13:15:20.952208Z   |                                             will receive SST                              |                                             
+2023-05-18T13:15:20.952833Z   |                                             cluster1-2 will resync local node             |                                             
+2023-05-18T13:15:20.952903Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-18T13:15:20.983470Z   |                                             cluster1-2 failed to sync cluster1-1          |                                             
+2023-05-18T13:15:20.983544Z   |                                             will never receive SST, aborting              |                                             
+2023-05-18T13:15:21.984924Z   |                                             terminated                                    |                                             
+2023-05-18T13:15:21.984931Z   |                                             former SST cancelled                          |                                             
+2023-05-18T13:15:21Z          |                                             crash: got signal 11                          |                                             
+2023-05-18T13:15:26.986441Z   cluster1-2 joined                             |                                             |                                             
+2023-05-18T13:15:27.250148Z   CLOSED -> OPEN                                |                                             |                                             
+2023-05-18T13:15:27.250392Z   PRIMARY(n=2)                                  |                                             |                                             
+2023-05-18T13:15:27.251695Z   OPEN -> PRIMARY                               |                                             |                                             
+2023-05-18T13:15:27.928143Z   will receive SST                              |                                             |                                             
+2023-05-18T13:15:27.928839Z   cluster1-2 will resync local node             |                                             |                                             
+2023-05-18T13:15:27.928922Z   PRIMARY -> JOINER                             |                                             |                                             
+2023-05-18T13:15:27.936607Z   cluster1-2 failed to sync cluster1-0          |                                             |                                             
+2023-05-18T13:15:27.936646Z   will never receive SST, aborting              |                                             |                                             
+2023-05-18T13:15:28.938590Z   terminated                                    |                                             |                                             
+2023-05-18T13:15:28.938596Z   former SST cancelled                          |                                             |                                             
+2023-05-18T13:15:28Z          crash: got signal 11                          |                                             |                                             
+2023-05-18T13:16:42.748579Z   starting(8.0.31)                              |                                             |                                             
+2023-05-18T13:16:42.752047Z   started(cluster)                              |                                             |                                             
+2023-05-18T13:16:42.753354Z   (repeated x1)recovering gcache                |                                             |                                             
+2023-05-18T13:16:44.038772Z   |                                             starting(8.0.31)                              |                                             
+2023-05-18T13:16:44.047631Z   |                                             started(cluster)                              |                                             
+2023-05-18T13:16:44.048841Z   |                                             (repeated x1)recovering gcache                |                                             
+2023-05-18T13:16:53.022755Z   recovering gcache                             |                                             |                                             
+2023-05-18T13:16:54.404329Z   |                                             recovering gcache                             |                                             
+2023-05-18T13:17:18.945779Z   cluster1-2 joined                             |                                             |                                             
+2023-05-18T13:17:19.313660Z   CLOSED -> OPEN                                |                                             |                                             
+2023-05-18T13:17:19.313949Z   PRIMARY(n=2)                                  |                                             |                                             
+2023-05-18T13:17:19.315225Z   OPEN -> PRIMARY                               |                                             |                                             
+2023-05-18T13:17:19.973975Z   will receive SST                              |                                             |                                             
+2023-05-18T13:17:19.974428Z   cluster1-2 will resync local node             |                                             |                                             
+2023-05-18T13:17:19.974494Z   PRIMARY -> JOINER                             |                                             |                                             
+2023-05-18T13:17:20.792306Z   receiving SST                                 |                                             |                                             
+2023-05-18T13:17:27.183483Z   cluster1-1 joined                             |                                             |                                             
+2023-05-18T13:17:27.183573Z   cluster1-2 joined                             |                                             |                                             
+2023-05-18T13:17:27.183629Z   |                                             cluster1-0 joined                             |                                             
+2023-05-18T13:17:27.183657Z   |                                             cluster1-2 joined                             |                                             
+2023-05-18T13:17:27.190242Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-18T13:17:27.682306Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-18T13:17:27.682491Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-18T13:17:27.683759Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-18T13:17:28.333954Z   |                                             will receive SST                              |                                             
+2023-05-18T13:17:28.334941Z   |                                             cannot find donor                             |                                             
+2023-05-18T13:17:28.335316Z   cluster1-1 cannot find donor                  |                                             |                                             
+2023-05-18T13:17:29.336201Z   |                                             cannot find donor                             |                                             
+2023-05-18T13:17:29.336417Z   cluster1-1 cannot find donor                  |                                             |                                             
+2023-05-18T13:17:30.337512Z   |                                             (repeated x97)cannot find donor               |                                             
+2023-05-18T13:17:30.337818Z   (repeated x97)cluster1-1 cannot find donor    |                                             |                                             
+2023-05-18T13:19:08.457504Z   |                                             cannot find donor                             |                                             
+2023-05-18T13:19:08.457564Z   cluster1-1 cannot find donor                  |                                             |                                             
+2023-05-18T13:19:09.406525Z   |                                             timeout from donor in gtid/keyring stage      |                                             
+2023-05-18T13:19:09.413762Z   |                                             SST error                                     |                                             
+2023-05-18T13:19:09.415563Z   |                                             NON-PRIMARY(n=1)                              |                                             
+2023-05-18T13:19:09.415585Z   cluster1-2 joined                             |                                             |                                             
+2023-05-18T13:19:09.415687Z   cluster1-1 left                               |                                             |                                             
+2023-05-18T13:19:09.415724Z   |                                             PRIMARY -> OPEN                               |                                             
+2023-05-18T13:19:09.415816Z   |                                             OPEN -> CLOSED                                |                                             
+2023-05-18T13:19:09.416006Z   |                                             terminated                                    |                                             
+2023-05-18T13:19:09.416019Z   |                                             former SST cancelled                          |                                             
+2023-05-18T13:19:09Z          |                                             crash: got signal 11                          |                                             
+2023-05-18T13:19:09.417064Z   cluster1-1 left                               |                                             |                                             
+2023-05-18T13:19:09.417210Z   PRIMARY(n=2)                                  |                                             |                                             
+2023-05-18T13:58:30.858063Z   got SST from cluster1-2                       |                                             |                                             
+2023-05-18T13:59:48.769593Z   |                                             starting(8.0.31)                              |                                             
+2023-05-18T13:59:48.776695Z   |                                             started(cluster)                              |                                             
+2023-05-18T13:59:48.777920Z   |                                             (repeated x1)recovering gcache                |                                             
+2023-05-18T13:59:59.654531Z   |                                             recovering gcache                             |                                             
+2023-05-18T14:00:40.229132Z   cluster1-1 joined                             |                                             |                                             
+2023-05-18T14:00:40.229229Z   cluster1-2 joined                             |                                             |                                             
+2023-05-18T14:00:40.229695Z   |                                             cluster1-0 joined                             |                                             
+2023-05-18T14:00:40.229722Z   |                                             cluster1-2 joined                             |                                             
+2023-05-18T14:00:40.230585Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-18T14:00:40.728600Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-18T14:00:40.728799Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-18T14:00:40.730137Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-18T14:00:41.369410Z   |                                             will receive SST                              |                                             
+2023-05-18T14:00:41.369859Z   cluster1-2 will resync cluster1-1             |                                             |                                             
+2023-05-18T14:00:41.370272Z   |                                             cluster1-2 will resync local node             |                                             
+2023-05-18T14:00:41.370311Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-18T14:00:42.195051Z   |                                             receiving SST                                 |                                             
+2023-05-18T14:01:56.927693Z   preparing SST backup                          |                                             |                                             
+2023-05-18T14:02:35.121591Z   wsrep recovery                                |                                             |                                             
+2023-05-18T14:02:35.186713Z   JOINER -> JOINED                              |                                             |                                             
+2023-05-18T14:02:37.197966Z   JOINED -> SYNCED                              |                                             |                                             
+2023-05-18T14:41:35.276414Z   cluster1-2 synced cluster1-1                  |                                             |                                             
+2023-05-18T14:41:35.276839Z   |                                             got SST from cluster1-2                       |                                             
+2023-05-18T14:45:20.989367Z   |                                             preparing SST backup                          |                                             
+2023-05-18T14:46:02.034943Z   |                                             wsrep recovery                                |                                             
+2023-05-18T14:46:02.049460Z   |                                             JOINER -> JOINED                              |                                             
+2023-05-18T14:46:03.716487Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-19T02:00:37.805239Z   garb joined                                   |                                             |                                             
+2023-05-19T02:00:37.805339Z   cluster1-1 joined                             |                                             |                                             
+2023-05-19T02:00:37.805365Z   cluster1-2 joined                             |                                             |                                             
+2023-05-19T02:00:37.805571Z   |                                             garb joined                                   |                                             
+2023-05-19T02:00:37.805636Z   |                                             cluster1-0 joined                             |                                             
+2023-05-19T02:00:37.805652Z   |                                             cluster1-2 joined                             |                                             
+2023-05-19T02:00:37.806917Z   PRIMARY(n=4)                                  |                                             |                                             
+2023-05-19T02:00:37.806923Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-19T02:00:38.271977Z   cluster1-2 will resync garb                   |                                             |                                             
+2023-05-19T02:00:38.272185Z   |                                             cluster1-2 will resync garb                   |                                             
+2023-05-19T02:44:49.991765Z   cluster1-2 synced garb                        |                                             |                                             
+2023-05-19T02:44:49.991801Z   |                                             cluster1-2 synced garb                        |                                             
+2023-05-19T02:44:52.007874Z   cluster1-1 joined                             |                                             |                                             
+2023-05-19T02:44:52.007893Z   cluster1-2 joined                             |                                             |                                             
+2023-05-19T02:44:52.007915Z   garb left                                     |                                             |                                             
+2023-05-19T02:44:52.009049Z   |                                             cluster1-0 joined                             |                                             
+2023-05-19T02:44:52.009063Z   |                                             cluster1-2 joined                             |                                             
+2023-05-19T02:44:52.009071Z   |                                             garb left                                     |                                             
+2023-05-19T02:44:52.010059Z   |                                             garb left                                     |                                             
+2023-05-19T02:44:52.010070Z   garb left                                     |                                             |                                             
+2023-05-19T02:44:52.010131Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-19T02:44:52.010155Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-19T02:50:07.120064Z   received shutdown                             |                                             |                                             
+2023-05-19T02:50:17.122926Z   |                                             cluster1-2 joined                             |                                             
+2023-05-19T02:50:17.123053Z   |                                             cluster1-0 left                               |                                             
+2023-05-19T02:50:17.123274Z   NON-PRIMARY(n=1)                              |                                             |                                             
+2023-05-19T02:50:17.123461Z   SYNCED -> OPEN                                |                                             |                                             
+2023-05-19T02:50:17.123560Z   OPEN -> CLOSED                                |                                             |                                             
+2023-05-19T02:50:17.124167Z   |                                             cluster1-0 left                               |                                             
+2023-05-19T02:50:17.124228Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-19T03:00:44.215170Z   starting(8.0.31)                              |                                             |                                             
+2023-05-19T03:00:44.218802Z   started(cluster)                              |                                             |                                             
+2023-05-19T03:00:44.219956Z   recovering gcache                             |                                             |                                             
+2023-05-19T03:00:47.302675Z   recovering gcache                             |                                             |                                             
+2023-05-19T03:00:47.486695Z   |                                             cluster1-0 joined                             |                                             
+2023-05-19T03:00:47.486729Z   |                                             cluster1-2 joined                             |                                             
+2023-05-19T03:00:47.486876Z   cluster1-1 joined                             |                                             |                                             
+2023-05-19T03:00:47.486901Z   cluster1-2 joined                             |                                             |                                             
+2023-05-19T03:00:47.487789Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-19T03:00:47.887639Z   CLOSED -> OPEN                                |                                             |                                             
+2023-05-19T03:00:47.887884Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-19T03:00:47.890175Z   OPEN -> PRIMARY                               |                                             |                                             
+2023-05-19T03:00:48.533857Z   will receive SST                              |                                             |                                             
+2023-05-19T03:00:48.534320Z   |                                             local node will resync cluster1-0             |                                             
+2023-05-19T03:00:48.534355Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-19T03:00:48.534431Z   cluster1-1 will resync local node             |                                             |                                             
+2023-05-19T03:00:48.534500Z   PRIMARY -> JOINER                             |                                             |                                             
+2023-05-19T03:00:48.540245Z   |                                             IST to cluster1-0(seqno:666332)               |                                             
+2023-05-19T03:00:49.352397Z   receiving SST                                 |                                             |                                             
+2023-05-19T03:00:59.993379Z   |                                             SST to cluster1-0                             |                                             
+2023-05-19T03:39:14.162296Z   |                                             finished sending IST to cluster1-0            |                                             
+2023-05-19T03:39:14.162325Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-19T03:39:14.162825Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-19T03:39:14.162862Z   got SST from cluster1-1                       |                                             |                                             
+2023-05-19T03:42:34.536980Z   preparing SST backup                          |                                             |                                             
+2023-05-19T03:43:12.409922Z   wsrep recovery                                |                                             |                                             
+2023-05-19T03:43:12.417929Z   JOINER -> JOINED                              |                                             |                                             
+2023-05-19T03:43:13.728480Z   JOINED -> SYNCED                              |                                             |                                             
+2023-05-20T02:00:39.121171Z   garb joined                                   |                                             |                                             
+2023-05-20T02:00:39.121232Z   cluster1-1 joined                             |                                             |                                             
+2023-05-20T02:00:39.121242Z   cluster1-2 joined                             |                                             |                                             
+2023-05-20T02:00:39.121260Z   |                                             garb joined                                   |                                             
+2023-05-20T02:00:39.121310Z   |                                             cluster1-0 joined                             |                                             
+2023-05-20T02:00:39.121318Z   |                                             cluster1-2 joined                             |                                             
+2023-05-20T02:00:40.123638Z   PRIMARY(n=4)                                  |                                             |                                             
+2023-05-20T02:00:40.123709Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-20T02:00:40.146578Z   cluster1-2 will resync garb                   |                                             |                                             
+2023-05-20T02:00:40.146782Z   |                                             cluster1-2 will resync garb                   |                                             
+2023-05-20T02:42:44.902691Z   |                                             cluster1-2 synced garb                        |                                             
+2023-05-20T02:42:44.902770Z   cluster1-2 synced garb                        |                                             |                                             
+2023-05-20T02:42:47.269884Z   |                                             cluster1-0 joined                             |                                             
+2023-05-20T02:42:47.269976Z   |                                             cluster1-2 joined                             |                                             
+2023-05-20T02:42:47.270003Z   |                                             garb left                                     |                                             
+2023-05-20T02:42:47.270306Z   cluster1-1 joined                             |                                             |                                             
+2023-05-20T02:42:47.270430Z   cluster1-2 joined                             |                                             |                                             
+2023-05-20T02:42:47.270476Z   garb left                                     |                                             |                                             
+2023-05-20T02:42:47.271539Z   garb left                                     |                                             |                                             
+2023-05-20T02:42:47.271582Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-20T02:42:47.271594Z   |                                             garb left                                     |                                             
+2023-05-20T02:42:47.271625Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-21T00:53:38.824876Z   cluster1-1 joined                             |                                             |                                             
+2023-05-21T00:53:38.824946Z   |                                             cluster1-0 joined                             |                                             
+2023-05-21T00:53:38.825112Z   |                                             cluster1-2 left                               |                                             
+2023-05-21T00:53:38.825142Z   cluster1-2 left                               |                                             |                                             
+2023-05-21T00:53:38.826164Z   cluster1-2 left                               |                                             |                                             
+2023-05-21T00:53:38.826309Z   PRIMARY(n=2)                                  |                                             |                                             
+2023-05-21T00:53:38.826696Z   |                                             cluster1-2 left                               |                                             
+2023-05-21T00:53:38.826836Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-21T00:54:28.830096Z   cluster1-2 joined                             |                                             |                                             
+2023-05-21T00:54:28.830142Z   |                                             cluster1-2 joined                             |                                             
+2023-05-21T00:54:28.830173Z   cluster1-1 joined                             |                                             |                                             
+2023-05-21T00:54:28.830199Z   |                                             cluster1-0 joined                             |                                             
+2023-05-21T00:54:28.831682Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-21T00:54:28.831694Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-21T00:54:29.949424Z   cluster1-1 will resync cluster1-2             |                                             |                                             
+2023-05-21T00:54:29.949513Z   |                                             local node will resync cluster1-2             |                                             
+2023-05-21T00:54:29.949596Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-21T00:54:29.963765Z   |                                             IST to cluster1-2(seqno:2503896)              |                                             
+2023-05-21T00:54:30.390475Z   |                                             IST will be used                              |                                             
+2023-05-21T00:54:31.413573Z   cluster1-1 synced cluster1-2                  |                                             |                                             
+2023-05-21T00:54:31.413660Z   |                                             finished sending IST to cluster1-2            |                                             
+2023-05-21T00:54:31.413740Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-21T00:54:31.414346Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-21T00:54:43.888619Z   |                                             received shutdown                             |                                             
+2023-05-21T00:54:53.891429Z   cluster1-2 joined                             |                                             |                                             
+2023-05-21T00:54:53.891553Z   cluster1-1 left                               |                                             |                                             
+2023-05-21T00:54:53.891588Z   |                                             NON-PRIMARY(n=1)                              |                                             
+2023-05-21T00:54:53.891740Z   |                                             SYNCED -> OPEN                                |                                             
+2023-05-21T00:54:53.891837Z   |                                             OPEN -> CLOSED                                |                                             
+2023-05-21T00:54:53.893441Z   cluster1-1 left                               |                                             |                                             
+2023-05-21T00:54:53.893497Z   PRIMARY(n=2)                                  |                                             |                                             
+2023-05-21T00:55:15.214858Z   |                                             shutdown complete                             |                                             
+2023-05-21T00:55:33.793456Z   |                                             starting(8.0.31)                              |                                             
+2023-05-21T00:55:33.802082Z   |                                             started(cluster)                              |                                             
+2023-05-21T00:55:33.803486Z   |                                             recovering gcache                             |                                             
+2023-05-21T00:55:34.512593Z   |                                             recovering gcache                             |                                             
+                                                                            10.16.27.98                                                                                 
+                                                                            (node ip)                                                                                   
+                                                                             V                                                                                          
+                                                                            10.16.27.149                                                                                
+2023-05-21T00:55:35.115170Z   cluster1-2 joined                             |                                             |                                             
+2023-05-21T00:55:35.115253Z   cluster1-1 joined                             |                                             |                                             
+2023-05-21T00:55:35.115506Z   |                                             cluster1-2 joined                             |                                             
+2023-05-21T00:55:35.115531Z   |                                             cluster1-0 joined                             |                                             
+2023-05-21T00:55:35.116524Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-21T00:55:35.614653Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-21T00:55:35.614852Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-21T00:55:35.615886Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-21T00:55:36.251244Z   |                                             will receive IST(seqno:2504601)               |                                             
+2023-05-21T00:55:36.252039Z   local node will resync cluster1-1             |                                             |                                             
+2023-05-21T00:55:36.252124Z   SYNCED -> DONOR                               |                                             |                                             
+2023-05-21T00:55:36.252155Z   |                                             cluster1-0 will resync local node             |                                             
+2023-05-21T00:55:36.252188Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-21T00:55:36.266261Z   IST to cluster1-1(seqno:2504601)              |                                             |                                             
+2023-05-21T00:55:36.710320Z   IST will be used                              |                                             |                                             
+2023-05-21T00:55:37.727377Z   finished sending IST to cluster1-1            |                                             |                                             
+2023-05-21T00:55:37.727418Z   DESYNCED -> JOINED                            |                                             |                                             
+2023-05-21T00:55:37.727472Z   |                                             got IST from cluster1-0                       |                                             
+2023-05-21T00:55:37.727951Z   JOINED -> SYNCED                              |                                             |                                             
+2023-05-21T00:55:45.002685Z   |                                             wsrep recovery                                |                                             
+2023-05-21T00:55:45.288182Z   |                                             IST received(seqno:2504601)                   |                                             
+2023-05-21T00:55:45.288875Z   |                                             JOINER -> JOINED                              |                                             
+2023-05-21T00:55:45.289507Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-21T00:55:54.030991Z   received shutdown                             |                                             |                                             
+2023-05-21T00:56:04.033823Z   |                                             cluster1-2 joined                             |                                             
+2023-05-21T00:56:04.033845Z   NON-PRIMARY(n=1)                              |                                             |                                             
+2023-05-21T00:56:04.033955Z   |                                             cluster1-0 left                               |                                             
+2023-05-21T00:56:04.034007Z   SYNCED -> OPEN                                |                                             |                                             
+2023-05-21T00:56:04.034129Z   OPEN -> CLOSED                                |                                             |                                             
+2023-05-21T00:56:04.035594Z   |                                             cluster1-0 left                               |                                             
+2023-05-21T00:56:04.035622Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-21T00:56:31.600421Z   shutdown complete                             |                                             |                                             
+2023-05-21T00:56:51.547391Z   starting(8.0.31)                              |                                             |                                             
+2023-05-21T00:56:51.551022Z   started(cluster)                              |                                             |                                             
+2023-05-21T00:56:51.552128Z   recovering gcache                             |                                             |                                             
+2023-05-21T00:56:52.187726Z   recovering gcache                             |                                             |                                             
+                              10.16.29.188                                                                                                                              
+                              (node ip)                                                                                                                                 
+                               V                                                                                                                                        
+                              10.16.29.14                                                                                                                               
+2023-05-21T00:56:52.766452Z   cluster1-2 joined                             |                                             |                                             
+2023-05-21T00:56:52.766462Z   cluster1-1 joined                             |                                             |                                             
+2023-05-21T00:56:52.766616Z   |                                             cluster1-2 joined                             |                                             
+2023-05-21T00:56:52.766720Z   |                                             cluster1-0 joined                             |                                             
+2023-05-21T00:56:52.768230Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-21T00:56:53.265778Z   CLOSED -> OPEN                                |                                             |                                             
+2023-05-21T00:56:53.265935Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-21T00:56:53.267175Z   OPEN -> PRIMARY                               |                                             |                                             
+2023-05-21T00:56:53.820470Z   will receive IST(seqno:2505347)               |                                             |                                             
+2023-05-21T00:56:53.821936Z   cluster1-1 will resync local node             |                                             |                                             
+2023-05-21T00:56:53.822007Z   PRIMARY -> JOINER                             |                                             |                                             
+2023-05-21T00:56:53.822068Z   |                                             local node will resync cluster1-0             |                                             
+2023-05-21T00:56:53.822153Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-21T00:56:53.840165Z   |                                             IST to cluster1-0(seqno:2505347)              |                                             
+2023-05-21T00:56:54.243247Z   |                                             IST will be used                              |                                             
+2023-05-21T00:56:55.263953Z   |                                             finished sending IST to cluster1-0            |                                             
+2023-05-21T00:56:55.264015Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-21T00:56:55.264113Z   got IST from cluster1-1                       |                                             |                                             
+2023-05-21T00:56:55.264876Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-21T00:57:01.549618Z   wsrep recovery                                |                                             |                                             
+2023-05-21T00:57:01.890216Z   IST received(seqno:2505347)                   |                                             |                                             
+2023-05-21T00:57:01.891209Z   JOINER -> JOINED                              |                                             |                                             
+2023-05-21T00:57:01.891813Z   JOINED -> SYNCED                              |                                             |                                             
+2023-05-21T01:19:12.465768Z   |                                             cluster1-0 joined                             |                                             
+2023-05-21T01:19:12.465839Z   cluster1-1 joined                             |                                             |                                             
+2023-05-21T01:19:12.465854Z   |                                             cluster1-2 left                               |                                             
+2023-05-21T01:19:12.465991Z   cluster1-2 left                               |                                             |                                             
+2023-05-21T01:19:12.467253Z   |                                             cluster1-2 left                               |                                             
+2023-05-21T01:19:12.467317Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-21T01:19:12.467691Z   cluster1-2 left                               |                                             |                                             
+2023-05-21T01:19:12.467846Z   PRIMARY(n=2)                                  |                                             |                                             
+2023-05-21T01:20:08.164581Z   cluster1-1 joined                             |                                             |                                             
+2023-05-21T01:20:08.164607Z   |                                             cluster1-0 joined                             |                                             
+2023-05-21T01:20:08.164666Z   cluster1-2 joined                             |                                             |                                             
+2023-05-21T01:20:08.164706Z   |                                             cluster1-2 joined                             |                                             
+2023-05-21T01:20:08.166058Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-21T01:20:08.166139Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-21T01:20:09.397398Z   cluster1-1 will resync cluster1-2             |                                             |                                             
+2023-05-21T01:20:09.397424Z   |                                             local node will resync cluster1-2             |                                             
+2023-05-21T01:20:09.397514Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-21T01:20:09.409969Z   |                                             IST to cluster1-2(seqno:2521738)              |                                             
+2023-05-21T01:20:09.824497Z   |                                             IST will be used                              |                                             
+2023-05-21T01:20:10.843020Z   cluster1-1 synced cluster1-2                  |                                             |                                             
+2023-05-21T01:20:10.843044Z   |                                             finished sending IST to cluster1-2            |                                             
+2023-05-21T01:20:10.843128Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-21T01:20:10.843767Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-21T01:20:22.596139Z   |                                             received shutdown                             |                                             
+2023-05-21T01:20:32.598567Z   cluster1-2 joined                             |                                             |                                             
+2023-05-21T01:20:32.598720Z   |                                             NON-PRIMARY(n=1)                              |                                             
+2023-05-21T01:20:32.598723Z   cluster1-1 left                               |                                             |                                             
+2023-05-21T01:20:32.598878Z   |                                             SYNCED -> OPEN                                |                                             
+2023-05-21T01:20:32.598980Z   |                                             OPEN -> CLOSED                                |                                             
+2023-05-21T01:20:32.599998Z   cluster1-1 left                               |                                             |                                             
+2023-05-21T01:20:32.600066Z   PRIMARY(n=2)                                  |                                             |                                             
+2023-05-21T01:20:52.869609Z   |                                             shutdown complete                             |                                             
+2023-05-21T01:21:11.409415Z   |                                             starting(8.0.31)                              |                                             
+2023-05-21T01:21:11.419588Z   |                                             started(cluster)                              |                                             
+2023-05-21T01:21:11.421017Z   |                                             recovering gcache                             |                                             
+2023-05-21T01:21:12.148458Z   |                                             recovering gcache                             |                                             
+                                                                            10.16.27.149                                                                                
+                                                                            (node ip)                                                                                   
+                                                                             V                                                                                          
+                                                                            10.16.27.203                                                                                
+2023-05-21T01:21:12.754120Z   cluster1-2 joined                             |                                             |                                             
+2023-05-21T01:21:12.754144Z   |                                             cluster1-0 joined                             |                                             
+2023-05-21T01:21:12.754158Z   |                                             cluster1-2 joined                             |                                             
+2023-05-21T01:21:12.754192Z   cluster1-1 joined                             |                                             |                                             
+2023-05-21T01:21:12.755542Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-21T01:21:13.253595Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-21T01:21:13.253786Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-21T01:21:13.254822Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-21T01:21:13.830568Z   |                                             will receive IST(seqno:2522685)               |                                             
+2023-05-21T01:21:13.831224Z   cluster1-2 will resync cluster1-1             |                                             |                                             
+2023-05-21T01:21:13.831364Z   |                                             cluster1-2 will resync local node             |                                             
+2023-05-21T01:21:13.831439Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-21T01:21:15.333851Z   cluster1-2 synced cluster1-1                  |                                             |                                             
+2023-05-21T01:21:15.333858Z   |                                             got IST from cluster1-2                       |                                             
+2023-05-21T01:21:22.288131Z   |                                             wsrep recovery                                |                                             
+2023-05-21T01:21:22.898839Z   |                                             IST received(seqno:2522685)                   |                                             
+2023-05-21T01:21:22.899619Z   |                                             JOINER -> JOINED                              |                                             
+2023-05-21T01:21:23.029024Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-21T01:21:33.487761Z   received shutdown                             |                                             |                                             
+2023-05-21T01:21:43.490218Z   |                                             cluster1-2 joined                             |                                             
+2023-05-21T01:21:43.490347Z   NON-PRIMARY(n=1)                              |                                             |                                             
+2023-05-21T01:21:43.490351Z   |                                             cluster1-0 left                               |                                             
+2023-05-21T01:21:43.490461Z   SYNCED -> OPEN                                |                                             |                                             
+2023-05-21T01:21:43.490528Z   OPEN -> CLOSED                                |                                             |                                             
+2023-05-21T01:21:43.492282Z   |                                             cluster1-0 left                               |                                             
+2023-05-21T01:21:43.492343Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-21T01:22:09.957644Z   shutdown complete                             |                                             |                                             
+2023-05-21T01:22:28.363578Z   starting(8.0.31)                              |                                             |                                             
+2023-05-21T01:22:28.367473Z   started(cluster)                              |                                             |                                             
+2023-05-21T01:22:28.368588Z   recovering gcache                             |                                             |                                             
+2023-05-21T01:22:29.021216Z   recovering gcache                             |                                             |                                             
+                              10.16.29.14                                                                                                                               
+                              (node ip)                                                                                                                                 
+                               V                                                                                                                                        
+                              10.16.29.241                                                                                                                              
+2023-05-21T01:22:29.152458Z   |                                             cluster1-0 joined                             |                                             
+2023-05-21T01:22:29.152542Z   |                                             cluster1-2 joined                             |                                             
+2023-05-21T01:22:29.152837Z   cluster1-2 joined                             |                                             |                                             
+2023-05-21T01:22:29.152861Z   cluster1-1 joined                             |                                             |                                             
+2023-05-21T01:22:29.153988Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-21T01:22:29.618317Z   CLOSED -> OPEN                                |                                             |                                             
+2023-05-21T01:22:29.618481Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-21T01:22:29.620709Z   OPEN -> PRIMARY                               |                                             |                                             
+2023-05-21T01:22:30.266257Z   will receive IST(seqno:2523752)               |                                             |                                             
+2023-05-21T01:22:30.267198Z   cluster1-1 will resync local node             |                                             |                                             
+2023-05-21T01:22:30.267264Z   |                                             local node will resync cluster1-0             |                                             
+2023-05-21T01:22:30.267267Z   PRIMARY -> JOINER                             |                                             |                                             
+2023-05-21T01:22:30.267342Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-21T01:22:30.284151Z   |                                             IST to cluster1-0(seqno:2523752)              |                                             
+2023-05-21T01:22:30.690731Z   |                                             IST will be used                              |                                             
+2023-05-21T01:22:31.707614Z   got IST from cluster1-1                       |                                             |                                             
+2023-05-21T01:22:31.707646Z   |                                             finished sending IST to cluster1-0            |                                             
+2023-05-21T01:22:31.707711Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-21T01:22:31.708193Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-21T01:22:38.451890Z   wsrep recovery                                |                                             |                                             
+2023-05-21T01:22:38.880335Z   IST received(seqno:2523752)                   |                                             |                                             
+2023-05-21T01:22:38.882383Z   JOINER -> JOINED                              |                                             |                                             
+2023-05-21T01:22:38.883539Z   JOINED -> SYNCED                              |                                             |                                             
+2023-05-21T03:00:20.427423Z   |                                             cluster1-0 joined                             |                                             
+2023-05-21T03:00:20.427494Z   |                                             garb joined                                   |                                             
+2023-05-21T03:00:20.427533Z   |                                             cluster1-2 joined                             |                                             
+2023-05-21T03:00:20.427567Z   garb joined                                   |                                             |                                             
+2023-05-21T03:00:20.427614Z   cluster1-2 joined                             |                                             |                                             
+2023-05-21T03:00:20.427622Z   cluster1-1 joined                             |                                             |                                             
+2023-05-21T03:00:20.429353Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-21T03:00:20.429883Z   PRIMARY(n=4)                                  |                                             |                                             
+2023-05-21T03:00:20.928257Z   |                                             cluster1-2 will resync garb                   |                                             
+2023-05-21T03:00:20.928631Z   cluster1-2 will resync garb                   |                                             |                                             
+2023-05-21T03:42:29.775490Z   |                                             cluster1-2 synced garb                        |                                             
+2023-05-21T03:42:29.776133Z   cluster1-2 synced garb                        |                                             |                                             
+2023-05-21T03:42:31.791064Z   |                                             cluster1-0 joined                             |                                             
+2023-05-21T03:42:31.791148Z   |                                             cluster1-2 joined                             |                                             
+2023-05-21T03:42:31.791208Z   |                                             garb left                                     |                                             
+2023-05-21T03:42:31.791969Z   cluster1-2 joined                             |                                             |                                             
+2023-05-21T03:42:31.792056Z   cluster1-1 joined                             |                                             |                                             
+2023-05-21T03:42:31.792084Z   garb left                                     |                                             |                                             
+2023-05-21T03:42:31.792896Z   |                                             garb left                                     |                                             
+2023-05-21T03:42:31.792966Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-21T03:42:31.793522Z   garb left                                     |                                             |                                             
+2023-05-21T03:42:31.793616Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-22T03:00:18.103104Z   cluster1-2 joined                             |                                             |                                             
+2023-05-22T03:00:18.103142Z   cluster1-1 joined                             |                                             |                                             
+2023-05-22T03:00:18.103149Z   garb joined                                   |                                             |                                             
+2023-05-22T03:00:18.103256Z   |                                             cluster1-0 joined                             |                                             
+2023-05-22T03:00:18.103420Z   |                                             cluster1-2 joined                             |                                             
+2023-05-22T03:00:18.103448Z   |                                             garb joined                                   |                                             
+2023-05-22T03:00:18.104955Z   PRIMARY(n=4)                                  |                                             |                                             
+2023-05-22T03:00:18.105186Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-22T03:00:18.604335Z   cluster1-2 will resync garb                   |                                             |                                             
+2023-05-22T03:00:18.604404Z   |                                             cluster1-2 will resync garb                   |                                             
+2023-05-22T03:42:17.472102Z   |                                             cluster1-2 synced garb                        |                                             
+2023-05-22T03:42:17.472302Z   cluster1-2 synced garb                        |                                             |                                             
+2023-05-22T03:42:19.981973Z   cluster1-2 joined                             |                                             |                                             
+2023-05-22T03:42:19.982069Z   cluster1-1 joined                             |                                             |                                             
+2023-05-22T03:42:19.982070Z   |                                             cluster1-0 joined                             |                                             
+2023-05-22T03:42:19.982096Z   garb left                                     |                                             |                                             
+2023-05-22T03:42:19.982108Z   |                                             cluster1-2 joined                             |                                             
+2023-05-22T03:42:19.982132Z   |                                             garb left                                     |                                             
+2023-05-22T03:42:19.986126Z   |                                             garb left                                     |                                             
+2023-05-22T03:42:19.986197Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-22T03:42:19.986489Z   garb left                                     |                                             |                                             
+2023-05-22T03:42:19.986558Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-22T05:00:38.651931Z   garb joined                                   |                                             |                                             
+2023-05-22T05:00:38.651990Z   |                                             cluster1-0 joined                             |                                             
+2023-05-22T05:00:38.652028Z   cluster1-2 joined                             |                                             |                                             
+2023-05-22T05:00:38.652053Z   cluster1-1 joined                             |                                             |                                             
+2023-05-22T05:00:38.652099Z   |                                             garb joined                                   |                                             
+2023-05-22T05:00:38.652124Z   |                                             cluster1-2 joined                             |                                             
+2023-05-22T05:00:38.654074Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-22T05:00:38.654180Z   PRIMARY(n=4)                                  |                                             |                                             
+2023-05-22T05:00:39.152013Z   cluster1-2 will resync garb                   |                                             |                                             
+2023-05-22T05:00:39.152105Z   |                                             cluster1-2 will resync garb                   |                                             
+2023-05-22T05:42:27.093203Z   cluster1-2 synced garb                        |                                             |                                             
+2023-05-22T05:42:27.093298Z   |                                             cluster1-2 synced garb                        |                                             
+2023-05-22T05:42:29.265224Z   cluster1-2 joined                             |                                             |                                             
+2023-05-22T05:42:29.265242Z   cluster1-1 joined                             |                                             |                                             
+2023-05-22T05:42:29.265253Z   garb left                                     |                                             |                                             
+2023-05-22T05:42:29.265680Z   |                                             cluster1-0 joined                             |                                             
+2023-05-22T05:42:29.265724Z   |                                             cluster1-2 joined                             |                                             
+2023-05-22T05:42:29.265751Z   |                                             garb left                                     |                                             
+2023-05-22T05:42:29.266637Z   garb left                                     |                                             |                                             
+2023-05-22T05:42:29.266704Z   |                                             garb left                                     |                                             
+2023-05-22T05:42:29.266717Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-22T05:42:29.266780Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-23T03:00:20.329378Z   |                                             cluster1-0 joined                             |                                             
+2023-05-23T03:00:20.329435Z   garb joined                                   |                                             |                                             
+2023-05-23T03:00:20.329467Z   |                                             garb joined                                   |                                             
+2023-05-23T03:00:20.329491Z   |                                             cluster1-2 joined                             |                                             
+2023-05-23T03:00:20.329519Z   cluster1-2 joined                             |                                             |                                             
+2023-05-23T03:00:20.329543Z   cluster1-1 joined                             |                                             |                                             
+2023-05-23T03:00:20.330917Z   PRIMARY(n=4)                                  |                                             |                                             
+2023-05-23T03:00:20.330937Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-23T03:00:20.830202Z   |                                             cluster1-2 will resync garb                   |                                             
+2023-05-23T03:00:20.830302Z   cluster1-2 will resync garb                   |                                             |                                             
+2023-05-23T03:42:33.009984Z   cluster1-2 synced garb                        |                                             |                                             
+2023-05-23T03:42:33.010045Z   |                                             cluster1-2 synced garb                        |                                             
+2023-05-23T03:42:35.008485Z   cluster1-2 joined                             |                                             |                                             
+2023-05-23T03:42:35.008497Z   cluster1-1 joined                             |                                             |                                             
+2023-05-23T03:42:35.008504Z   garb left                                     |                                             |                                             
+2023-05-23T03:42:35.009285Z   |                                             cluster1-0 joined                             |                                             
+2023-05-23T03:42:35.009336Z   |                                             cluster1-2 joined                             |                                             
+2023-05-23T03:42:35.009360Z   |                                             garb left                                     |                                             
+2023-05-23T03:42:35.010350Z   garb left                                     |                                             |                                             
+2023-05-23T03:42:35.010383Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-23T03:42:35.024977Z   |                                             garb left                                     |                                             
+2023-05-23T03:42:35.025045Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-24T03:00:21.217120Z   |                                             cluster1-0 joined                             |                                             
+2023-05-24T03:00:21.217214Z   |                                             garb joined                                   |                                             
+2023-05-24T03:00:21.217238Z   |                                             cluster1-2 joined                             |                                             
+2023-05-24T03:00:21.217414Z   garb joined                                   |                                             |                                             
+2023-05-24T03:00:21.217519Z   cluster1-2 joined                             |                                             |                                             
+2023-05-24T03:00:21.217546Z   cluster1-1 joined                             |                                             |                                             
+2023-05-24T03:00:21.218871Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-24T03:00:21.218947Z   PRIMARY(n=4)                                  |                                             |                                             
+2023-05-24T03:00:21.717835Z   |                                             cluster1-2 will resync garb                   |                                             
+2023-05-24T03:00:21.718081Z   cluster1-2 will resync garb                   |                                             |                                             
+2023-05-24T03:45:11.980179Z   cluster1-2 synced garb                        |                                             |                                             
+2023-05-24T03:45:11.980189Z   |                                             cluster1-2 synced garb                        |                                             
+2023-05-24T03:45:14.589728Z   cluster1-2 joined                             |                                             |                                             
+2023-05-24T03:45:14.589729Z   |                                             cluster1-0 joined                             |                                             
+2023-05-24T03:45:14.589749Z   cluster1-1 joined                             |                                             |                                             
+2023-05-24T03:45:14.589763Z   garb left                                     |                                             |                                             
+2023-05-24T03:45:14.589767Z   |                                             cluster1-2 joined                             |                                             
+2023-05-24T03:45:14.589789Z   |                                             garb left                                     |                                             
+2023-05-24T03:45:14.591467Z   |                                             garb left                                     |                                             
+2023-05-24T03:45:14.591482Z   garb left                                     |                                             |                                             
+2023-05-24T03:45:14.591503Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-24T03:45:14.591557Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-24T08:21:16.472713Z   |                                             cluster1-0 joined                             |                                             
+2023-05-24T08:21:16.472872Z   cluster1-1 joined                             |                                             |                                             
+2023-05-24T08:21:16.472985Z   cluster1-2 left                               |                                             |                                             
+2023-05-24T08:21:16.474136Z   |                                             cluster1-2 left                               |                                             
+2023-05-24T08:21:16.475291Z   cluster1-2 left                               |                                             |                                             
+2023-05-24T08:21:16.475463Z   |                                             cluster1-2 left                               |                                             
+2023-05-24T08:21:16.475483Z   PRIMARY(n=2)                                  |                                             |                                             
+2023-05-24T08:21:16.475528Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-24T08:22:01.125588Z   |                                             cluster1-0 joined                             |                                             
+2023-05-24T08:22:01.125674Z   |                                             cluster1-2 joined                             |                                             
+2023-05-24T08:22:01.125862Z   cluster1-2 joined                             |                                             |                                             
+2023-05-24T08:22:01.125950Z   cluster1-1 joined                             |                                             |                                             
+2023-05-24T08:22:01.127244Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-24T08:22:01.127387Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-24T08:22:02.311565Z   |                                             local node will resync cluster1-2             |                                             
+2023-05-24T08:22:02.311647Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-24T08:22:02.311766Z   cluster1-1 will resync cluster1-2             |                                             |                                             
+2023-05-24T08:22:02.325257Z   |                                             IST to cluster1-2(seqno:5144165)              |                                             
+2023-05-24T08:22:02.748089Z   |                                             IST will be used                              |                                             
+2023-05-24T08:22:03.764239Z   |                                             finished sending IST to cluster1-2            |                                             
+2023-05-24T08:22:03.764294Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-24T08:22:03.764584Z   cluster1-1 synced cluster1-2                  |                                             |                                             
+2023-05-24T08:22:03.764839Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-24T08:32:37.472913Z   received shutdown                             |                                             |                                             
+2023-05-24T08:42:31.487071Z   |                                             cluster1-2 joined                             |                                             
+2023-05-24T08:42:31.487146Z   |                                             cluster1-0 left                               |                                             
+2023-05-24T08:42:31.487732Z   NON-PRIMARY(n=1)                              |                                             |                                             
+2023-05-24T08:42:31.487796Z   SYNCED -> OPEN                                |                                             |                                             
+2023-05-24T08:42:31.487828Z   OPEN -> CLOSED                                |                                             |                                             
+2023-05-24T08:42:31.488231Z   |                                             cluster1-0 left                               |                                             
+2023-05-24T08:42:31.488252Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-24T08:43:00.498377Z   starting(8.0.31)                              |                                             |                                             
+2023-05-24T08:43:00.504399Z   started(cluster)                              |                                             |                                             
+2023-05-24T08:43:00.505651Z   recovering gcache                             |                                             |                                             
+2023-05-24T08:43:01.141047Z   recovering gcache                             |                                             |                                             
+2023-05-24T08:43:01.386744Z   |                                             cluster1-0 joined                             |                                             
+2023-05-24T08:43:01.386792Z   |                                             cluster1-2 joined                             |                                             
+2023-05-24T08:43:01.387024Z   cluster1-2 joined                             |                                             |                                             
+2023-05-24T08:43:01.387034Z   cluster1-1 joined                             |                                             |                                             
+2023-05-24T08:43:01.387588Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-24T08:43:01.712895Z   CLOSED -> OPEN                                |                                             |                                             
+2023-05-24T08:43:01.713165Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-24T08:43:01.714718Z   OPEN -> PRIMARY                               |                                             |                                             
+2023-05-24T08:43:02.417808Z   will receive IST(seqno:5153041)               |                                             |                                             
+2023-05-24T08:43:02.418439Z   |                                             local node will resync cluster1-0             |                                             
+2023-05-24T08:43:02.418491Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-24T08:43:02.418682Z   cluster1-1 will resync local node             |                                             |                                             
+2023-05-24T08:43:02.418709Z   PRIMARY -> JOINER                             |                                             |                                             
+2023-05-24T08:43:02.432861Z   |                                             IST to cluster1-0(seqno:5153041)              |                                             
+2023-05-24T08:43:02.859610Z   |                                             IST will be used                              |                                             
+2023-05-24T08:43:03.879518Z   |                                             finished sending IST to cluster1-0            |                                             
+2023-05-24T08:43:03.879590Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-24T08:43:03.879884Z   got IST from cluster1-1                       |                                             |                                             
+2023-05-24T08:43:03.880269Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-24T08:43:11.252798Z   wsrep recovery                                |                                             |                                             
+2023-05-24T08:43:11.779173Z   IST received(seqno:5153041)                   |                                             |                                             
+2023-05-24T08:43:11.779858Z   JOINER -> JOINED                              |                                             |                                             
+2023-05-24T08:43:11.780506Z   JOINED -> SYNCED                              |                                             |                                             
+2023-05-24T08:51:31.191288Z   (repeated x14127)too many connections         |                                             |                                             
+2023-05-24T08:54:25.857147Z   |                                             (repeated x1236)too many connections          |                                             
+2023-05-24T08:55:40.532333Z   |                                             too many connections                          |                                             
+2023-05-24T08:55:40.543569Z   too many connections                          |                                             |                                             
+2023-05-24T08:55:40.583937Z   |                                             (repeated x54)too many connections            |                                             
+2023-05-24T08:55:40.589334Z   (repeated x139)too many connections           |                                             |                                             
+2023-05-24T08:55:42.449249Z   too many connections                          |                                             |                                             
+2023-05-24T08:55:42.462964Z   cluster1-2 suspected to be down               |                                             |                                             
+2023-05-24T08:55:42.473404Z   (repeated x87)too many connections            |                                             |                                             
+2023-05-24T08:55:42.934639Z   |                                             too many connections                          |                                             
+2023-05-24T08:55:42.963220Z   |                                             cluster1-2 suspected to be down               |                                             
+2023-05-24T08:55:42.982146Z   |                                             (repeated x5)too many connections             |                                             
+2023-05-24T08:55:43.411608Z   |                                             too many connections                          |                                             
+2023-05-24T08:55:43.460587Z   too many connections                          |                                             |                                             
+2023-05-24T08:55:43.463902Z   |                                             cluster1-0 joined                             |                                             
+2023-05-24T08:55:43.464038Z   cluster1-1 joined                             |                                             |                                             
+2023-05-24T08:55:43.464983Z   cluster1-2 left                               |                                             |                                             
+2023-05-24T08:55:43.465054Z   PRIMARY(n=2)                                  |                                             |                                             
+2023-05-24T08:55:43.466667Z   |                                             cluster1-2 left                               |                                             
+2023-05-24T08:55:43.466742Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-24T08:55:43.478867Z   (repeated x2618)too many connections          |                                             |                                             
+2023-05-24T08:55:43.549775Z   |                                             (repeated x914)too many connections           |                                             
+2023-05-24T08:56:19.200275Z   |                                             too many connections                          |                                             
+2023-05-24T08:56:25.582987Z   too many connections                          |                                             |                                             
+2023-05-24T08:56:25.600196Z   (repeated x26)too many connections            |                                             |                                             
+2023-05-24T08:56:26.060649Z   too many connections                          |                                             |                                             
+2023-05-24T08:56:26.079279Z   |                                             cluster1-0 joined                             |                                             
+2023-05-24T08:56:26.079318Z   |                                             cluster1-2 joined                             |                                             
+2023-05-24T08:56:26.079533Z   cluster1-2 joined                             |                                             |                                             
+2023-05-24T08:56:26.079603Z   cluster1-1 joined                             |                                             |                                             
+2023-05-24T08:56:26.080575Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-24T08:56:26.081031Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-24T08:56:26.083864Z   too many connections                          |                                             |                                             
+2023-05-24T08:56:26.089732Z   (repeated x42)too many connections            |                                             |                                             
+2023-05-24T08:56:26.770395Z   too many connections                          |                                             |                                             
+2023-05-24T08:56:26.780586Z   |                                             local node will resync cluster1-2             |                                             
+2023-05-24T08:56:26.780678Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-24T08:56:26.780686Z   cluster1-1 will resync cluster1-2             |                                             |                                             
+2023-05-24T08:56:26.794328Z   |                                             IST to cluster1-2(seqno:5154413)              |                                             
+2023-05-24T08:56:26.799475Z   (repeated x94)too many connections            |                                             |                                             
+2023-05-24T08:56:27.242147Z   |                                             IST will be used                              |                                             
+2023-05-24T08:56:28.245207Z   too many connections                          |                                             |                                             
+2023-05-24T08:56:28.259779Z   |                                             finished sending IST to cluster1-2            |                                             
+2023-05-24T08:56:28.259847Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-24T08:56:28.259965Z   cluster1-1 synced cluster1-2                  |                                             |                                             
+2023-05-24T08:56:28.260407Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-24T08:56:28.284935Z   (repeated x10)too many connections            |                                             |                                             
+2023-05-24T08:56:28.704294Z   too many connections                          |                                             |                                             
+2023-05-24T08:56:28.808334Z   (repeated x3590)too many connections          |                                             |                                             
+2023-05-24T08:57:03.500612Z   |                                             (repeated x168)too many connections           |                                             
+2023-05-24T08:57:16.956296Z   |                                             too many connections                          |                                             
+2023-05-24T08:57:20.491581Z   |                                             received shutdown                             |                                             
+2023-05-24T08:57:23.761287Z   too many connections                          |                                             |                                             
+2023-05-19T03:42:52.432749Z   starting(8.0.31)(post.processing.log)         |                                             |                                             
+2023-05-19T03:42:58.941611Z   started(standalone)(post.processing.log)      |                                             |                                             
+2023-05-24T08:57:23.767800Z   (repeated x7198)too many connections          |                                             |                                             
+2023-05-24T08:57:27.361076Z   |                                             too many connections                          |                                             
+2023-05-24T08:59:34.202664Z   too many connections                          |                                             |                                             
+2023-05-24T09:07:25.631121Z   cluster1-1 suspected to be down               |                                             |                                             
+2023-05-24T09:07:26.131695Z   cluster1-2 joined                             |                                             |                                             
+2023-05-24T09:07:26.132852Z   cluster1-1 left                               |                                             |                                             
+2023-05-24T09:07:26.132933Z   PRIMARY(n=2)                                  |                                             |                                             
+2023-05-24T09:08:00.080637Z   |                                             starting(8.0.31)                              |                                             
+2023-05-24T09:08:00.090151Z   |                                             started(cluster)                              |                                             
+2023-05-24T09:08:00.091405Z   |                                             recovering gcache                             |                                             
+2023-05-24T09:08:00.706292Z   |                                             recovering gcache                             |                                             
+2023-05-24T09:08:01.278958Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-24T09:08:01.280521Z   cluster1-2 joined                             |                                             |                                             
+2023-05-24T09:08:01.280524Z   |                                             cluster1-0 joined                             |                                             
+2023-05-24T09:08:01.280556Z   |                                             cluster1-2 joined                             |                                             
+2023-05-24T09:08:01.280599Z   cluster1-1 joined                             |                                             |                                             
+2023-05-24T09:08:01.282166Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-24T09:08:01.282175Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-24T09:08:01.283175Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-24T09:08:01.941376Z   |                                             will receive IST(seqno:5155889)               |                                             
+2023-05-24T09:08:01.941969Z   |                                             cluster1-2 will resync local node             |                                             
+2023-05-24T09:08:01.941997Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-24T09:08:01.942020Z   cluster1-2 will resync cluster1-1             |                                             |                                             
+2023-05-24T09:08:03.417354Z   |                                             got IST from cluster1-2                       |                                             
+2023-05-24T09:08:03.417514Z   cluster1-2 synced cluster1-1                  |                                             |                                             
+2023-05-24T09:08:09.881553Z   |                                             wsrep recovery                                |                                             
+2023-05-24T09:08:10.997657Z   |                                             IST received(seqno:5155889)                   |                                             
+2023-05-24T09:08:10.998552Z   |                                             JOINER -> JOINED                              |                                             
+2023-05-24T09:08:10.999115Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-24T09:08:57.462448Z   received shutdown                             |                                             |                                             
+2023-05-24T09:19:02.336997Z   |                                             cluster1-0 suspected to be down               |                                             
+2023-05-24T09:19:03.338014Z   |                                             cluster1-2 joined                             |                                             
+2023-05-24T09:19:03.340267Z   |                                             cluster1-0 left                               |                                             
+2023-05-24T09:19:03.340337Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-24T09:19:37.055707Z   starting(8.0.31)                              |                                             |                                             
+2023-05-24T09:19:37.071531Z   started(cluster)                              |                                             |                                             
+2023-05-24T09:19:37.072937Z   recovering gcache                             |                                             |                                             
+2023-05-24T09:19:37.704088Z   recovering gcache                             |                                             |                                             
+2023-05-24T09:19:38.280834Z   |                                             cluster1-0 joined                             |                                             
+2023-05-24T09:19:38.280937Z   |                                             cluster1-2 joined                             |                                             
+2023-05-24T09:19:38.280964Z   cluster1-2 joined                             |                                             |                                             
+2023-05-24T09:19:38.280992Z   cluster1-1 joined                             |                                             |                                             
+2023-05-24T09:19:38.282667Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-24T09:19:38.779653Z   CLOSED -> OPEN                                |                                             |                                             
+2023-05-24T09:19:38.779857Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-24T09:19:38.781851Z   OPEN -> PRIMARY                               |                                             |                                             
+2023-05-24T09:19:39.338473Z   will receive IST(seqno:5156720)               |                                             |                                             
+2023-05-24T09:19:39.339687Z   |                                             local node will resync cluster1-0             |                                             
+2023-05-24T09:19:39.339783Z   cluster1-1 will resync local node             |                                             |                                             
+2023-05-24T09:19:39.339784Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-24T09:19:39.339860Z   PRIMARY -> JOINER                             |                                             |                                             
+2023-05-24T09:19:39.359574Z   |                                             IST to cluster1-0(seqno:5156720)              |                                             
+2023-05-24T09:19:39.812801Z   |                                             IST will be used                              |                                             
+2023-05-24T09:19:40.833367Z   |                                             finished sending IST to cluster1-0            |                                             
+2023-05-24T09:19:40.833393Z   got IST from cluster1-1                       |                                             |                                             
+2023-05-24T09:19:40.833451Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-24T09:19:40.834089Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-24T09:19:47.390495Z   wsrep recovery                                |                                             |                                             
+2023-05-24T09:19:47.742772Z   IST received(seqno:5156720)                   |                                             |                                             
+2023-05-24T09:19:47.744825Z   JOINER -> JOINED                              |                                             |                                             
+2023-05-24T09:19:47.745816Z   JOINED -> SYNCED                              |                                             |                                             
+2023-05-24T09:19:58.001359Z   |                                             (repeated x670)too many connections           |                                             
+2023-05-24T09:23:58.339523Z   |                                             too many connections                          |                                             
+2023-05-25T03:00:18.871163Z   cluster1-2 joined                             |                                             |                                             
+2023-05-25T03:00:18.871225Z   garb joined                                   |                                             |                                             
+2023-05-25T03:00:18.871235Z   cluster1-1 joined                             |                                             |                                             
+2023-05-25T03:00:18.871388Z   |                                             cluster1-0 joined                             |                                             
+2023-05-25T03:00:18.871468Z   |                                             cluster1-2 joined                             |                                             
+2023-05-25T03:00:18.871485Z   |                                             garb joined                                   |                                             
+2023-05-25T03:00:19.873796Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-25T03:00:19.874026Z   PRIMARY(n=4)                                  |                                             |                                             
+2023-05-25T03:00:20.363932Z   cluster1-2 will resync garb                   |                                             |                                             
+2023-05-25T03:00:20.363986Z   |                                             cluster1-2 will resync garb                   |                                             
+2023-05-25T03:44:11.626005Z   |                                             cluster1-2 synced garb                        |                                             
+2023-05-25T03:44:11.626112Z   cluster1-2 synced garb                        |                                             |                                             
+2023-05-25T03:44:13.987810Z   |                                             cluster1-0 joined                             |                                             
+2023-05-25T03:44:13.987866Z   |                                             cluster1-2 joined                             |                                             
+2023-05-25T03:44:13.987902Z   |                                             garb left                                     |                                             
+2023-05-25T03:44:13.987908Z   cluster1-2 joined                             |                                             |                                             
+2023-05-25T03:44:13.987968Z   cluster1-1 joined                             |                                             |                                             
+2023-05-25T03:44:13.988012Z   garb left                                     |                                             |                                             
+2023-05-25T03:44:13.988890Z   |                                             garb left                                     |                                             
+2023-05-25T03:44:13.988956Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-25T03:44:13.989008Z   garb left                                     |                                             |                                             
+2023-05-25T03:44:13.989030Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-25T03:48:13.523650Z   cluster1-1 joined                             |                                             |                                             
+2023-05-25T03:48:13.523696Z   |                                             cluster1-0 joined                             |                                             
+2023-05-25T03:48:13.523738Z   cluster1-2 left                               |                                             |                                             
+2023-05-25T03:48:13.523884Z   |                                             cluster1-2 left                               |                                             
+2023-05-25T03:48:13.525186Z   cluster1-2 left                               |                                             |                                             
+2023-05-25T03:48:13.525258Z   PRIMARY(n=2)                                  |                                             |                                             
+2023-05-25T03:48:13.525483Z   |                                             cluster1-2 left                               |                                             
+2023-05-25T03:48:13.525517Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-25T03:49:24.329464Z   |                                             |                                             starting(8.0.31)                              
+2023-05-25T03:49:24.332449Z   |                                             |                                             started(cluster)                              
+2023-05-25T03:49:24.333454Z   |                                             |                                             no grastate.dat file                          
+2023-05-25T03:49:24.333464Z   |                                             |                                             bootstrapping(empty grastate)                 
+2023-05-25T03:49:24.333499Z   |                                             |                                             safe_to_bootstrap: 1                          
+2023-05-25T03:49:24.849844Z   |                                             cluster1-0 joined                             |                                             
+2023-05-25T03:49:24.849938Z   |                                             cluster1-2 joined                             |                                             
+2023-05-25T03:49:24.850000Z   cluster1-2 joined                             |                                             |                                             
+2023-05-25T03:49:24.850187Z   cluster1-1 joined                             |                                             |                                             
+2023-05-25T03:49:24.850405Z   |                                             |                                             cluster1-0 joined                             
+2023-05-25T03:49:24.850417Z   |                                             |                                             cluster1-1 joined                             
+2023-05-25T03:49:25.852094Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-25T03:49:25.852441Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-25T03:49:26.348763Z   |                                             |                                             CLOSED -> OPEN                                
+2023-05-25T03:49:26.349013Z   |                                             |                                             PRIMARY(n=3)                                  
+2023-05-25T03:49:26.350500Z   |                                             |                                             OPEN -> PRIMARY                               
+2023-05-25T03:49:27.004187Z   |                                             |                                             will receive SST                              
+2023-05-25T03:49:27.005073Z   |                                             local node will resync cluster1-2             |                                             
+2023-05-25T03:49:27.005141Z   cluster1-1 will resync cluster1-2             |                                             |                                             
+2023-05-25T03:49:27.005200Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-25T03:49:27.005213Z   |                                             |                                             cluster1-1 will resync local node             
+2023-05-25T03:49:27.005286Z   |                                             |                                             PRIMARY -> JOINER                             
+2023-05-25T03:49:27.012633Z   |                                             IST to cluster1-2(seqno:5835877)              |                                             
+2023-05-25T03:49:27.823189Z   |                                             |                                             receiving SST                                 
+2023-05-25T03:49:38.513896Z   |                                             SST to cluster1-2                             |                                             
+2023-05-25T04:31:22.635591Z   |                                             finished sending IST to cluster1-2            |                                             
+2023-05-25T04:31:22.635628Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-25T04:31:22.635717Z   |                                             |                                             got SST from cluster1-1                       
+2023-05-25T04:31:22.635767Z   cluster1-1 synced cluster1-2                  |                                             |                                             
+2023-05-25T04:31:22.636094Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-25T04:31:22.667270Z   |                                             |                                             preparing SST backup                          
+2023-05-25T04:31:58.316262Z   |                                             |                                             wsrep recovery                                
+2023-05-25T04:31:58.337408Z   |                                             |                                             JOINER -> JOINED                              
+2023-05-25T04:31:59.767489Z   |                                             |                                             JOINED -> SYNCED                              
+2023-05-25T04:34:20.398345Z   |                                             |                                             received shutdown                             
+2023-05-25T04:34:30.401364Z   |                                             cluster1-0 joined                             |                                             
+2023-05-25T04:34:30.401445Z   cluster1-1 joined                             |                                             |                                             
+2023-05-25T04:34:30.401532Z   |                                             |                                             NON-PRIMARY(n=1)                              
+2023-05-25T04:34:30.401543Z   |                                             cluster1-2 left                               |                                             
+2023-05-25T04:34:30.401594Z   cluster1-2 left                               |                                             |                                             
+2023-05-25T04:34:30.401727Z   |                                             |                                             SYNCED -> OPEN                                
+2023-05-25T04:34:30.401855Z   |                                             |                                             OPEN -> CLOSED                                
+2023-05-25T04:34:30.403167Z   cluster1-2 left                               |                                             |                                             
+2023-05-25T04:34:30.403229Z   PRIMARY(n=2)                                  |                                             |                                             
+2023-05-25T04:34:30.403506Z   |                                             cluster1-2 left                               |                                             
+2023-05-25T04:34:30.403555Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-25T04:31:38.830198Z   |                                             |                                             starting(8.0.31)(post.processing.log)         
+2023-05-25T04:31:45.148850Z   |                                             |                                             started(standalone)(post.processing.log)      
+2023-05-25T04:34:43.205745Z   |                                             |                                             shutdown complete                             
+2023-05-25T04:31:51.207735Z   |                                             |                                             shutdown complete(post.processing.log)        
+2023-05-25T04:35:01.293586Z   |                                             |                                             starting(8.0.31)                              
+2023-05-25T04:35:01.296248Z   |                                             |                                             started(cluster)                              
+2023-05-25T04:35:01.297362Z   |                                             |                                             recovering gcache                             
+2023-05-25T04:35:01.331535Z   |                                             |                                             recovering gcache                             
+                                                                                                                          10.16.28.207                                  
+                                                                                                                          (node ip)                                     
+                                                                                                                           V                                            
+                                                                                                                          10.16.28.213                                  
+2023-05-25T04:35:01.848758Z   |                                             cluster1-0 joined                             |                                             
+2023-05-25T04:35:01.848759Z   |                                             |                                             cluster1-0 joined                             
+2023-05-25T04:35:01.848785Z   |                                             |                                             cluster1-1 joined                             
+2023-05-25T04:35:01.848845Z   |                                             cluster1-2 joined                             |                                             
+2023-05-25T04:35:01.848877Z   cluster1-2 joined                             |                                             |                                             
+2023-05-25T04:35:01.848959Z   cluster1-1 joined                             |                                             |                                             
+2023-05-25T04:35:01.850481Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-25T04:35:01.850512Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-25T04:35:02.347755Z   |                                             |                                             CLOSED -> OPEN                                
+2023-05-25T04:35:02.347927Z   |                                             |                                             PRIMARY(n=3)                                  
+2023-05-25T04:35:02.349077Z   |                                             |                                             OPEN -> PRIMARY                               
+2023-05-25T04:35:02.908838Z   |                                             |                                             will receive IST(seqno:5858164)               
+2023-05-25T04:35:02.909866Z   |                                             |                                             cluster1-1 will resync local node             
+2023-05-25T04:35:02.909899Z   |                                             |                                             PRIMARY -> JOINER                             
+2023-05-25T04:35:02.909925Z   cluster1-1 will resync cluster1-2             |                                             |                                             
+2023-05-25T04:35:02.909983Z   |                                             local node will resync cluster1-2             |                                             
+2023-05-25T04:35:02.910059Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-25T04:35:02.921394Z   |                                             IST to cluster1-2(seqno:5858164)              |                                             
+2023-05-25T04:35:03.336995Z   |                                             IST will be used                              |                                             
+2023-05-25T04:35:04.355833Z   |                                             finished sending IST to cluster1-2            |                                             
+2023-05-25T04:35:04.355886Z   |                                             |                                             got IST from cluster1-1                       
+2023-05-25T04:35:04.355910Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-25T04:35:04.355933Z   cluster1-1 synced cluster1-2                  |                                             |                                             
+2023-05-25T04:35:04.356540Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-25T04:35:14.895241Z   |                                             |                                             wsrep recovery                                
+2023-05-25T04:35:15.076324Z   |                                             |                                             IST received(seqno:5858164)                   
+2023-05-25T04:35:15.077560Z   |                                             |                                             JOINER -> JOINED                              
+2023-05-25T04:35:15.078178Z   |                                             |                                             JOINED -> SYNCED                              
+2023-05-25T04:35:20.556329Z   |                                             received shutdown                             |                                             
+2023-05-25T04:35:30.559038Z   |                                             |                                             cluster1-0 joined                             
+2023-05-25T04:35:30.559192Z   cluster1-2 joined                             |                                             |                                             
+2023-05-25T04:35:30.559235Z   |                                             NON-PRIMARY(n=1)                              |                                             
+2023-05-25T04:35:30.559318Z   cluster1-1 left                               |                                             |                                             
+2023-05-25T04:35:30.559398Z   |                                             SYNCED -> OPEN                                |                                             
+2023-05-25T04:35:30.559515Z   |                                             OPEN -> CLOSED                                |                                             
+2023-05-25T04:35:30.559684Z   |                                             |                                             cluster1-1 left                               
+2023-05-25T04:35:30.560761Z   cluster1-1 left                               |                                             |                                             
+2023-05-25T04:35:30.560850Z   PRIMARY(n=2)                                  |                                             |                                             
+2023-05-25T04:35:30.561080Z   |                                             |                                             cluster1-1 left                               
+2023-05-25T04:35:30.561149Z   |                                             |                                             PRIMARY(n=2)                                  
+2023-05-25T04:35:53.568992Z   |                                             shutdown complete                             |                                             
+2023-05-18T14:45:54.212160Z   |                                             shutdown complete(post.processing.log)        |                                             
+2023-05-25T04:36:12.725113Z   |                                             starting(8.0.31)                              |                                             
+2023-05-25T04:36:12.735830Z   |                                             started(cluster)                              |                                             
+2023-05-25T04:36:12.737161Z   |                                             recovering gcache                             |                                             
+2023-05-25T04:36:13.381040Z   |                                             recovering gcache                             |                                             
+                                                                            10.16.27.203                                                                                
+                                                                            (node ip)                                                                                   
+                                                                             V                                                                                          
+                                                                            10.16.27.98                                                                                 
+2023-05-25T04:36:13.977726Z   |                                             |                                             cluster1-0 joined                             
+2023-05-25T04:36:13.977805Z   |                                             |                                             cluster1-1 joined                             
+2023-05-25T04:36:13.977867Z   |                                             cluster1-0 joined                             |                                             
+2023-05-25T04:36:13.977899Z   |                                             cluster1-2 joined                             |                                             
+2023-05-25T04:36:13.977932Z   cluster1-2 joined                             |                                             |                                             
+2023-05-25T04:36:13.978032Z   cluster1-1 joined                             |                                             |                                             
+2023-05-25T04:36:13.979426Z   |                                             |                                             PRIMARY(n=3)                                  
+2023-05-25T04:36:13.979510Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-25T04:36:14.476933Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-25T04:36:14.477197Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-25T04:36:14.478368Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-25T04:36:15.096770Z   |                                             will receive IST(seqno:5859104)               |                                             
+2023-05-25T04:36:15.097710Z   |                                             cluster1-2 will resync local node             |                                             
+2023-05-25T04:36:15.097740Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-25T04:36:15.097743Z   |                                             |                                             local node will resync cluster1-1             
+2023-05-25T04:36:15.097810Z   cluster1-2 will resync cluster1-1             |                                             |                                             
+2023-05-25T04:36:15.097829Z   |                                             |                                             SYNCED -> DONOR                               
+2023-05-25T04:36:15.113859Z   |                                             |                                             IST to cluster1-1(seqno:5859104)              
+2023-05-25T04:36:15.523060Z   |                                             |                                             IST will be used                              
+2023-05-25T04:36:16.543304Z   |                                             |                                             finished sending IST to cluster1-1            
+2023-05-25T04:36:16.543332Z   |                                             |                                             DESYNCED -> JOINED                            
+2023-05-25T04:36:16.543351Z   |                                             got IST from cluster1-2                       |                                             
+2023-05-25T04:36:16.543389Z   cluster1-2 synced cluster1-1                  |                                             |                                             
+2023-05-25T04:36:16.543843Z   |                                             |                                             JOINED -> SYNCED                              
+2023-05-25T04:36:29.019181Z   |                                             wsrep recovery                                |                                             
+2023-05-25T04:36:29.641103Z   |                                             IST received(seqno:5859104)                   |                                             
+2023-05-25T04:36:29.642082Z   |                                             JOINER -> JOINED                              |                                             
+2023-05-25T04:36:29.847276Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-25T04:37:01.595911Z   received shutdown                             |                                             |                                             
+2023-05-25T04:37:12.599050Z   NON-PRIMARY(n=1)                              |                                             |                                             
+2023-05-25T04:37:12.599120Z   |                                             cluster1-2 joined                             |                                             
+2023-05-25T04:37:12.599211Z   SYNCED -> OPEN                                |                                             |                                             
+2023-05-25T04:37:12.599244Z   |                                             cluster1-0 left                               |                                             
+2023-05-25T04:37:12.599252Z   |                                             |                                             cluster1-1 joined                             
+2023-05-25T04:37:12.599338Z   OPEN -> CLOSED                                |                                             |                                             
+2023-05-25T04:37:12.599352Z   |                                             |                                             cluster1-0 left                               
+2023-05-25T04:37:12.600485Z   |                                             |                                             cluster1-0 left                               
+2023-05-25T04:37:12.600510Z   |                                             |                                             PRIMARY(n=2)                                  
+2023-05-25T04:37:12.600902Z   |                                             cluster1-0 left                               |                                             
+2023-05-25T04:37:12.600973Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-25T04:37:42.247550Z   shutdown complete                             |                                             |                                             
+2023-05-19T03:43:05.371819Z   shutdown complete(post.processing.log)        |                                             |                                             
+2023-05-25T04:38:00.645783Z   starting(8.0.31)                              |                                             |                                             
+2023-05-25T04:38:00.659129Z   started(cluster)                              |                                             |                                             
+2023-05-25T04:38:00.660295Z   recovering gcache                             |                                             |                                             
+2023-05-25T04:38:01.262291Z   recovering gcache                             |                                             |                                             
+                              10.16.29.241                                                                                                                              
+                              (node ip)                                                                                                                                 
+                               V                                                                                                                                        
+                              10.16.29.34                                                                                                                               
+2023-05-25T04:38:01.575342Z   |                                             |                                             cluster1-0 joined                             
+2023-05-25T04:38:01.575395Z   |                                             |                                             cluster1-1 joined                             
+2023-05-25T04:38:01.575465Z   |                                             cluster1-0 joined                             |                                             
+2023-05-25T04:38:01.575543Z   |                                             cluster1-2 joined                             |                                             
+2023-05-25T04:38:01.575595Z   cluster1-2 joined                             |                                             |                                             
+2023-05-25T04:38:01.575616Z   cluster1-1 joined                             |                                             |                                             
+2023-05-25T04:38:01.576555Z   |                                             |                                             PRIMARY(n=3)                                  
+2023-05-25T04:38:01.576715Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-25T04:38:01.860312Z   CLOSED -> OPEN                                |                                             |                                             
+2023-05-25T04:38:01.860528Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-25T04:38:01.862258Z   OPEN -> PRIMARY                               |                                             |                                             
+2023-05-25T04:38:02.456823Z   will receive IST(seqno:5861187)               |                                             |                                             
+2023-05-25T04:38:02.457884Z   |                                             local node will resync cluster1-0             |                                             
+2023-05-25T04:38:02.457895Z   |                                             |                                             cluster1-1 will resync cluster1-0             
+2023-05-25T04:38:02.457924Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-25T04:38:02.457935Z   cluster1-1 will resync local node             |                                             |                                             
+2023-05-25T04:38:02.457961Z   PRIMARY -> JOINER                             |                                             |                                             
+2023-05-25T04:38:02.473572Z   |                                             IST to cluster1-0(seqno:5861187)              |                                             
+2023-05-25T04:38:02.904912Z   |                                             IST will be used                              |                                             
+2023-05-25T04:38:03.923687Z   |                                             |                                             cluster1-1 synced cluster1-0                  
+2023-05-25T04:38:03.923791Z   |                                             finished sending IST to cluster1-0            |                                             
+2023-05-25T04:38:03.923865Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-25T04:38:03.923889Z   got IST from cluster1-1                       |                                             |                                             
+2023-05-25T04:38:03.924496Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-25T04:38:14.821245Z   wsrep recovery                                |                                             |                                             
+2023-05-25T04:38:14.952628Z   IST received(seqno:5861187)                   |                                             |                                             
+2023-05-25T04:38:14.953589Z   JOINER -> JOINED                              |                                             |                                             
+2023-05-25T04:38:14.954030Z   JOINED -> SYNCED                              |                                             |                                             
+2023-05-26T03:00:22.581588Z   |                                             cluster1-0 joined                             |                                             
+2023-05-26T03:00:22.581645Z   |                                             garb joined                                   |                                             
+2023-05-26T03:00:22.581658Z   |                                             cluster1-2 joined                             |                                             
+2023-05-26T03:00:22.581847Z   garb joined                                   |                                             |                                             
+2023-05-26T03:00:22.581912Z   |                                             |                                             cluster1-0 joined                             
+2023-05-26T03:00:22.581946Z   cluster1-2 joined                             |                                             |                                             
+2023-05-26T03:00:22.581970Z   cluster1-1 joined                             |                                             |                                             
+2023-05-26T03:00:22.582016Z   |                                             |                                             garb joined                                   
+2023-05-26T03:00:22.582040Z   |                                             |                                             cluster1-1 joined                             
+2023-05-26T03:00:22.583782Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-26T03:00:22.583952Z   |                                             |                                             PRIMARY(n=4)                                  
+2023-05-26T03:00:22.583976Z   PRIMARY(n=4)                                  |                                             |                                             
+2023-05-26T03:00:23.082605Z   |                                             cluster1-2 will resync garb                   |                                             
+2023-05-26T03:00:23.082696Z   |                                             |                                             local node will resync garb                   
+2023-05-26T03:00:23.082706Z   |                                             |                                             SYNCED -> DONOR                               
+2023-05-26T03:00:23.082747Z   cluster1-2 will resync garb                   |                                             |                                             
+2023-05-26T03:00:34.572248Z   |                                             |                                             SST to garb                                   
+2023-05-26T03:40:23.808519Z   |                                             |                                             finished sending SST to garb                  
+2023-05-26T03:40:23.808574Z   |                                             |                                             DESYNCED -> JOINED                            
+2023-05-26T03:40:23.808600Z   cluster1-2 synced garb                        |                                             |                                             
+2023-05-26T03:40:23.808954Z   |                                             cluster1-2 synced garb                        |                                             
+2023-05-26T03:40:23.809230Z   |                                             |                                             JOINED -> SYNCED                              
+2023-05-26T03:40:26.047546Z   |                                             |                                             cluster1-0 joined                             
+2023-05-26T03:40:26.047565Z   cluster1-2 joined                             |                                             |                                             
+2023-05-26T03:40:26.047613Z   |                                             |                                             cluster1-1 joined                             
+2023-05-26T03:40:26.047651Z   cluster1-1 joined                             |                                             |                                             
+2023-05-26T03:40:26.047664Z   |                                             |                                             garb left                                     
+2023-05-26T03:40:26.047712Z   garb left                                     |                                             |                                             
+2023-05-26T03:40:26.047973Z   |                                             cluster1-0 joined                             |                                             
+2023-05-26T03:40:26.048058Z   |                                             cluster1-2 joined                             |                                             
+2023-05-26T03:40:26.048117Z   |                                             garb left                                     |                                             
+2023-05-26T03:40:26.049387Z   garb left                                     |                                             |                                             
+2023-05-26T03:40:26.049412Z   |                                             |                                             garb left                                     
+2023-05-26T03:40:26.049454Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-26T03:40:26.049477Z   |                                             |                                             PRIMARY(n=3)                                  
+2023-05-26T03:40:26.049765Z   |                                             garb left                                     |                                             
+2023-05-26T03:40:26.049947Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-27T03:00:19.537730Z   |                                             cluster1-0 joined                             |                                             
+2023-05-27T03:00:19.537767Z   |                                             cluster1-2 joined                             |                                             
+2023-05-27T03:00:19.537775Z   |                                             garb joined                                   |                                             
+2023-05-27T03:00:19.537993Z   cluster1-2 joined                             |                                             |                                             
+2023-05-27T03:00:19.538086Z   garb joined                                   |                                             |                                             
+2023-05-27T03:00:19.538110Z   cluster1-1 joined                             |                                             |                                             
+2023-05-27T03:00:19.539621Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-27T03:00:19.539965Z   PRIMARY(n=4)                                  |                                             |                                             
+2023-05-27T03:00:19.542417Z   |                                             |                                             cluster1-0 joined                             
+2023-05-27T03:00:19.542503Z   |                                             |                                             garb joined                                   
+2023-05-27T03:00:19.542526Z   |                                             |                                             cluster1-1 joined                             
+2023-05-27T03:00:19.544132Z   |                                             |                                             PRIMARY(n=4)                                  
+2023-05-27T03:00:20.038432Z   |                                             cluster1-2 will resync garb                   |                                             
+2023-05-27T03:00:20.038598Z   cluster1-2 will resync garb                   |                                             |                                             
+2023-05-27T03:00:20.043068Z   |                                             |                                             local node will resync garb                   
+2023-05-27T03:00:20.043091Z   |                                             |                                             SYNCED -> DONOR                               
+2023-05-27T03:00:31.529154Z   |                                             |                                             SST to garb                                   
+2023-05-27T03:39:48.765020Z   cluster1-2 synced garb                        |                                             |                                             
+2023-05-27T03:39:48.765166Z   |                                             cluster1-2 synced garb                        |                                             
+2023-05-27T03:39:48.768602Z   |                                             |                                             finished sending SST to garb                  
+2023-05-27T03:39:48.768676Z   |                                             |                                             DESYNCED -> JOINED                            
+2023-05-27T03:39:48.769112Z   |                                             |                                             JOINED -> SYNCED                              
+2023-05-27T03:39:51.224587Z   cluster1-2 joined                             |                                             |                                             
+2023-05-27T03:39:51.224622Z   cluster1-1 joined                             |                                             |                                             
+2023-05-27T03:39:51.224631Z   garb left                                     |                                             |                                             
+2023-05-27T03:39:51.224821Z   |                                             cluster1-0 joined                             |                                             
+2023-05-27T03:39:51.224991Z   |                                             cluster1-2 joined                             |                                             
+2023-05-27T03:39:51.225009Z   |                                             garb left                                     |                                             
+2023-05-27T03:39:51.226003Z   garb left                                     |                                             |                                             
+2023-05-27T03:39:51.226069Z   |                                             garb left                                     |                                             
+2023-05-27T03:39:51.226111Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-27T03:39:51.226160Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-27T03:39:51.228020Z   |                                             |                                             cluster1-0 joined                             
+2023-05-27T03:39:51.228100Z   |                                             |                                             cluster1-1 joined                             
+2023-05-27T03:39:51.228115Z   |                                             |                                             garb left                                     
+2023-05-27T03:39:51.229544Z   |                                             |                                             garb left                                     
+2023-05-27T03:39:51.229698Z   |                                             |                                             PRIMARY(n=3)                                  
+2023-05-28T03:00:20.179665Z   cluster1-2 joined                             |                                             |                                             
+2023-05-28T03:00:20.179723Z   cluster1-1 joined                             |                                             |                                             
+2023-05-28T03:00:20.179744Z   garb joined                                   |                                             |                                             
+2023-05-28T03:00:20.180516Z   |                                             cluster1-0 joined                             |                                             
+2023-05-28T03:00:20.180583Z   |                                             cluster1-2 joined                             |                                             
+2023-05-28T03:00:20.180597Z   |                                             garb joined                                   |                                             
+2023-05-28T03:00:20.180757Z   |                                             |                                             cluster1-0 joined                             
+2023-05-28T03:00:20.180839Z   |                                             |                                             cluster1-1 joined                             
+2023-05-28T03:00:20.180863Z   |                                             |                                             garb joined                                   
+2023-05-28T03:00:20.181677Z   PRIMARY(n=4)                                  |                                             |                                             
+2023-05-28T03:00:20.182305Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-28T03:00:20.182540Z   |                                             |                                             PRIMARY(n=4)                                  
+2023-05-28T03:00:20.680781Z   cluster1-2 will resync garb                   |                                             |                                             
+2023-05-28T03:00:20.681257Z   |                                             cluster1-2 will resync garb                   |                                             
+2023-05-28T03:00:20.681447Z   |                                             |                                             local node will resync garb                   
+2023-05-28T03:00:20.681471Z   |                                             |                                             SYNCED -> DONOR                               
+2023-05-28T03:00:32.184853Z   |                                             |                                             SST to garb                                   
+2023-05-28T03:40:51.321660Z   |                                             |                                             finished sending SST to garb                  
+2023-05-28T03:40:51.321733Z   |                                             |                                             DESYNCED -> JOINED                            
+2023-05-28T03:40:51.321783Z   cluster1-2 synced garb                        |                                             |                                             
+2023-05-28T03:40:51.322103Z   |                                             cluster1-2 synced garb                        |                                             
+2023-05-28T03:40:51.322593Z   |                                             |                                             JOINED -> SYNCED                              
+2023-05-28T03:40:53.656940Z   |                                             |                                             cluster1-0 joined                             
+2023-05-28T03:40:53.656966Z   |                                             |                                             cluster1-1 joined                             
+2023-05-28T03:40:53.656981Z   |                                             |                                             garb left                                     
+2023-05-28T03:40:53.657404Z   |                                             cluster1-0 joined                             |                                             
+2023-05-28T03:40:53.657428Z   |                                             cluster1-2 joined                             |                                             
+2023-05-28T03:40:53.657443Z   |                                             garb left                                     |                                             
+2023-05-28T03:40:53.657819Z   cluster1-2 joined                             |                                             |                                             
+2023-05-28T03:40:53.657840Z   cluster1-1 joined                             |                                             |                                             
+2023-05-28T03:40:53.657847Z   garb left                                     |                                             |                                             
+2023-05-28T03:40:53.658835Z   garb left                                     |                                             |                                             
+2023-05-28T03:40:53.658995Z   |                                             |                                             garb left                                     
+2023-05-28T03:40:53.659027Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-28T03:40:53.659156Z   |                                             |                                             PRIMARY(n=3)                                  
+2023-05-28T03:40:53.659348Z   |                                             garb left                                     |                                             
+2023-05-28T03:40:53.659384Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-28T08:09:01.368781Z   |                                             received shutdown                             |                                             
+2023-05-28T08:19:06.122140Z   cluster1-1 suspected to be down               |                                             |                                             
+2023-05-28T08:19:06.623762Z   |                                             |                                             cluster1-1 suspected to be down               
+2023-05-28T08:19:07.123055Z   cluster1-2 joined                             |                                             |                                             
+2023-05-28T08:19:07.124213Z   |                                             |                                             cluster1-0 joined                             
+2023-05-28T08:19:07.124217Z   cluster1-1 left                               |                                             |                                             
+2023-05-28T08:19:07.124375Z   PRIMARY(n=2)                                  |                                             |                                             
+2023-05-28T08:19:07.126252Z   |                                             |                                             cluster1-1 left                               
+2023-05-28T08:19:07.126298Z   |                                             |                                             PRIMARY(n=2)                                  
+2023-05-28T08:19:39.773671Z   received shutdown                             |                                             |                                             
+2023-05-28T08:23:11.393160Z   |                                             |                                             cluster1-0 left                               
+2023-05-28T08:23:11.394190Z   NON-PRIMARY(n=1)                              |                                             |                                             
+2023-05-28T08:23:11.394402Z   SYNCED -> OPEN                                |                                             |                                             
+2023-05-28T08:23:11.394509Z   OPEN -> CLOSED                                |                                             |                                             
+2023-05-28T08:23:11.394531Z   |                                             |                                             cluster1-0 left                               
+2023-05-28T08:23:11.394588Z   |                                             |                                             PRIMARY(n=1)                                  
+2023-05-28T08:19:21.529819Z   |                                             starting(8.0.31)(recovery.log)                |                                             
+2023-05-28T08:19:35.008610Z   |                                             wsrep recovery(recovery.log)                  |                                             
+2023-05-28T08:19:45.378813Z   |                                             shutdown complete(recovery.log)               |                                             
+2023-05-28T08:23:23.908187Z   |                                             starting(8.0.31)                              |                                             
+2023-05-28T08:23:23.919124Z   |                                             started(cluster)                              |                                             
+2023-05-28T08:23:23.920390Z   |                                             recovering gcache                             |                                             
+2023-05-28T08:23:24.582927Z   |                                             recovering gcache                             |                                             
+2023-05-28T08:23:25.195411Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-28T08:23:25.197121Z   |                                             |                                             cluster1-1 joined                             
+2023-05-28T08:23:25.198245Z   |                                             cluster1-2 joined                             |                                             
+2023-05-28T08:23:25.200143Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-28T08:23:25.200241Z   |                                             |                                             PRIMARY(n=2)                                  
+2023-05-28T08:23:25.200793Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-28T08:23:25.809238Z   |                                             will receive IST(seqno:8605683)               |                                             
+2023-05-28T08:23:25.809921Z   |                                             cluster1-2 will resync local node             |                                             
+2023-05-28T08:23:25.810003Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-28T08:23:25.810849Z   |                                             |                                             local node will resync cluster1-1             
+2023-05-28T08:23:25.810936Z   |                                             |                                             SYNCED -> DONOR                               
+2023-05-28T08:23:25.824732Z   |                                             |                                             IST to cluster1-1(seqno:8605683)              
+2023-05-28T08:23:26.251768Z   |                                             |                                             IST will be used                              
+2023-05-28T08:23:27.268102Z   |                                             got IST from cluster1-2                       |                                             
+2023-05-28T08:23:27.268845Z   |                                             |                                             finished sending IST to cluster1-1            
+2023-05-28T08:23:27.268914Z   |                                             |                                             DESYNCED -> JOINED                            
+2023-05-28T08:23:27.269439Z   |                                             |                                             JOINED -> SYNCED                              
+2023-05-28T08:23:39.881488Z   |                                             wsrep recovery                                |                                             
+2023-05-28T08:23:40.876116Z   |                                             IST received(seqno:8605683)                   |                                             
+2023-05-28T08:23:40.876609Z   |                                             JOINER -> JOINED                              |                                             
+2023-05-28T08:23:41.181383Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-28T08:23:48.440344Z   shutdown complete                             |                                             |                                             
+2023-05-28T08:24:03.789253Z   starting(8.0.31)                              |                                             |                                             
+2023-05-28T08:24:03.802597Z   started(cluster)                              |                                             |                                             
+2023-05-28T08:24:03.803745Z   recovering gcache                             |                                             |                                             
+2023-05-28T08:24:04.451214Z   recovering gcache                             |                                             |                                             
+2023-05-28T08:24:04.580181Z   cluster1-2 joined                             |                                             |                                             
+2023-05-28T08:24:04.580186Z   cluster1-1 joined                             |                                             |                                             
+2023-05-28T08:24:04.580353Z   |                                             cluster1-0 joined                             |                                             
+2023-05-28T08:24:04.580368Z   |                                             cluster1-2 joined                             |                                             
+2023-05-28T08:24:04.581094Z   |                                             |                                             cluster1-0 joined                             
+2023-05-28T08:24:04.581117Z   |                                             |                                             cluster1-1 joined                             
+2023-05-28T08:24:05.582656Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-28T08:24:05.583994Z   |                                             |                                             PRIMARY(n=3)                                  
+2023-05-28T08:24:06.072396Z   CLOSED -> OPEN                                |                                             |                                             
+2023-05-28T08:24:06.072665Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-28T08:24:06.074275Z   OPEN -> PRIMARY                               |                                             |                                             
+2023-05-28T08:24:06.692619Z   will receive IST(seqno:8607495)               |                                             |                                             
+2023-05-28T08:24:06.693734Z   cluster1-1 will resync local node             |                                             |                                             
+2023-05-28T08:24:06.693814Z   PRIMARY -> JOINER                             |                                             |                                             
+2023-05-28T08:24:06.693995Z   |                                             local node will resync cluster1-0             |                                             
+2023-05-28T08:24:06.694081Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-28T08:24:06.694718Z   |                                             |                                             cluster1-1 will resync cluster1-0             
+2023-05-28T08:24:06.710536Z   |                                             IST to cluster1-0(seqno:8607495)              |                                             
+2023-05-28T08:24:07.166023Z   |                                             IST will be used                              |                                             
+2023-05-28T08:24:08.182490Z   got IST from cluster1-1                       |                                             |                                             
+2023-05-28T08:24:08.182724Z   |                                             finished sending IST to cluster1-0            |                                             
+2023-05-28T08:24:08.182760Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-28T08:24:08.183221Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-28T08:24:08.183529Z   |                                             |                                             cluster1-1 synced cluster1-0                  
+2023-05-28T08:24:19.334302Z   wsrep recovery                                |                                             |                                             
+2023-05-28T08:24:20.501118Z   IST received(seqno:8607495)                   |                                             |                                             
+2023-05-28T08:24:20.502038Z   JOINER -> JOINED                              |                                             |                                             
+2023-05-28T08:24:20.658917Z   JOINED -> SYNCED                              |                                             |                                             
+2023-05-28T08:41:19.817710Z   received shutdown                             |                                             |                                             
+2023-05-28T08:45:00.599029Z   NON-PRIMARY(n=1)                              |                                             |                                             
+2023-05-28T08:45:00.599104Z   SYNCED -> OPEN                                |                                             |                                             
+2023-05-28T08:45:00.599137Z   OPEN -> CLOSED                                |                                             |                                             
+2023-05-28T08:45:00.599496Z   |                                             cluster1-2 joined                             |                                             
+2023-05-28T08:45:00.599569Z   |                                             cluster1-0 left                               |                                             
+2023-05-28T08:45:00.600242Z   |                                             |                                             cluster1-1 joined                             
+2023-05-28T08:45:00.600380Z   |                                             |                                             cluster1-0 left                               
+2023-05-28T08:45:00.601727Z   |                                             cluster1-0 left                               |                                             
+2023-05-28T08:45:00.601802Z   |                                             PRIMARY(n=2)                                  |                                             
+2023-05-28T08:45:00.601872Z   |                                             |                                             cluster1-0 left                               
+2023-05-28T08:45:00.602020Z   |                                             |                                             PRIMARY(n=2)                                  
+2023-05-28T08:45:29.372593Z   shutdown complete                             |                                             |                                             
+2023-05-28T08:45:43.616580Z   starting(8.0.31)                              |                                             |                                             
+2023-05-28T08:45:43.633451Z   started(cluster)                              |                                             |                                             
+2023-05-28T08:45:43.634696Z   recovering gcache                             |                                             |                                             
+2023-05-28T08:45:44.344424Z   recovering gcache                             |                                             |                                             
+2023-05-28T08:45:44.504384Z   cluster1-2 joined                             |                                             |                                             
+2023-05-28T08:45:44.504394Z   cluster1-1 joined                             |                                             |                                             
+2023-05-28T08:45:44.504948Z   |                                             cluster1-0 joined                             |                                             
+2023-05-28T08:45:44.504992Z   |                                             cluster1-2 joined                             |                                             
+2023-05-28T08:45:44.505616Z   |                                             |                                             cluster1-0 joined                             
+2023-05-28T08:45:44.505646Z   |                                             |                                             cluster1-1 joined                             
+2023-05-28T08:45:44.505932Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-28T08:45:44.506535Z   |                                             |                                             PRIMARY(n=3)                                  
+2023-05-28T08:45:44.945587Z   CLOSED -> OPEN                                |                                             |                                             
+2023-05-28T08:45:44.945768Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-28T08:45:44.947395Z   OPEN -> PRIMARY                               |                                             |                                             
+2023-05-28T08:45:45.576073Z   will receive IST(seqno:8616014)               |                                             |                                             
+2023-05-28T08:45:45.577425Z   cluster1-1 will resync local node             |                                             |                                             
+2023-05-28T08:45:45.577501Z   PRIMARY -> JOINER                             |                                             |                                             
+2023-05-28T08:45:45.577952Z   |                                             local node will resync cluster1-0             |                                             
+2023-05-28T08:45:45.578054Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-28T08:45:45.578639Z   |                                             |                                             cluster1-1 will resync cluster1-0             
+2023-05-28T08:45:45.591166Z   |                                             IST to cluster1-0(seqno:8616014)              |                                             
+2023-05-28T08:45:45.986742Z   |                                             IST will be used                              |                                             
+2023-05-28T08:45:47.004479Z   got IST from cluster1-1                       |                                             |                                             
+2023-05-28T08:45:47.005056Z   |                                             finished sending IST to cluster1-0            |                                             
+2023-05-28T08:45:47.005159Z   |                                             DESYNCED -> JOINED                            |                                             
+2023-05-28T08:45:47.005643Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-28T08:45:47.005725Z   |                                             |                                             cluster1-1 synced cluster1-0                  
+2023-05-28T08:45:58.262507Z   wsrep recovery                                |                                             |                                             
+2023-05-28T08:45:58.828269Z   IST received(seqno:8616014)                   |                                             |                                             
+2023-05-28T08:45:58.829309Z   JOINER -> JOINED                              |                                             |                                             
+2023-05-28T08:45:58.829961Z   JOINED -> SYNCED                              |                                             |                                             
+2023-05-28T08:52:18.119268Z   (repeated x408)too many connections           |                                             |                                             
+2023-05-28T08:52:47.465770Z   |                                             |                                             (repeated x9)too many connections             
+2023-05-28T08:53:48.040160Z   too many connections                          |                                             |                                             
+2023-05-28T08:53:48.056529Z   |                                             |                                             too many connections                          
+2023-05-28T08:54:21.486294Z   |                                             received shutdown                             |                                             
+2023-05-28T08:55:07.630416Z   cluster1-2 joined                             |                                             |                                             
+2023-05-28T08:55:07.630563Z   cluster1-1 left                               |                                             |                                             
+2023-05-28T08:55:07.630879Z   |                                             NON-PRIMARY(n=1)                              |                                             
+2023-05-28T08:55:07.631003Z   |                                             SYNCED -> OPEN                                |                                             
+2023-05-28T08:55:07.631060Z   |                                             OPEN -> CLOSED                                |                                             
+2023-05-28T08:55:07.631347Z   |                                             |                                             cluster1-0 joined                             
+2023-05-28T08:55:07.631488Z   |                                             |                                             cluster1-1 left                               
+2023-05-28T08:55:07.631670Z   cluster1-1 left                               |                                             |                                             
+2023-05-28T08:55:07.631751Z   PRIMARY(n=2)                                  |                                             |                                             
+2023-05-28T08:55:07.632948Z   |                                             |                                             cluster1-1 left                               
+2023-05-28T08:55:07.633020Z   |                                             |                                             PRIMARY(n=2)                                  
+2023-05-28T08:55:37.412783Z   |                                             shutdown complete                             |                                             
+2023-05-28T08:55:51.876757Z   |                                             starting(8.0.31)                              |                                             
+2023-05-28T08:55:51.886863Z   |                                             started(cluster)                              |                                             
+2023-05-28T08:55:51.888167Z   |                                             recovering gcache                             |                                             
+2023-05-28T08:55:52.546135Z   |                                             recovering gcache                             |                                             
+2023-05-28T08:55:53.692114Z   cluster1-1 joined                             |                                             |                                             
+2023-05-28T08:55:53.692201Z   cluster1-2 joined                             |                                             |                                             
+2023-05-28T08:55:53.692388Z   |                                             cluster1-0 joined                             |                                             
+2023-05-28T08:55:53.692399Z   |                                             cluster1-2 joined                             |                                             
+2023-05-28T08:55:53.692911Z   |                                             |                                             cluster1-0 joined                             
+2023-05-28T08:55:53.693001Z   |                                             |                                             cluster1-1 joined                             
+2023-05-28T08:55:53.694007Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-28T08:55:53.694614Z   |                                             |                                             PRIMARY(n=3)                                  
+2023-05-28T08:55:54.183486Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-28T08:55:54.183677Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-28T08:55:54.186317Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-28T08:55:54.807556Z   |                                             will receive IST(seqno:8618666)               |                                             
+2023-05-28T08:55:54.808270Z   cluster1-2 will resync cluster1-1             |                                             |                                             
+2023-05-28T08:55:54.808658Z   |                                             cluster1-2 will resync local node             |                                             
+2023-05-28T08:55:54.808706Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-28T08:55:54.809248Z   |                                             |                                             local node will resync cluster1-1             
+2023-05-28T08:55:54.809337Z   |                                             |                                             SYNCED -> DONOR                               
+2023-05-28T08:55:54.823835Z   |                                             |                                             IST to cluster1-1(seqno:8618666)              
+2023-05-28T08:55:55.177191Z   |                                             |                                             IST will be used                              
+2023-05-28T08:55:56.193609Z   cluster1-2 synced cluster1-1                  |                                             |                                             
+2023-05-28T08:55:56.193999Z   |                                             got IST from cluster1-2                       |                                             
+2023-05-28T08:55:56.194486Z   |                                             |                                             finished sending IST to cluster1-1            
+2023-05-28T08:55:56.194594Z   |                                             |                                             DESYNCED -> JOINED                            
+2023-05-28T08:55:56.195234Z   |                                             |                                             JOINED -> SYNCED                              
+2023-05-28T08:56:07.958413Z   |                                             wsrep recovery                                |                                             
+2023-05-28T08:56:08.256725Z   |                                             IST received(seqno:8618666)                   |                                             
+2023-05-28T08:56:08.257640Z   |                                             JOINER -> JOINED                              |                                             
+2023-05-28T08:56:08.258254Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-29T03:00:17.916558Z   |                                             |                                             garb joined                                   
+2023-05-29T03:00:17.916588Z   |                                             |                                             cluster1-0 joined                             
+2023-05-29T03:00:17.916596Z   |                                             |                                             cluster1-1 joined                             
+2023-05-29T03:00:17.917011Z   garb joined                                   |                                             |                                             
+2023-05-29T03:00:17.917037Z   cluster1-1 joined                             |                                             |                                             
+2023-05-29T03:00:17.917043Z   cluster1-2 joined                             |                                             |                                             
+2023-05-29T03:00:17.917285Z   |                                             garb joined                                   |                                             
+2023-05-29T03:00:17.917372Z   |                                             cluster1-0 joined                             |                                             
+2023-05-29T03:00:17.917383Z   |                                             cluster1-2 joined                             |                                             
+2023-05-29T03:00:18.919405Z   |                                             |                                             PRIMARY(n=4)                                  
+2023-05-29T03:00:18.919902Z   PRIMARY(n=4)                                  |                                             |                                             
+2023-05-29T03:00:18.919952Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-29T03:00:19.379393Z   |                                             |                                             local node will resync garb                   
+2023-05-29T03:00:19.379427Z   |                                             |                                             SYNCED -> DONOR                               
+2023-05-29T03:00:19.379660Z   cluster1-2 will resync garb                   |                                             |                                             
+2023-05-29T03:00:19.379736Z   |                                             cluster1-2 will resync garb                   |                                             
+2023-05-29T03:00:30.869972Z   |                                             |                                             SST to garb                                   
+2023-05-29T03:41:39.124527Z   |                                             |                                             finished sending SST to garb                  
+2023-05-29T03:41:39.124632Z   |                                             |                                             DESYNCED -> JOINED                            
+2023-05-29T03:41:39.125339Z   |                                             |                                             JOINED -> SYNCED                              
+2023-05-29T03:41:39.125763Z   |                                             cluster1-2 synced garb                        |                                             
+2023-05-29T03:41:39.125854Z   cluster1-2 synced garb                        |                                             |                                             
+2023-05-29T05:00:37.738615Z   |                                             |                                             garb joined                                   
+2023-05-29T05:00:37.738711Z   |                                             |                                             cluster1-0 joined                             
+2023-05-29T05:00:37.738735Z   |                                             |                                             cluster1-1 joined                             
+2023-05-29T05:00:37.738755Z   |                                             |                                             garb joined                                   
+2023-05-29T05:00:37.740237Z   garb joined                                   |                                             |                                             
+2023-05-29T05:00:37.740269Z   |                                             garb joined                                   |                                             
+2023-05-29T05:00:37.740320Z   cluster1-1 joined                             |                                             |                                             
+2023-05-29T05:00:37.740345Z   cluster1-2 joined                             |                                             |                                             
+2023-05-29T05:00:37.740366Z   garb joined                                   |                                             |                                             
+2023-05-29T05:00:37.740402Z   |                                             cluster1-0 joined                             |                                             
+2023-05-29T05:00:37.740430Z   |                                             cluster1-2 joined                             |                                             
+2023-05-29T05:00:37.740475Z   |                                             garb joined                                   |                                             
+2023-05-29T05:00:37.740651Z   |                                             |                                             PRIMARY(n=5)                                  
+2023-05-29T05:00:37.742138Z   |                                             PRIMARY(n=5)                                  |                                             
+2023-05-29T05:00:37.742177Z   PRIMARY(n=5)                                  |                                             |                                             
+2023-05-29T05:00:38.239851Z   |                                             |                                             local node will resync garb                   
+2023-05-29T05:00:38.239874Z   |                                             |                                             SYNCED -> DONOR                               
+2023-05-29T05:00:38.241430Z   |                                             cluster1-2 will resync garb                   |                                             
+2023-05-29T05:00:38.241476Z   cluster1-2 will resync garb                   |                                             |                                             
+2023-05-29T05:00:49.731756Z   |                                             |                                             SST to garb                                   
+2023-05-29T05:54:56.049218Z   |                                             |                                             finished sending SST to garb                  
+2023-05-29T05:54:56.049291Z   |                                             |                                             DESYNCED -> JOINED                            
+2023-05-29T05:54:56.049762Z   |                                             |                                             JOINED -> SYNCED                              
+2023-05-29T05:54:56.050912Z   |                                             cluster1-2 synced garb                        |                                             
+2023-05-29T05:54:56.050919Z   cluster1-2 synced garb                        |                                             |                                             
+2023-05-29T05:54:58.219414Z   |                                             |                                             garb joined                                   
+2023-05-29T05:54:58.219474Z   |                                             |                                             cluster1-0 joined                             
+2023-05-29T05:54:58.219489Z   |                                             |                                             cluster1-1 joined                             
+2023-05-29T05:54:58.219504Z   |                                             |                                             garb left                                     
+2023-05-29T05:54:58.220860Z   garb joined                                   |                                             |                                             
+2023-05-29T05:54:58.220913Z   cluster1-1 joined                             |                                             |                                             
+2023-05-29T05:54:58.220925Z   cluster1-2 joined                             |                                             |                                             
+2023-05-29T05:54:58.220954Z   garb left                                     |                                             |                                             
+2023-05-29T05:54:58.221144Z   |                                             garb joined                                   |                                             
+2023-05-29T05:54:58.221241Z   |                                             cluster1-0 joined                             |                                             
+2023-05-29T05:54:58.221263Z   |                                             cluster1-2 joined                             |                                             
+2023-05-29T05:54:58.221280Z   |                                             garb left                                     |                                             
+2023-05-29T05:55:03.220834Z   |                                             |                                             garb suspected to be down                     
+2023-05-29T05:55:03.222309Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T05:55:03.722761Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T05:55:04.222613Z   |                                             |                                             cluster1-0 joined                             
+2023-05-29T05:55:04.222670Z   |                                             |                                             cluster1-1 joined                             
+2023-05-29T05:55:04.223778Z   |                                             |                                             garb left                                     
+2023-05-29T05:55:04.223869Z   |                                             |                                             PRIMARY(n=3)                                  
+2023-05-29T05:55:04.224239Z   |                                             cluster1-0 joined                             |                                             
+2023-05-29T05:55:04.224260Z   |                                             cluster1-2 joined                             |                                             
+2023-05-29T05:55:04.224438Z   cluster1-1 joined                             |                                             |                                             
+2023-05-29T05:55:04.224539Z   cluster1-2 joined                             |                                             |                                             
+2023-05-29T05:55:04.225735Z   |                                             garb left                                     |                                             
+2023-05-29T05:55:04.225794Z   garb left                                     |                                             |                                             
+2023-05-29T05:55:04.225815Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-29T05:55:04.225876Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-29T06:18:41.339691Z   |                                             |                                             cluster1-0 joined                             
+2023-05-29T06:18:41.339777Z   |                                             |                                             cluster1-1 joined                             
+2023-05-29T06:18:41.339802Z   |                                             |                                             garb joined                                   
+2023-05-29T06:18:41.340638Z   cluster1-1 joined                             |                                             |                                             
+2023-05-29T06:18:41.340748Z   cluster1-2 joined                             |                                             |                                             
+2023-05-29T06:18:41.340777Z   garb joined                                   |                                             |                                             
+2023-05-29T06:18:41.340846Z   |                                             cluster1-0 joined                             |                                             
+2023-05-29T06:18:41.340903Z   |                                             cluster1-2 joined                             |                                             
+2023-05-29T06:18:41.340914Z   |                                             garb joined                                   |                                             
+2023-05-29T06:18:41.341398Z   |                                             |                                             PRIMARY(n=4)                                  
+2023-05-29T06:18:41.342417Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-29T06:18:41.342618Z   PRIMARY(n=4)                                  |                                             |                                             
+2023-05-29T06:18:41.840368Z   |                                             |                                             local node will resync garb                   
+2023-05-29T06:18:41.840393Z   |                                             |                                             SYNCED -> DONOR                               
+2023-05-29T06:18:41.841468Z   |                                             cluster1-2 will resync garb                   |                                             
+2023-05-29T06:18:41.841677Z   cluster1-2 will resync garb                   |                                             |                                             
+2023-05-29T06:18:53.370532Z   |                                             |                                             SST to garb                                   
+2023-05-29T06:21:16.932469Z   |                                             |                                             garb joined                                   
+2023-05-29T06:21:16.932542Z   |                                             |                                             cluster1-0 joined                             
+2023-05-29T06:21:16.932559Z   |                                             |                                             cluster1-1 joined                             
+2023-05-29T06:21:16.932574Z   |                                             |                                             garb joined                                   
+2023-05-29T06:21:16.933460Z   |                                             garb joined                                   |                                             
+2023-05-29T06:21:16.933530Z   |                                             cluster1-0 joined                             |                                             
+2023-05-29T06:21:16.933543Z   |                                             cluster1-2 joined                             |                                             
+2023-05-29T06:21:16.933554Z   |                                             garb joined                                   |                                             
+2023-05-29T06:21:16.933921Z   garb joined                                   |                                             |                                             
+2023-05-29T06:21:16.933996Z   cluster1-1 joined                             |                                             |                                             
+2023-05-29T06:21:16.934011Z   cluster1-2 joined                             |                                             |                                             
+2023-05-29T06:21:16.934022Z   garb joined                                   |                                             |                                             
+2023-05-29T06:21:16.934118Z   |                                             |                                             PRIMARY(n=5)                                  
+2023-05-29T06:21:16.935175Z   |                                             PRIMARY(n=5)                                  |                                             
+2023-05-29T06:21:16.935415Z   PRIMARY(n=5)                                  |                                             |                                             
+2023-05-29T06:21:17.398796Z   |                                             |                                             cluster1-1 will resync garb                   
+2023-05-29T06:21:17.399780Z   |                                             local node will resync garb                   |                                             
+2023-05-29T06:21:17.399791Z   |                                             SYNCED -> DONOR                               |                                             
+2023-05-29T06:21:17.400070Z   cluster1-1 will resync garb                   |                                             |                                             
+2023-05-29T06:21:28.872272Z   |                                             SST to garb                                   |                                             
+2023-05-29T07:16:31.663110Z   |                                             cluster1-2 synced garb                        |                                             
+2023-05-29T07:16:31.663588Z   cluster1-2 synced garb                        |                                             |                                             
+2023-05-29T07:16:31.664728Z   |                                             |                                             finished sending SST to garb                  
+2023-05-29T07:16:31.664811Z   |                                             |                                             DESYNCED -> JOINED                            
+2023-05-29T07:16:31.665547Z   |                                             |                                             JOINED -> SYNCED                              
+2023-05-29T07:16:33.678136Z   |                                             |                                             garb joined                                   
+2023-05-29T07:16:33.678217Z   |                                             |                                             cluster1-0 joined                             
+2023-05-29T07:16:33.678236Z   |                                             |                                             cluster1-1 joined                             
+2023-05-29T07:16:33.678252Z   |                                             |                                             garb left                                     
+2023-05-29T07:16:34.694046Z   |                                             SST error                                     |                                             
+2023-05-29T07:16:38.678115Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:38.678140Z   cluster1-2 suspected to be down               |                                             |                                             
+2023-05-29T07:16:38.678174Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:38.678187Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:38.678199Z   |                                             cluster1-2 suspected to be down               |                                             
+2023-05-29T07:16:38.678232Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:38.679876Z   |                                             |                                             garb suspected to be down                     
+2023-05-29T07:16:38.679923Z   |                                             |                                             cluster1-0 suspected to be down               
+2023-05-29T07:16:38.679965Z   |                                             |                                             cluster1-1 suspected to be down               
+2023-05-29T07:16:39.178309Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:39.178383Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:39.178407Z   cluster1-2 suspected to be down               |                                             |                                             
+2023-05-29T07:16:39.178437Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:39.178468Z   |                                             cluster1-2 suspected to be down               |                                             
+2023-05-29T07:16:39.178496Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:39.678585Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:39.678620Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:39.678649Z   |                                             cluster1-2 suspected to be down               |                                             
+2023-05-29T07:16:39.678672Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:39.678717Z   cluster1-2 suspected to be down               |                                             |                                             
+2023-05-29T07:16:39.678763Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:39.680986Z   |                                             |                                             NON-PRIMARY(n=1)                              
+2023-05-29T07:16:39.681204Z   |                                             |                                             SYNCED -> OPEN                                
+2023-05-29T07:16:39.681241Z   |                                             |                                             NON-PRIMARY(n=1)                              
+2023-05-29T07:16:40.178884Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:40.178983Z   cluster1-2 suspected to be down               |                                             |                                             
+2023-05-29T07:16:40.179015Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:40.179037Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:40.179126Z   |                                             cluster1-2 suspected to be down               |                                             
+2023-05-29T07:16:40.179154Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:40.679187Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:40.679234Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:40.679286Z   |                                             cluster1-2 suspected to be down               |                                             
+2023-05-29T07:16:40.679287Z   cluster1-2 suspected to be down               |                                             |                                             
+2023-05-29T07:16:40.679299Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:40.679313Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:41.679431Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:41.679447Z   cluster1-2 suspected to be down               |                                             |                                             
+2023-05-29T07:16:41.679615Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:41.679645Z   |                                             cluster1-2 suspected to be down               |                                             
+2023-05-29T07:16:42.179558Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:42.179662Z   cluster1-2 suspected to be down               |                                             |                                             
+2023-05-29T07:16:42.179845Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:42.179935Z   |                                             cluster1-2 suspected to be down               |                                             
+2023-05-29T07:16:42.679809Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:42.679917Z   cluster1-2 suspected to be down               |                                             |                                             
+2023-05-29T07:16:42.680147Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:42.680227Z   |                                             cluster1-2 suspected to be down               |                                             
+2023-05-29T07:16:43.179985Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:43.180032Z   cluster1-2 suspected to be down               |                                             |                                             
+2023-05-29T07:16:43.180363Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:43.180449Z   |                                             cluster1-2 suspected to be down               |                                             
+2023-05-29T07:16:43.680203Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:43.680308Z   cluster1-2 suspected to be down               |                                             |                                             
+2023-05-29T07:16:43.680663Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:43.680746Z   |                                             cluster1-2 suspected to be down               |                                             
+2023-05-29T07:16:44.180424Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:44.180519Z   cluster1-2 suspected to be down               |                                             |                                             
+2023-05-29T07:16:44.181005Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:44.181104Z   |                                             cluster1-2 suspected to be down               |                                             
+2023-05-29T07:16:44.680653Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:44.680716Z   cluster1-2 suspected to be down               |                                             |                                             
+2023-05-29T07:16:44.681319Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:44.681413Z   |                                             cluster1-2 suspected to be down               |                                             
+2023-05-29T07:16:45.180784Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:45.180828Z   cluster1-2 suspected to be down               |                                             |                                             
+2023-05-29T07:16:45.181934Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:45.182024Z   |                                             cluster1-2 suspected to be down               |                                             
+2023-05-29T07:16:45.680937Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:45.680994Z   cluster1-2 suspected to be down               |                                             |                                             
+2023-05-29T07:16:45.682205Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:45.682266Z   |                                             cluster1-2 suspected to be down               |                                             
+2023-05-29T07:16:46.181058Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:46.181106Z   cluster1-2 suspected to be down               |                                             |                                             
+2023-05-29T07:16:46.182370Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:46.182475Z   |                                             cluster1-2 suspected to be down               |                                             
+2023-05-29T07:16:46.681295Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:46.681392Z   cluster1-2 suspected to be down               |                                             |                                             
+2023-05-29T07:16:46.682637Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:46.682671Z   |                                             cluster1-2 suspected to be down               |                                             
+2023-05-29T07:16:47.181556Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:47.181655Z   cluster1-2 suspected to be down               |                                             |                                             
+2023-05-29T07:16:47.182793Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:47.182876Z   |                                             cluster1-2 suspected to be down               |                                             
+2023-05-29T07:16:47.681851Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:47.681934Z   cluster1-2 suspected to be down               |                                             |                                             
+2023-05-29T07:16:47.683061Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:47.683101Z   |                                             cluster1-2 suspected to be down               |                                             
+2023-05-29T07:16:48.182043Z   garb suspected to be down                     |                                             |                                             
+2023-05-29T07:16:48.182140Z   cluster1-2 suspected to be down               |                                             |                                             
+2023-05-29T07:16:48.183482Z   |                                             garb suspected to be down                     |                                             
+2023-05-29T07:16:48.183563Z   |                                             cluster1-2 suspected to be down               |                                             
+2023-05-29T07:16:48.682756Z   |                                             garb left                                     |                                             
+2023-05-29T07:16:48.682898Z   |                                             NON-PRIMARY(n=1)                              |                                             
+2023-05-29T07:16:48.682999Z   |                                             DESYNCED -> OPEN                              |                                             
+2023-05-29T07:16:48.683014Z   |                                             NON-PRIMARY(n=1)                              |                                             
+2023-05-29T07:16:48.683734Z   garb left                                     |                                             |                                             
+2023-05-29T07:16:48.683956Z   NON-PRIMARY(n=1)                              |                                             |                                             
+2023-05-29T07:16:48.684193Z   SYNCED -> OPEN                                |                                             |                                             
+2023-05-29T07:16:48.684230Z   NON-PRIMARY(n=1)                              |                                             |                                             
+2023-05-29T07:16:49.684876Z   |                                             cluster1-0 joined                             |                                             
+2023-05-29T07:16:49.684971Z   |                                             cluster1-2 joined                             |                                             
+2023-05-29T07:16:49.685351Z   cluster1-1 joined                             |                                             |                                             
+2023-05-29T07:16:49.685402Z   cluster1-2 joined                             |                                             |                                             
+2023-05-29T07:16:49.685497Z   |                                             NON-PRIMARY(n=3)                              |                                             
+2023-05-29T07:16:49.686149Z   NON-PRIMARY(n=3)                              |                                             |                                             
+2023-05-29T07:16:49.686256Z   |                                             |                                             unspecified joined                            
+2023-05-29T07:16:49.686310Z   |                                             |                                             cluster1-1 joined                             
+2023-05-29T07:16:49.687051Z   |                                             |                                             NON-PRIMARY(n=3)                              
+2023-05-29T07:17:06.846743Z   |                                             |                                             received shutdown                             
+2023-05-29T07:17:15.812255Z   received shutdown                             |                                             |                                             
+2023-05-29T07:17:16.848791Z   |                                             unspecified joined                            |                                             
+2023-05-29T07:17:16.848924Z   |                                             unspecified left                              |                                             
+2023-05-29T07:17:16.849374Z   unspecified joined                            |                                             |                                             
+2023-05-29T07:17:16.849499Z   unspecified left                              |                                             |                                             
+2023-05-29T07:17:16.850012Z   |                                             NON-PRIMARY(n=2)                              |                                             
+2023-05-29T07:17:16.850477Z   |                                             |                                             NON-PRIMARY(n=1)                              
+2023-05-29T07:17:16.850489Z   NON-PRIMARY(n=2)                              |                                             |                                             
+2023-05-29T07:17:16.850794Z   |                                             |                                             OPEN -> CLOSED                                
+2023-05-29T07:17:17.387918Z   |                                             received shutdown                             |                                             
+2023-05-29T07:17:26.815037Z   |                                             unspecified left                              |                                             
+2023-05-29T07:17:26.815352Z   |                                             NON-PRIMARY(n=1)                              |                                             
+2023-05-29T07:17:26.816357Z   NON-PRIMARY(n=1)                              |                                             |                                             
+2023-05-29T07:17:26.816671Z   OPEN -> CLOSED                                |                                             |                                             
+2023-05-29T07:17:27.390229Z   |                                             OPEN -> CLOSED                                |                                             
+2023-05-29T07:17:45.090041Z   |                                             |                                             shutdown complete                             
+2023-05-29T07:17:52.956890Z   shutdown complete                             |                                             |                                             
+2023-05-29T07:17:55.556216Z   |                                             shutdown complete                             |                                             
+2023-05-29T07:19:34.593510Z   starting(8.0.31)                              |                                             |                                             
+2023-05-29T07:19:34.607812Z   started(cluster)                              |                                             |                                             
+2023-05-29T07:19:34.608840Z   safe_to_bootstrap: 1                          |                                             |                                             
+2023-05-29T07:19:34.608976Z   recovering gcache                             |                                             |                                             
+2023-05-29T07:19:35.197239Z   recovering gcache                             |                                             |                                             
+2023-05-29T07:19:35.284187Z   bootstrapping                                 |                                             |                                             
+2023-05-29T07:19:35.284852Z   CLOSED -> OPEN                                |                                             |                                             
+2023-05-29T07:19:35.285076Z   PRIMARY(n=1)                                  |                                             |                                             
+2023-05-29T07:19:35.286156Z   (restored)OPEN -> JOINED                      |                                             |                                             
+2023-05-29T07:19:35.286229Z   JOINED -> SYNCED                              |                                             |                                             
+2023-05-29T07:20:12.578000Z   |                                             |                                             starting(8.0.31)                              
+2023-05-29T07:20:12.581823Z   |                                             |                                             started(cluster)                              
+2023-05-29T07:20:12.583060Z   |                                             |                                             recovering gcache                             
+2023-05-29T07:20:13.267704Z   |                                             |                                             recovering gcache                             
+2023-05-29T07:20:13.855900Z   cluster1-2 joined                             |                                             |                                             
+2023-05-29T07:20:13.857279Z   |                                             |                                             cluster1-0 joined                             
+2023-05-29T07:20:13.857329Z   PRIMARY(n=2)                                  |                                             |                                             
+2023-05-29T07:20:14.356588Z   |                                             |                                             CLOSED -> OPEN                                
+2023-05-29T07:20:14.356749Z   |                                             |                                             PRIMARY(n=2)                                  
+2023-05-29T07:20:14.358922Z   |                                             |                                             OPEN -> PRIMARY                               
+2023-05-29T07:20:14.962538Z   local node will resync cluster1-2             |                                             |                                             
+2023-05-29T07:20:14.962618Z   SYNCED -> DONOR                               |                                             |                                             
+2023-05-29T07:20:14.962620Z   |                                             |                                             will receive IST(seqno:9339113)               
+2023-05-29T07:20:14.963634Z   |                                             |                                             cluster1-0 will resync local node             
+2023-05-29T07:20:14.963723Z   |                                             |                                             PRIMARY -> JOINER                             
+2023-05-29T07:20:14.979257Z   IST to cluster1-2(seqno:9339113)              |                                             |                                             
+2023-05-29T07:20:15.349516Z   IST will be used                              |                                             |                                             
+2023-05-29T07:20:16.366198Z   finished sending IST to cluster1-2            |                                             |                                             
+2023-05-29T07:20:16.366270Z   DESYNCED -> JOINED                            |                                             |                                             
+2023-05-29T07:20:16.366599Z   JOINED -> SYNCED                              |                                             |                                             
+2023-05-29T07:20:16.367386Z   |                                             |                                             got IST from cluster1-0                       
+2023-05-29T07:20:28.138289Z   |                                             |                                             wsrep recovery                                
+2023-05-29T07:20:28.379593Z   |                                             |                                             IST received(seqno:9339113)                   
+2023-05-29T07:20:28.380334Z   |                                             |                                             JOINER -> JOINED                              
+2023-05-29T07:20:28.455306Z   |                                             |                                             JOINED -> SYNCED                              
+2023-05-29T07:20:30.982370Z   |                                             starting(8.0.31)                              |                                             
+2023-05-29T07:20:30.994020Z   |                                             started(cluster)                              |                                             
+2023-05-29T07:20:30.995328Z   |                                             recovering gcache                             |                                             
+2023-05-29T07:20:31.626044Z   |                                             recovering gcache                             |                                             
+2023-05-29T07:20:32.215655Z   |                                             cluster1-0 joined                             |                                             
+2023-05-29T07:20:32.215681Z   |                                             cluster1-2 joined                             |                                             
+2023-05-29T07:20:32.216241Z   cluster1-2 joined                             |                                             |                                             
+2023-05-29T07:20:32.216334Z   cluster1-1 joined                             |                                             |                                             
+2023-05-29T07:20:32.217405Z   |                                             |                                             cluster1-0 joined                             
+2023-05-29T07:20:32.217511Z   |                                             |                                             cluster1-1 joined                             
+2023-05-29T07:20:32.217863Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-29T07:20:32.219022Z   |                                             |                                             PRIMARY(n=3)                                  
+2023-05-29T07:20:32.714734Z   |                                             CLOSED -> OPEN                                |                                             
+2023-05-29T07:20:32.714910Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-29T07:20:32.717573Z   |                                             OPEN -> PRIMARY                               |                                             
+2023-05-29T07:20:33.299585Z   |                                             will receive IST(seqno:9339350)               |                                             
+2023-05-29T07:20:33.300653Z   |                                             cluster1-0 will resync local node             |                                             
+2023-05-29T07:20:33.300727Z   |                                             PRIMARY -> JOINER                             |                                             
+2023-05-29T07:20:33.301361Z   local node will resync cluster1-1             |                                             |                                             
+2023-05-29T07:20:33.301459Z   SYNCED -> DONOR                               |                                             |                                             
+2023-05-29T07:20:33.302423Z   |                                             |                                             cluster1-0 will resync cluster1-1             
+2023-05-29T07:20:33.314392Z   IST to cluster1-1(seqno:9339350)              |                                             |                                             
+2023-05-29T07:20:33.730384Z   IST will be used                              |                                             |                                             
+2023-05-29T07:20:34.750551Z   |                                             got IST from cluster1-0                       |                                             
+2023-05-29T07:20:34.751280Z   finished sending IST to cluster1-1            |                                             |                                             
+2023-05-29T07:20:34.751368Z   DESYNCED -> JOINED                            |                                             |                                             
+2023-05-29T07:20:34.751983Z   JOINED -> SYNCED                              |                                             |                                             
+2023-05-29T07:20:34.752408Z   |                                             |                                             cluster1-0 synced cluster1-1                  
+2023-05-29T07:20:47.797067Z   |                                             wsrep recovery                                |                                             
+2023-05-29T07:20:48.198421Z   |                                             IST received(seqno:9339350)                   |                                             
+2023-05-29T07:20:48.199500Z   |                                             JOINER -> JOINED                              |                                             
+2023-05-29T07:20:48.200243Z   |                                             JOINED -> SYNCED                              |                                             
+2023-05-29T07:54:32.160958Z   |                                             garb joined                                   |                                             
+2023-05-29T07:54:32.161002Z   |                                             cluster1-0 joined                             |                                             
+2023-05-29T07:54:32.161009Z   |                                             cluster1-2 joined                             |                                             
+2023-05-29T07:54:32.161040Z   garb joined                                   |                                             |                                             
+2023-05-29T07:54:32.161077Z   cluster1-2 joined                             |                                             |                                             
+2023-05-29T07:54:32.161084Z   cluster1-1 joined                             |                                             |                                             
+2023-05-29T07:54:32.161868Z   |                                             PRIMARY(n=4)                                  |                                             
+2023-05-29T07:54:32.161979Z   PRIMARY(n=4)                                  |                                             |                                             
+2023-05-29T07:54:32.164088Z   |                                             |                                             garb joined                                   
+2023-05-29T07:54:32.164138Z   |                                             |                                             cluster1-0 joined                             
+2023-05-29T07:54:32.164147Z   |                                             |                                             cluster1-1 joined                             
+2023-05-29T07:54:32.165047Z   |                                             |                                             PRIMARY(n=4)                                  
+2023-05-29T07:54:32.440770Z   |                                             cluster1-2 will resync garb                   |                                             
+2023-05-29T07:54:32.440867Z   cluster1-2 will resync garb                   |                                             |                                             
+2023-05-29T07:54:32.443905Z   |                                             |                                             local node will resync garb                   
+2023-05-29T07:54:32.443943Z   |                                             |                                             SYNCED -> DONOR                               
+2023-05-29T07:54:43.911767Z   |                                             |                                             SST to garb                                   
+2023-05-29T08:45:19.117463Z   |                                             cluster1-2 synced garb                        |                                             
+2023-05-29T08:45:19.117474Z   cluster1-2 synced garb                        |                                             |                                             
+2023-05-29T08:45:19.121268Z   |                                             |                                             finished sending SST to garb                  
+2023-05-29T08:45:19.121298Z   |                                             |                                             DESYNCED -> JOINED                            
+2023-05-29T08:45:19.122002Z   |                                             |                                             JOINED -> SYNCED                              
+2023-05-29T08:45:21.448009Z   cluster1-2 joined                             |                                             |                                             
+2023-05-29T08:45:21.448042Z   cluster1-1 joined                             |                                             |                                             
+2023-05-29T08:45:21.448063Z   garb left                                     |                                             |                                             
+2023-05-29T08:45:21.448135Z   |                                             cluster1-0 joined                             |                                             
+2023-05-29T08:45:21.448173Z   |                                             cluster1-2 joined                             |                                             
+2023-05-29T08:45:21.448197Z   |                                             garb left                                     |                                             
+2023-05-29T08:45:21.449441Z   garb left                                     |                                             |                                             
+2023-05-29T08:45:21.449521Z   PRIMARY(n=3)                                  |                                             |                                             
+2023-05-29T08:45:21.449586Z   |                                             garb left                                     |                                             
+2023-05-29T08:45:21.449684Z   |                                             PRIMARY(n=3)                                  |                                             
+2023-05-29T08:45:21.451385Z   |                                             |                                             cluster1-0 joined                             
+2023-05-29T08:45:21.451433Z   |                                             |                                             cluster1-1 joined                             
+2023-05-29T08:45:21.451442Z   |                                             |                                             garb left                                     
+2023-05-29T08:45:21.454564Z   |                                             |                                             garb left                                     
+2023-05-29T08:45:21.454608Z   |                                             |                                             PRIMARY(n=3)                                  
+                                                                                                                                                                        
+identifier                    cluster1-0                                    cluster1-1                                    cluster1-2                                    
+current path                  tests/logs/operator_ambiguous_ips/node1.log   tests/logs/operator_ambiguous_ips/node2.log   tests/logs/operator_ambiguous_ips/node3.log   
+last known ip                 10.16.29.34                                   10.16.27.98                                   10.16.28.213                                  
+last known name               cluster1-0                                    cluster1-1                                    cluster1-2                                    
+mysql version                 8.0.31                                        8.0.31                                        8.0.31                                        

--- a/src/go/pt-galera-log-explainer/tests/expected/operator_concurrent_ssts_list_all_no_color
+++ b/src/go/pt-galera-log-explainer/tests/expected/operator_concurrent_ssts_list_all_no_color
@@ -1,4 +1,4 @@
-identifier                    tests/logs/operator_concurrent_ssts/node1.log   tests/logs/operator_concurrent_ssts/node2.log   tests/logs/operator_concurrent_ssts/node3.log   
+identifier                    cluster1-0                                      cluster1-1                                      cluster1-2                                      
 current path                  tests/logs/operator_concurrent_ssts/node1.log   tests/logs/operator_concurrent_ssts/node2.log   tests/logs/operator_concurrent_ssts/node3.log   
 last known ip                 10.16.29.34                                     10.16.27.98                                     10.16.28.213                                    
 last known name               cluster1-0                                      cluster1-1                                      cluster1-2                                      
@@ -788,7 +788,7 @@ mysql version                 8.0.31                                          8.
 2023-05-29T08:45:21.454564Z   |                                               |                                               garb left                                       
 2023-05-29T08:45:21.454608Z   |                                               |                                               PRIMARY(n=3)                                    
                                                                                                                                                                               
-identifier                    tests/logs/operator_concurrent_ssts/node1.log   tests/logs/operator_concurrent_ssts/node2.log   tests/logs/operator_concurrent_ssts/node3.log   
+identifier                    cluster1-0                                      cluster1-1                                      cluster1-2                                      
 current path                  tests/logs/operator_concurrent_ssts/node1.log   tests/logs/operator_concurrent_ssts/node2.log   tests/logs/operator_concurrent_ssts/node3.log   
 last known ip                 10.16.29.34                                     10.16.27.98                                     10.16.28.213                                    
 last known name               cluster1-0                                      cluster1-1                                      cluster1-2                                      

--- a/src/go/pt-galera-log-explainer/tests/expected/operator_split_list_all_no_color
+++ b/src/go/pt-galera-log-explainer/tests/expected/operator_split_list_all_no_color
@@ -1,0 +1,132 @@
+identifier                    cluster1-pxc-0                                          cluster1-pxc-1                             cluster1-pxc-2                             
+current path                  tests/logs/operator_split/node0.log                     tests/logs/operator_split/node1.log        tests/logs/operator_split/node2.log        
+last known ip                 10.42.0.5                                               10.42.2.8                                  10.42.1.10                                 
+last known name               cluster1-pxc-0                                          cluster1-pxc-1                             cluster1-pxc-2                             
+mysql version                 8.0.32                                                  8.0.32                                     8.0.32                                     
+                                                                                                                                                                            
+2024-02-09T10:43:18.764700Z   started(standalone)                                     |                                          |                                          
+2024-02-09T10:43:29.907284Z   starting(8.0.32, could not catch how/when it stopped)   |                                          |                                          
+2024-02-09T10:43:29.911161Z   started(cluster)                                        |                                          |                                          
+2024-02-09T10:43:29.912919Z   no grastate.dat file                                    |                                          |                                          
+2024-02-09T10:43:29.912934Z   bootstrapping(empty grastate)                           |                                          |                                          
+2024-02-09T10:43:29.913010Z   safe_to_bootstrap: 1                                    |                                          |                                          
+2024-02-09T10:43:29.943469Z   bootstrapping                                           |                                          |                                          
+2024-02-09T10:43:29.951652Z   CLOSED -> OPEN                                          |                                          |                                          
+2024-02-09T10:43:29.951979Z   PRIMARY(n=1)                                            |                                          |                                          
+2024-02-09T10:43:29.952352Z   (restored)OPEN -> JOINED                                |                                          |                                          
+2024-02-09T10:43:29.952384Z   JOINED -> SYNCED                                        |                                          |                                          
+2024-02-09T10:43:34.188233Z   received shutdown                                       |                                          |                                          
+2024-02-09T10:43:44.190649Z   SYNCED -> CLOSED                                        |                                          |                                          
+2024-02-09T10:43:46.563893Z   shutdown complete                                       |                                          |                                          
+2024-02-09T10:43:58.465095Z   starting(8.0.32)                                        |                                          |                                          
+2024-02-09T10:43:58.470074Z   started(cluster)                                        |                                          |                                          
+2024-02-09T10:43:58.471892Z   safe_to_bootstrap: 1                                    |                                          |                                          
+2024-02-09T10:43:58.472170Z   recovering gcache                                       |                                          |                                          
+2024-02-09T10:43:58.472225Z   recovering gcache                                       |                                          |                                          
+2024-02-09T10:43:58.491964Z   bootstrapping                                           |                                          |                                          
+2024-02-09T10:43:58.499487Z   CLOSED -> OPEN                                          |                                          |                                          
+2024-02-09T10:43:58.499690Z   PRIMARY(n=1)                                            |                                          |                                          
+2024-02-09T10:43:58.499964Z   (restored)OPEN -> JOINED                                |                                          |                                          
+2024-02-09T10:43:58.499994Z   JOINED -> SYNCED                                        |                                          |                                          
+2024-02-09T10:45:04.175273Z   |                                                       starting(8.0.32)                           |                                          
+2024-02-09T10:45:04.179554Z   |                                                       started(cluster)                           |                                          
+2024-02-09T10:45:04.181272Z   |                                                       no grastate.dat file                       |                                          
+2024-02-09T10:45:04.181292Z   |                                                       bootstrapping(empty grastate)              |                                          
+2024-02-09T10:45:04.181350Z   |                                                       safe_to_bootstrap: 1                       |                                          
+2024-02-09T10:45:04.719407Z   cluster1-pxc-1 joined                                   |                                          |                                          
+2024-02-09T10:45:04.719538Z   |                                                       cluster1-pxc-0 joined                      |                                          
+2024-02-09T10:45:04.737264Z   PRIMARY(n=2)                                            |                                          |                                          
+2024-02-09T10:45:05.218295Z   |                                                       CLOSED -> OPEN                             |                                          
+2024-02-09T10:45:05.218502Z   |                                                       PRIMARY(n=2)                               |                                          
+2024-02-09T10:45:05.219600Z   |                                                       OPEN -> PRIMARY                            |                                          
+2024-02-09T10:45:06.301742Z   |                                                       will receive SST                           |                                          
+2024-02-09T10:45:06.302574Z   |                                                       cluster1-pxc-0 will resync local node      |                                          
+2024-02-09T10:45:06.302624Z   |                                                       PRIMARY -> JOINER                          |                                          
+2024-02-09T10:45:06.302828Z   local node will resync cluster1-pxc-1                   |                                          |                                          
+2024-02-09T10:45:06.302913Z   SYNCED -> DONOR                                         |                                          |                                          
+2024-02-09T10:45:06.312458Z   IST to cluster1-pxc-1(seqno:35)                         |                                          |                                          
+2024-02-09T10:45:08.158143Z   |                                                       receiving SST                              |                                          
+2024-02-09T10:45:18.201951Z   SST to cluster1-pxc-1                                   |                                          |                                          
+2024-02-09T10:45:21.265590Z   finished sending IST to cluster1-pxc-1                  |                                          |                                          
+2024-02-09T10:45:21.265656Z   DESYNCED -> JOINED                                      |                                          |                                          
+2024-02-09T10:45:21.265687Z   |                                                       got SST from cluster1-pxc-0                |                                          
+2024-02-09T10:45:21.266336Z   JOINED -> SYNCED                                        |                                          |                                          
+2024-02-09T10:45:21.272868Z   |                                                       preparing SST backup                       |                                          
+2024-02-09T10:45:27.690579Z   |                                                       wsrep recovery                             |                                          
+2024-02-09T10:45:27.707754Z   |                                                       IST received(seqno:35)                     |                                          
+2024-02-09T10:45:27.708442Z   |                                                       JOINER -> JOINED                           |                                          
+2024-02-09T10:45:27.709084Z   |                                                       JOINED -> SYNCED                           |                                          
+2024-02-09T10:46:35.633632Z   |                                                       |                                          starting(8.0.32)                           
+2024-02-09T10:46:35.638118Z   |                                                       |                                          started(cluster)                           
+2024-02-09T10:46:35.639792Z   |                                                       |                                          no grastate.dat file                       
+2024-02-09T10:46:35.639806Z   |                                                       |                                          bootstrapping(empty grastate)              
+2024-02-09T10:46:35.639870Z   |                                                       |                                          safe_to_bootstrap: 1                       
+2024-02-09T10:45:23.538218Z   |                                                       starting(8.0.32)(post.processing.log)      |                                          
+2024-02-09T10:45:24.441865Z   |                                                       started(standalone)(post.processing.log)   |                                          
+2024-02-09T10:45:26.683757Z   |                                                       shutdown complete(post.processing.log)     |                                          
+2024-02-09T10:46:36.177246Z   |                                                       cluster1-pxc-0 joined                      |                                          
+2024-02-09T10:46:36.177345Z   |                                                       cluster1-pxc-2 joined                      |                                          
+2024-02-09T10:46:36.177674Z   cluster1-pxc-1 joined                                   |                                          |                                          
+2024-02-09T10:46:36.177738Z   cluster1-pxc-2 joined                                   |                                          |                                          
+2024-02-09T10:46:36.178025Z   |                                                       |                                          cluster1-pxc-0 joined                      
+2024-02-09T10:46:36.178042Z   |                                                       |                                          cluster1-pxc-1 joined                      
+2024-02-09T10:46:37.195810Z   |                                                       PRIMARY(n=3)                               |                                          
+2024-02-09T10:46:37.195858Z   PRIMARY(n=3)                                            |                                          |                                          
+2024-02-09T10:46:37.676991Z   |                                                       |                                          CLOSED -> OPEN                             
+2024-02-09T10:46:37.677354Z   |                                                       |                                          PRIMARY(n=3)                               
+2024-02-09T10:46:37.679340Z   |                                                       |                                          OPEN -> PRIMARY                            
+2024-02-09T10:46:38.762965Z   |                                                       |                                          will receive SST                           
+2024-02-09T10:46:38.764075Z   |                                                       |                                          cluster1-pxc-1 will resync local node      
+2024-02-09T10:46:38.764092Z   |                                                       |                                          PRIMARY -> JOINER                          
+2024-02-09T10:46:38.764127Z   |                                                       local node will resync cluster1-pxc-2      |                                          
+2024-02-09T10:46:38.764189Z   cluster1-pxc-1 will resync cluster1-pxc-2               |                                          |                                          
+2024-02-09T10:46:38.764195Z   |                                                       SYNCED -> DONOR                            |                                          
+2024-02-09T10:46:38.774983Z   |                                                       IST to cluster1-pxc-2(seqno:36)            |                                          
+2024-02-09T10:46:40.617441Z   |                                                       |                                          receiving SST                              
+2024-02-09T10:46:50.653965Z   |                                                       SST to cluster1-pxc-2                      |                                          
+2024-02-09T10:46:53.708248Z   |                                                       finished sending IST to cluster1-pxc-2     |                                          
+2024-02-09T10:46:53.708271Z   cluster1-pxc-1 synced cluster1-pxc-2                    |                                          |                                          
+2024-02-09T10:46:53.708314Z   |                                                       DESYNCED -> JOINED                         |                                          
+2024-02-09T10:46:53.708455Z   |                                                       |                                          got SST from cluster1-pxc-1                
+2024-02-09T10:46:53.709514Z   |                                                       JOINED -> SYNCED                           |                                          
+2024-02-09T10:46:53.715924Z   |                                                       |                                          preparing SST backup                       
+2024-02-09T10:46:55.948110Z   |                                                       |                                          starting(8.0.32)(post.processing.log)      
+2024-02-09T10:46:56.967340Z   |                                                       |                                          started(standalone)(post.processing.log)   
+2024-02-09T10:46:59.255089Z   |                                                       |                                          shutdown complete(post.processing.log)     
+2024-02-09T10:47:00.605623Z   |                                                       |                                          wsrep recovery                             
+2024-02-09T10:47:00.622122Z   |                                                       |                                          IST received(seqno:36)                     
+2024-02-09T10:47:00.622913Z   |                                                       |                                          JOINER -> JOINED                           
+2024-02-09T10:47:00.623634Z   |                                                       |                                          JOINED -> SYNCED                           
+                                                                                                                                 tests/logs/operator_split/node2.log        
+                                                                                                                                 (file path)                                
+                                                                                                                                  V                                         
+                                                                                                                                 tests/logs/operator_split/node2.2.log      
+2024-02-09T10:57:00.561080Z   |                                                       |                                          starting(8.0.32)                           
+2024-02-09T10:57:00.565384Z   |                                                       |                                          started(cluster)                           
+2024-02-09T10:57:00.567068Z   |                                                       |                                          no grastate.dat file                       
+2024-02-09T10:57:00.567079Z   |                                                       |                                          bootstrapping(empty grastate)              
+2024-02-09T10:57:00.567139Z   |                                                       |                                          safe_to_bootstrap: 1                       
+2024-02-09T10:57:01.099130Z   |                                                       |                                          cluster1-pxc-0 joined                      
+2024-02-09T10:57:01.099157Z   |                                                       |                                          cluster1-pxc-1 joined                      
+2024-02-09T10:57:01.597877Z   |                                                       |                                          CLOSED -> OPEN                             
+2024-02-09T10:57:01.598280Z   |                                                       |                                          PRIMARY(n=3)                               
+2024-02-09T10:57:01.600245Z   |                                                       |                                          OPEN -> PRIMARY                            
+2024-02-09T10:57:02.668245Z   |                                                       |                                          will receive SST                           
+2024-02-09T10:57:02.669659Z   |                                                       |                                          cluster1-pxc-1 will resync local node      
+2024-02-09T10:57:02.669703Z   |                                                       |                                          PRIMARY -> JOINER                          
+2024-02-09T10:57:04.525871Z   |                                                       |                                          receiving SST                              
+2024-02-09T10:57:17.601741Z   |                                                       |                                          got SST from cluster1-pxc-1                
+2024-02-09T10:57:17.610081Z   |                                                       |                                          preparing SST backup                       
+2024-02-09T10:57:19.848464Z   |                                                       |                                          starting(8.0.32)(post.processing.log)      
+2024-02-09T10:57:20.797809Z   |                                                       |                                          started(standalone)(post.processing.log)   
+2024-02-09T10:57:24.141411Z   |                                                       |                                          wsrep recovery                             
+2024-02-09T10:57:24.160432Z   |                                                       |                                          IST received(seqno:42)                     
+2024-02-09T10:57:24.161564Z   |                                                       |                                          JOINER -> JOINED                           
+2024-02-09T10:57:24.162369Z   |                                                       |                                          JOINED -> SYNCED                           
+2024-02-09T10:57:23.055898Z   |                                                       |                                          shutdown complete(post.processing.log)     
+                                                                                                                                                                            
+identifier                    cluster1-pxc-0                                          cluster1-pxc-1                             cluster1-pxc-2                             
+current path                  tests/logs/operator_split/node0.log                     tests/logs/operator_split/node1.log        tests/logs/operator_split/node2.2.log      
+last known ip                 10.42.0.5                                               10.42.2.8                                  10.42.1.10                                 
+last known name               cluster1-pxc-0                                          cluster1-pxc-1                             cluster1-pxc-2                             
+mysql version                 8.0.32                                                  8.0.32                                     8.0.32                                     

--- a/src/go/pt-galera-log-explainer/tests/logs/operator_split/node0.log
+++ b/src/go/pt-galera-log-explainer/tests/logs/operator_split/node0.log
@@ -1,0 +1,1083 @@
++ trap exit SIGTERM
++ '[' m = - ']'
++ CFG=/etc/mysql/node.cnf
++ wantHelp=
++ for arg in "$@"
++ case "$arg" in
+++ mysqld -V
+++ awk '{print $3}'
+++ awk -F. '{print $1"."$2}'
++ MYSQL_VERSION=8.0
+++ mysqld -V
+++ awk '{print $3}'
+++ awk -F. '{print $3}'
+++ awk -F- '{print $1}'
++ MYSQL_PATCH_VERSION=32
++ vault_secret=/etc/mysql/vault-keyring-secret/keyring_vault.conf
++ '[' -f /etc/mysql/vault-keyring-secret/keyring_vault.conf ']'
++ '[' -f /usr/lib64/mysql/plugin/binlog_utils_udf.so ']'
++ sed -i '/\[mysqld\]/a plugin_load="binlog_utils_udf=binlog_utils_udf.so"' /etc/mysql/node.cnf
++ sed -i '/\[mysqld\]/a gtid-mode=ON' /etc/mysql/node.cnf
++ sed -i '/\[mysqld\]/a enforce-gtid-consistency' /etc/mysql/node.cnf
++ grep -q '^progress=' /etc/mysql/node.cnf
++ sed -i 's|^progress=.*|progress=1|' /etc/mysql/node.cnf
++ grep -q '^\[sst\]' /etc/mysql/node.cnf
++ grep -q '^cpat=' /etc/mysql/node.cnf
++ sed '/^\[sst\]/a cpat=.*\\.pem$\\|.*init\\.ok$\\|.*galera\\.cache$\\|.*wsrep_recovery_verbose\\.log$\\|.*readiness-check\\.sh$\\|.*liveness-check\\.sh$\\|.*get-pxc-state$\\|.*sst_in_progress$\\|.*pmm-prerun\\.sh$\\|.*sst-xb-tmpdir$\\|.*\\.sst$\\|.*gvwstate\\.dat$\\|.*grastate\\.dat$\\|.*\\.err$\\|.*\\.log$\\|.*RPM_UPGRADE_MARKER$\\|.*RPM_UPGRADE_HISTORY$\\|.*pxc-entrypoint\\.sh$\\|.*unsafe-bootstrap\\.sh$\\|.*pxc-configure-pxc\\.sh\\|.*peer-list$\\|.*auth_plugin$' /etc/mysql/node.cnf
++ [[ 8.0 == \8\.\0 ]]
++ [[ 32 -ge 26 ]]
++ grep -q '^skip_replica_start=ON' /etc/mysql/node.cnf
++ sed -i '/\[mysqld\]/a skip_replica_start=ON' /etc/mysql/node.cnf
++ auth_plugin=caching_sha2_password
++ [[ -f /var/lib/mysql/auth_plugin ]]
++ [[ -z caching_sha2_password ]]
++ [[ 8.0 == \5\.\7 ]]
++ echo caching_sha2_password
++ sed -i /default_authentication_plugin/d /etc/mysql/node.cnf
++ [[ 8.0 == \8\.\0 ]]
++ [[ 32 -ge 27 ]]
++ sed -i '/\[mysqld\]/a authentication_policy=caching_sha2_password,,' /etc/mysql/node.cnf
++ file_env XTRABACKUP_PASSWORD xtrabackup xtrabackup
+Percona XtraDB Cluster: Finding peers
+2024/02/09 10:43:17 Peer finder enter
+2024/02/09 10:43:17 Determined Domain to be pxc.svc.cluster.local
+2024/02/09 10:43:17 Peer list updated
+was []
+now [10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local]
+2024/02/09 10:43:17 execing: /var/lib/mysql/pxc-configure-pxc.sh with stdin: 10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local
+2024/02/09 10:43:17 ++ hostname -I
+++ awk ' { print $1 } '
++ NODE_IP=10.42.0.5
+++ hostname -f
+++ cut -d. -f2
++ CLUSTER_NAME=cluster1-pxc
++ SERVER_NUM=0
++ SERVER_ID=32109360
+++ hostname -f
++ NODE_NAME=cluster1-pxc-0.cluster1-pxc.pxc.svc.cluster.local
++ NODE_PORT=3306
++ read -ra LINE
++ echo 'read line 10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local'
+read line 10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local
+++ getent hosts 10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local
+++ awk '{ print $1 }'
++ LINE_IP=10.42.0.5
++ '[' 10.42.0.5 '!=' 10.42.0.5 ']'
++ read -ra LINE
++ '[' 0 '!=' 0 ']'
++ '[' 0 '!=' 0 ']'
++ CFG=/etc/mysql/node.cnf
+++ mysqld -V
+++ awk '{print $3}'
+++ awk -F. '{print $1"."$2}'
++ MYSQL_VERSION=8.0
++ '[' 8.0 == 8.0 ']'
++ grep -E -q '^[#]?admin-address' /etc/mysql/node.cnf
++ sed '/^\[mysqld\]/a admin-address=\n' /etc/mysql/node.cnf
++ grep -E -q '^[#]?log_error_suppression_list' /etc/mysql/node.cnf
++ sed '/^\[mysqld\]/a log_error_suppression_list="MY-010055"\n' /etc/mysql/node.cnf
++ '[' yes == yes ']'
++ grep -E -q '^[#]?log-error' /etc/mysql/node.cnf
++ sed '/^\[mysqld\]/a log-error=/var/lib/mysql/mysqld-error.log\n' /etc/mysql/node.cnf
++ grep -E -q '^[#]?wsrep_sst_donor' /etc/mysql/node.cnf
++ sed '/^\[mysqld\]/a wsrep_sst_donor=\n' /etc/mysql/node.cnf
++ grep -E -q '^[#]?wsrep_node_incoming_address' /etc/mysql/node.cnf
++ grep -E -q '^[#]?wsrep_provider_options' /etc/mysql/node.cnf
++ sed '/^\[mysqld\]/a wsrep_provider_options="pc.weight=10"\n' /etc/mysql/node.cnf
++ sed -r 's|^[#]?server_id=.*$|server_id=32109360|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?coredumper$|coredumper|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?wsrep_node_address=.*$|wsrep_node_address=10.42.0.5|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?wsrep_cluster_name=.*$|wsrep_cluster_name=cluster1-pxc|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?wsrep_sst_donor=.*$|wsrep_sst_donor=|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?wsrep_cluster_address=.*$|wsrep_cluster_address=gcomm://|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?wsrep_node_incoming_address=.*$|wsrep_node_incoming_address=cluster1-pxc-0.cluster1-pxc.pxc.svc.cluster.local:3306|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?admin-address=.*$|admin-address=10.42.0.5|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?extra_max_connections=.*$|extra_max_connections=100|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?extra_port=.*$|extra_port=33062|' /etc/mysql/node.cnf
++ CA=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
++ '[' -f /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt ']'
++ SSL_DIR=/etc/mysql/ssl
++ '[' -f /etc/mysql/ssl/ca.crt ']'
++ CA=/etc/mysql/ssl/ca.crt
++ SSL_INTERNAL_DIR=/etc/mysql/ssl-internal
++ '[' -f /etc/mysql/ssl-internal/ca.crt ']'
++ CA=/etc/mysql/ssl-internal/ca.crt
++ KEY=/etc/mysql/ssl/tls.key
++ CERT=/etc/mysql/ssl/tls.crt
++ '[' -f /etc/mysql/ssl-internal/tls.key -a -f /etc/mysql/ssl-internal/tls.crt ']'
++ KEY=/etc/mysql/ssl-internal/tls.key
++ CERT=/etc/mysql/ssl-internal/tls.crt
++ '[' -f /etc/mysql/ssl-internal/ca.crt -a -f /etc/mysql/ssl-internal/tls.key -a -f /etc/mysql/ssl-internal/tls.crt ']'
++ sed '/^\[mysqld\]/a pxc-encrypt-cluster-traffic=ON\nssl-ca=/etc/mysql/ssl-internal/ca.crt\nssl-key=/etc/mysql/ssl-internal/tls.key\nssl-cert=/etc/mysql/ssl-internal/tls.crt' /etc/mysql/node.cnf
+2024/02/09 10:43:18 Peer finder exiting
+Cluster address set to: 
++ mkdir -p /var/lib/mysql/
+++ _get_cnf_config sst cpat
+++ local group=sst
+++ local var=cpat
+++ local reval=
++++ my_print_defaults sst
++++ awk -F= '{st=index($0,"="); cur=$0; if ($1 ~ /_/) { gsub(/_/,"-",$1);} if (st != 0) { print $1"="substr(cur,st+1) } else { print cur }}'
++++ grep -- --cpat=
++++ cut -d= -f2-
++++ tail -1
+++ reval='.*\.pem$\|.*init\.ok$\|.*galera\.cache$\|.*wsrep_recovery_verbose\.log$\|.*readiness-check\.sh$\|.*liveness-check\.sh$\|.*get-pxc-state$\|.*sst_in_progress$\|.*pmm-prerun\.sh$\|.*sst-xb-tmpdir$\|.*\.sst$\|.*gvwstate\.dat$\|.*grastate\.dat$\|.*\.err$\|.*\.log$\|.*RPM_UPGRADE_MARKER$\|.*RPM_UPGRADE_HISTORY$\|.*pxc-entrypoint\.sh$\|.*unsafe-bootstrap\.sh$\|.*pxc-configure-pxc\.sh\|.*peer-list$\|.*auth_plugin$'
+++ [[ -z .*\.pem$\|.*init\.ok$\|.*galera\.cache$\|.*wsrep_recovery_verbose\.log$\|.*readiness-check\.sh$\|.*liveness-check\.sh$\|.*get-pxc-state$\|.*sst_in_progress$\|.*pmm-prerun\.sh$\|.*sst-xb-tmpdir$\|.*\.sst$\|.*gvwstate\.dat$\|.*grastate\.dat$\|.*\.err$\|.*\.log$\|.*RPM_UPGRADE_MARKER$\|.*RPM_UPGRADE_HISTORY$\|.*pxc-entrypoint\.sh$\|.*unsafe-bootstrap\.sh$\|.*pxc-configure-pxc\.sh\|.*peer-list$\|.*auth_plugin$ ]]
+++ echo '.*\.pem$\|.*init\.ok$\|.*galera\.cache$\|.*wsrep_recovery_verbose\.log$\|.*readiness-check\.sh$\|.*liveness-check\.sh$\|.*get-pxc-state$\|.*sst_in_progress$\|.*pmm-prerun\.sh$\|.*sst-xb-tmpdir$\|.*\.sst$\|.*gvwstate\.dat$\|.*grastate\.dat$\|.*\.err$\|.*\.log$\|.*RPM_UPGRADE_MARKER$\|.*RPM_UPGRADE_HISTORY$\|.*pxc-entrypoint\.sh$\|.*unsafe-bootstrap\.sh$\|.*pxc-configure-pxc\.sh\|.*peer-list$\|.*auth_plugin$'
++ cpat='.*\.pem$\|.*init\.ok$\|.*galera\.cache$\|.*wsrep_recovery_verbose\.log$\|.*readiness-check\.sh$\|.*liveness-check\.sh$\|.*get-pxc-state$\|.*sst_in_progress$\|.*pmm-prerun\.sh$\|.*sst-xb-tmpdir$\|.*\.sst$\|.*gvwstate\.dat$\|.*grastate\.dat$\|.*\.err$\|.*\.log$\|.*RPM_UPGRADE_MARKER$\|.*RPM_UPGRADE_HISTORY$\|.*pxc-entrypoint\.sh$\|.*unsafe-bootstrap\.sh$\|.*pxc-configure-pxc\.sh\|.*peer-list$\|.*auth_plugin$'
++ find /var/lib/mysql/ -mindepth 1 -regex '.*\.pem$\|.*init\.ok$\|.*galera\.cache$\|.*wsrep_recovery_verbose\.log$\|.*readiness-check\.sh$\|.*liveness-check\.sh$\|.*get-pxc-state$\|.*sst_in_progress$\|.*pmm-prerun\.sh$\|.*sst-xb-tmpdir$\|.*\.sst$\|.*gvwstate\.dat$\|.*grastate\.dat$\|.*\.err$\|.*\.log$\|.*RPM_UPGRADE_MARKER$\|.*RPM_UPGRADE_HISTORY$\|.*pxc-entrypoint\.sh$\|.*unsafe-bootstrap\.sh$\|.*pxc-configure-pxc\.sh\|.*peer-list$\|.*auth_plugin$' -prune -o -exec rm -rfv '{}' +
++ echo 'Initializing database'
++ mysqld --initialize-insecure --skip-ssl --datadir=/var/lib/mysql//sst-xb-tmpdir
+Initializing database
++ mv /var/lib/mysql//sst-xb-tmpdir/#ib_16384_0.dblwr /var/lib/mysql//sst-xb-tmpdir/#ib_16384_1.dblwr /var/lib/mysql//sst-xb-tmpdir/#innodb_redo /var/lib/mysql//sst-xb-tmpdir/#innodb_temp /var/lib/mysql//sst-xb-tmpdir/auto.cnf /var/lib/mysql//sst-xb-tmpdir/ib_buffer_pool /var/lib/mysql//sst-xb-tmpdir/ibdata1 /var/lib/mysql//sst-xb-tmpdir/mysql /var/lib/mysql//sst-xb-tmpdir/mysql.ibd /var/lib/mysql//sst-xb-tmpdir/performance_schema /var/lib/mysql//sst-xb-tmpdir/private_key.pem /var/lib/mysql//sst-xb-tmpdir/public_key.pem /var/lib/mysql//sst-xb-tmpdir/sys /var/lib/mysql//sst-xb-tmpdir/undo_001 /var/lib/mysql//sst-xb-tmpdir/undo_002 /var/lib/mysql//
++ rm -rfv /var/lib/mysql//sst-xb-tmpdir
+removed directory '/var/lib/mysql//sst-xb-tmpdir'
+Database initialized
++ echo 'Database initialized'
++ echo caching_sha2_password
+++ _get_config socket mysqld
+++ local conf=socket
+++ shift
+++ awk '$1 == "socket" && /^[^ \t]/ { sub(/^[^ \t]+[ \t]+/, ""); print; exit }'
++++ mktemp -u
+++ mysqld --verbose --help --wsrep-provider=none --log-bin-index=/tmp/tmp.zddfv6eoco
++ SOCKET=/tmp/mysql.sock
++ pid=178
++ mysql=(mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" --password="")
++ wsrep_local_state_select='SELECT variable_value FROM performance_schema.global_status WHERE variable_name='\''wsrep_local_state_comment'\'''
++ for i in {120..0}
++ mysqld --skip-networking --socket=/tmp/mysql.sock
+++ echo 'SELECT variable_value FROM performance_schema.global_status WHERE variable_name='\''wsrep_local_state_comment'\'''
+++ mysql --protocol=socket -uroot -hlocalhost --socket=/tmp/mysql.sock --password= -s
++ wsrep_local_state=
++ true
++ '[' '' = Synced ']'
++ echo 'MySQL init process in progress...'
++ sleep 1
+MySQL init process in progress...
++ for i in {120..0}
+++ echo 'SELECT variable_value FROM performance_schema.global_status WHERE variable_name='\''wsrep_local_state_comment'\'''
+++ mysql --protocol=socket -uroot -hlocalhost --socket=/tmp/mysql.sock --password= -s
+MySQL init process in progress...
++ wsrep_local_state=
++ true
++ '[' '' = Synced ']'
++ echo 'MySQL init process in progress...'
++ sleep 1
++ for i in {120..0}
+++ echo 'SELECT variable_value FROM performance_schema.global_status WHERE variable_name='\''wsrep_local_state_comment'\'''
+++ mysql --protocol=socket -uroot -hlocalhost --socket=/tmp/mysql.sock --password= -s
++ wsrep_local_state=Synced
++ '[' Synced = Synced ']'
++ break
++ '[' 118 = 0 ']'
++ '[' -z '' ']'
++ echo 'set wsrep_on=0;'
++ echo 'SET @@SESSION.SQL_LOG_BIN = off;'
++ mysql --protocol=socket -uroot -hlocalhost --socket=/tmp/mysql.sock --password= mysql
++ mysql_tzinfo_to_sql /usr/share/zoneinfo
++ sed 's/Local time zone must be set--see zic manual page/FCTY/'
+mysql: [Warning] Using a password on the command line interface can be insecure.
+Warning: Unable to load '/usr/share/zoneinfo/iso3166.tab' as time zone. Skipping it.
+Warning: Unable to load '/usr/share/zoneinfo/leap-seconds.list' as time zone. Skipping it.
+Warning: Unable to load '/usr/share/zoneinfo/leapseconds' as time zone. Skipping it.
+Warning: Unable to load '/usr/share/zoneinfo/tzdata.zi' as time zone. Skipping it.
+Warning: Unable to load '/usr/share/zoneinfo/zone.tab' as time zone. Skipping it.
+Warning: Unable to load '/usr/share/zoneinfo/zone1970.tab' as time zone. Skipping it.
++ echo 'set wsrep_on=1;'
+mysql: [Warning] Using a password on the command line interface can be insecure.
++ file_env MYSQL_DATABASE
+
++ echo
++ ls /docker-entrypoint-initdb.d/
++ kill -s TERM 178
++ wait 178
++ echo
+
+MySQL init process done. Ready for start up.
+
++ echo 'MySQL init process done. Ready for start up.'
++ echo
++ '[' '!' -z '' ']'
++ '[' mysqld = mysqld -a -z '' ']'
++ _check_config mysqld
++ toRun=("$@" --verbose --help --wsrep-provider='none')
+++ mysqld --verbose --help --wsrep-provider=none
++ errors=
+++ _get_config datadir mysqld
+++ local conf=datadir
+++ shift
+++ awk '$1 == "datadir" && /^[^ \t]/ { sub(/^[^ \t]+[ \t]+/, ""); print; exit }'
++++ mktemp -u
+++ mysqld --verbose --help --wsrep-provider=none --log-bin-index=/tmp/tmp.aUSp4cEGKr
++ DATADIR=/var/lib/mysql/
+++ _get_cnf_config sst tmpdir /var/lib/mysql//sst-xb-tmpdir
+++ local group=sst
+++ local var=tmpdir
+++ local reval=
++++ my_print_defaults sst
++++ awk -F= '{st=index($0,"="); cur=$0; if ($1 ~ /_/) { gsub(/_/,"-",$1);} if (st != 0) { print $1"="substr(cur,st+1) } else { print cur }}'
++++ grep -- --tmpdir=
++++ cut -d= -f2-
++++ tail -1
+++ reval=
+++ [[ -z '' ]]
+++ reval=/var/lib/mysql//sst-xb-tmpdir
+++ echo /var/lib/mysql//sst-xb-tmpdir
++ SST_DIR=/var/lib/mysql//sst-xb-tmpdir
+++ _get_cnf_config sst progress /var/lib/mysql//sst_in_progress
+++ local group=sst
+++ local var=progress
+++ local reval=
++++ my_print_defaults sst
++++ awk -F= '{st=index($0,"="); cur=$0; if ($1 ~ /_/) { gsub(/_/,"-",$1);} if (st != 0) { print $1"="substr(cur,st+1) } else { print cur }}'
++++ grep -- --progress=
++++ cut -d= -f2-
++++ tail -1
+++ reval=1
+++ [[ -z 1 ]]
+++ echo 1
++ SST_P_FILE=1
++ rm -rvf /var/lib/mysql//sst-xb-tmpdir 1
++ mysqld --version
++ sed s/-ps//
++ tee /tmp/version_info
+/usr/sbin/mysqld  Ver 8.0.32-24.2 for Linux on x86_64 (Percona XtraDB Cluster (GPL), Release rel24, Revision 2119e75, WSREP version 26.1.4.3)
++ '[' -f /var/lib/mysql//version_info ']'
++ mysqld --version
++ sed s/-ps//
++ grep -v wsrep_sst_auth /etc/mysql/node.cnf
+[mysqld]
+pxc-encrypt-cluster-traffic=ON
+ssl-ca=/etc/mysql/ssl-internal/ca.crt
+ssl-key=/etc/mysql/ssl-internal/tls.key
+ssl-cert=/etc/mysql/ssl-internal/tls.crt
+wsrep_provider_options="pc.weight=10"
+
+wsrep_sst_donor=
+
+log-error=/var/lib/mysql/mysqld-error.log
+
+log_error_suppression_list="MY-010055"
+
+admin-address=10.42.0.5
+
+authentication_policy=caching_sha2_password,,
+skip_replica_start=ON
+enforce-gtid-consistency
+gtid-mode=ON
+plugin_load="binlog_utils_udf=binlog_utils_udf.so"
+
+datadir=/var/lib/mysql
+socket=/tmp/mysql.sock
+skip-host-cache
+
+coredumper
+server_id=32109360
+binlog_format=ROW
+default_storage_engine=InnoDB
+
+innodb_flush_log_at_trx_commit  = 0
+innodb_flush_method             = O_DIRECT
+innodb_file_per_table           = 1
+innodb_autoinc_lock_mode=2
+
+bind_address = 0.0.0.0
+
+wsrep_slave_threads=2
+wsrep_cluster_address=gcomm://
+wsrep_provider=/usr/lib64/galera4/libgalera_smm.so
+
+wsrep_cluster_name=cluster1-pxc
+wsrep_node_address=10.42.0.5
+wsrep_node_incoming_address=cluster1-pxc-0.cluster1-pxc.pxc.svc.cluster.local:3306
+
+wsrep_sst_method=xtrabackup-v2
+
+[client]
+socket=/tmp/mysql.sock
+
+[sst]
+cpat=.*\.pem$\|.*init\.ok$\|.*galera\.cache$\|.*wsrep_recovery_verbose\.log$\|.*readiness-check\.sh$\|.*liveness-check\.sh$\|.*get-pxc-state$\|.*sst_in_progress$\|.*pmm-prerun\.sh$\|.*sst-xb-tmpdir$\|.*\.sst$\|.*gvwstate\.dat$\|.*grastate\.dat$\|.*\.err$\|.*\.log$\|.*RPM_UPGRADE_MARKER$\|.*RPM_UPGRADE_HISTORY$\|.*pxc-entrypoint\.sh$\|.*unsafe-bootstrap\.sh$\|.*pxc-configure-pxc\.sh\|.*peer-list$\|.*auth_plugin$
+progress=1
+
+++ cat /var/run/secrets/kubernetes.io/serviceaccount/namespace
++ POD_NAMESPACE=pxc
++ wsrep_start_position_opt=
++ '[' mysqld = mysqld -a -z '' ']'
+++ _get_config datadir mysqld
+++ local conf=datadir
+++ shift
+++ awk '$1 == "datadir" && /^[^ \t]/ { sub(/^[^ \t]+[ \t]+/, ""); print; exit }'
++++ mktemp -u
+++ mysqld --verbose --help --wsrep-provider=none --log-bin-index=/tmp/tmp.Rcfb3j5md3
++ DATADIR=/var/lib/mysql/
++ grastate_loc=/var/lib/mysql//grastate.dat
++ wsrep_verbose_logfile=/var/lib/mysql//wsrep_recovery_verbose.log
++ '[' -f /var/lib/mysql//wsrep_recovery_verbose.log ']'
++ '[' -s /var/lib/mysql//grastate.dat -a -d /var/lib/mysql//mysql ']'
+++ grep uuid: /var/lib/mysql//grastate.dat
+++ cut -d: -f2
+++ tr -d ' '
++ uuid=103be6ae-c738-11ee-95d1-526d43d08e41
+++ grep seqno: /var/lib/mysql//grastate.dat
+++ cut -d: -f2
+++ tr -d ' '
++ seqno=22
+++ grep safe_to_bootstrap: /var/lib/mysql//grastate.dat
+++ cut -d: -f2
+++ tr -d ' '
++ safe_to_bootstrap=1
++ '[' -n 22 ']'
++ '[' 22 -ne -1 ']'
++ echo 'Skipping wsrep-recover for 103be6ae-c738-11ee-95d1-526d43d08e41:22 pair'
++ echo 'Assigning 103be6ae-c738-11ee-95d1-526d43d08e41:22 to wsrep_start_position'
+Skipping wsrep-recover for 103be6ae-c738-11ee-95d1-526d43d08e41:22 pair
+Assigning 103be6ae-c738-11ee-95d1-526d43d08e41:22 to wsrep_start_position
++ wsrep_start_position_opt=--wsrep_start_position=103be6ae-c738-11ee-95d1-526d43d08e41:22
++ '[' -z --wsrep_start_position=103be6ae-c738-11ee-95d1-526d43d08e41:22 -a -d /var/lib/mysql//mysql ']'
++ '[' -n cluster1-pxc-unready ']'
+++ get_primary
+++ peer-list -on-start=/var/lib/mysql/get-pxc-state -service=cluster1-pxc-unready
+++ grep wsrep_ready:ON:wsrep_connected:ON:wsrep_local_state_comment:Synced:wsrep_cluster_status:Primary
+++ sort
+++ tail -1
+++ true
++ is_primary_exists=
++ is_manual_recovery
++ set +o xtrace
++ [[ -z '' ]]
++ [[ -f /var/lib/mysql//grastate.dat ]]
++ [[ 1 != 1 ]]
++ [[ -z '' ]]
++ [[ -f /var/lib/mysql//gvwstate.dat ]]
++ [[ -z '' ]]
++ [[ -f /var/lib/mysql//grastate.dat ]]
++ [[ 1 == 1 ]]
++ [[ -n '' ]]
++ test -e /opt/percona/hookscript/hook.sh
++ exec mysqld --wsrep_start_position=103be6ae-c738-11ee-95d1-526d43d08e41:22
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /pxc-entrypoint.sh /var/lib/mysql/pxc-entrypoint.sh
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /unsafe-bootstrap.sh /var/lib/mysql/unsafe-bootstrap.sh
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /pxc-configure-pxc.sh /var/lib/mysql/pxc-configure-pxc.sh
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /liveness-check.sh /var/lib/mysql/liveness-check.sh
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /readiness-check.sh /var/lib/mysql/readiness-check.sh
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /peer-list /var/lib/mysql/peer-list
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /get-pxc-state /var/lib/mysql/get-pxc-state
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /pmm-prerun.sh /var/lib/mysql/pmm-prerun.sh
++ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/fluent-bit/bin
++ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/fluent-bit/bin
++ '[' fluent-bit = logrotate ']'
++ '[' fluent-bit = fluent-bit ']'
++ fluentbit_opt+='-c /etc/fluentbit/fluentbit.conf'
++ test -e /opt/percona/hookscript/hook.sh
++ exec fluent-bit -c /etc/fluentbit/fluentbit.conf
+Fluent Bit v2.1.5
+* Copyright (C) 2015-2022 The Fluent Bit Authors
+* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
+* https://fluentbit.io
+
+{"log":"2024-02-09T10:43:18.761541Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:18.761567Z 0 [Warning] [MY-011068] [Server] The syntax 'wsrep_slave_threads' is deprecated and will be removed in a future release. Please use wsrep_applier_threads instead.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:18.761591Z 0 [Warning] [MY-011068] [Server] The syntax '--ssl=off' is deprecated and will be removed in a future release. Please use --tls-version='' instead.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:18.761675Z 0 [Warning] [MY-000000] [WSREP] Node is running in bootstrap/initialize mode. Disabling pxc_strict_mode checks\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:18.762309Z 0 [System] [MY-013169] [Server] /usr/sbin/mysqld (mysqld 8.0.32-24.2) initializing of server in progress as process 127\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:18.764686Z 0 [Note] [MY-000000] [Galera] Loading provider none initial position: 00000000-0000-0000-0000-000000000000:-1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:18.764700Z 0 [Note] [MY-000000] [Galera] wsrep_load(): loading provider library 'none'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:18.785343Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:20.180204Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:21.538423Z 0 [Warning] [MY-013501] [Server] Ignoring --plugin-load[_add] list as the server is running with --initialize(-insecure).\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:23.240292Z 6 [Warning] [MY-010453] [Server] root@localhost is created with an empty password ! Please consider switching off the --initialize-insecure option.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.904429Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.904461Z 0 [Warning] [MY-011068] [Server] The syntax 'wsrep_slave_threads' is deprecated and will be removed in a future release. Please use wsrep_applier_threads instead.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.906513Z 0 [Warning] [MY-010097] [Server] Insecure configuration for --secure-log-path: Current value does not restrict location of generated files. Consider setting it to a valid, non-empty path.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.907284Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.32-24.2) starting as process 178\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.911064Z 0 [Warning] [MY-010068] [Server] CA certificate /etc/mysql/ssl-internal/ca.crt is self signed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.911103Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.911146Z 0 [Note] [MY-000000] [Galera] Loading provider /usr/lib64/galera4/libgalera_smm.so initial position: 00000000-0000-0000-0000-000000000000:-1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.911161Z 0 [Note] [MY-000000] [Galera] wsrep_load(): loading provider library '/usr/lib64/galera4/libgalera_smm.so'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.911938Z 0 [Note] [MY-000000] [Galera] wsrep_load(): Galera 4.14(779b689) by Codership Oy <info@codership.com> (modified by Percona <https://percona.com/>) loaded successfully.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.911998Z 0 [Note] [MY-000000] [Galera] CRC-32C: using 64-bit x86 acceleration.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.912252Z 0 [Warning] [MY-000000] [Galera] SSL compression is not effective. The option socket.ssl_compression is deprecated and will be removed in future releases.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.912263Z 0 [Warning] [MY-000000] [Galera] Parameter 'socket.ssl_compression' is deprecated and will be removed in future versions\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.912919Z 0 [Warning] [MY-000000] [Galera] Could not open state file for reading: '/var/lib/mysql//grastate.dat'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.912934Z 0 [Warning] [MY-000000] [Galera] No persistent state found. Bootstraping with default state\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.913010Z 0 [Note] [MY-000000] [Galera] Found saved state: 00000000-0000-0000-0000-000000000000:-1, safe_to_bootstrap: 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.913389Z 0 [Note] [MY-000000] [Galera] Generated new GCache ID: 1035fbcf-c738-11ee-9c9f-1781681b8dcf\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.913411Z 0 [Note] [MY-000000] [Galera] GCache DEBUG: opened preamble:\nVersion: 0\nUUID: 00000000-0000-0000-0000-000000000000\nSeqno: -1 - -1\nOffset: -1\nSynced: 0\nEncVersion: 0\nEncrypted: 0\nMasterKeyConst UUID: 1035fbcf-c738-11ee-9c9f-1781681b8dcf\nMasterKey UUID: 00000000-0000-0000-0000-000000000000\nMasterKey ID: 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.913432Z 0 [Note] [MY-000000] [Galera] Skipped GCache ring buffer recovery: could not determine history UUID.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.922069Z 0 [Note] [MY-000000] [Galera] Passing config to GCS: allocator.disk_pages_encryption = no; allocator.encryption_cache_page_size = 32K; allocator.encryption_cache_size = 16777216; base_dir = /var/lib/mysql/; base_host = 10.42.0.5; base_port = 4567; cert.log_conflicts = no; cert.optimistic_pa = no; debug = no; evs.auto_evict = 0; evs.delay_margin = PT1S; evs.delayed_keep_period = PT30S; evs.inactive_check_period = PT0.5S; evs.inactive_timeout = PT15S; evs.join_retrans_period = PT1S; evs.max_install_timeouts = 3; evs.send_window = 10; evs.stats_report_period = PT1M; evs.suspect_timeout = PT5S; evs.user_send_window = 4; evs.view_forget_timeout = PT24H; gcache.dir = /var/lib/mysql/; gcache.encryption = no; gcache.encryption_cache_page_size = 32K; gcache.encryption_cache_size = 16777216; gcache.freeze_purge_at_seqno = -1; gcache.keep_pages_count = 0; gcache.keep_pages_size = 0; gcache.mem_size = 0; gcache.name = galera.cache; gcache.page_size = 128M; gcache.recover = yes; gcache.size = 128M; gcomm.thread_prio = ; gcs.fc_debug = 0; gcs.fc_factor = 1.0; gcs.fc_limit = 100; gcs.fc_master_slave = no; gcs.fc_single_primary = no; gcs.max_packet_size = 64500; gcs.max_throttle = 0.25; gcs.recv_q_hard_limit = 9223372036854775807; gcs.recv_q_soft_limit = 0.25; gcs.sync_donor = no; gmcast.segment = 0; gmcast.version = 0; pc.announce_timeout = PT3S; pc.checksum = false; pc.ignore_quorum = false; pc.ignore_sb = false; pc.npvo = false; pc.recovery = true; pc.version = 0; pc.wait_prim = true; pc.wait_prim_timeout = PT30S; pc.weight = 10; protonet.backend = asio; protonet.version = 0; repl.causal_read_timeout = PT30S; repl.commit_order = 3; repl.key_format = FLAT8; repl.max_ws_size = 2147483647; repl.proto_max = 10; socket.checksum = 2; socket.recv_buf_size = auto; socket.send_buf_size = auto; socket.ssl = YES; socket.ssl_ca = /etc/mysql/ssl-internal/ca.crt; socket.ssl_cert = /etc/mysql/ssl-internal/tls.crt; socket.ssl_cipher = ; socket.ssl_compression = YES; socket.ssl_key = /etc/mysql/ssl-internal/tls.key; socket.ssl_reload = 1; \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.941261Z 0 [Note] [MY-000000] [WSREP] Starting replication\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.941325Z 0 [Note] [MY-000000] [Galera] Connecting with bootstrap option: 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.941347Z 0 [Note] [MY-000000] [Galera] Setting GCS initial position to 00000000-0000-0000-0000-000000000000:-1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.941412Z 0 [Note] [MY-000000] [Galera] protonet asio version 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.942238Z 0 [Note] [MY-000000] [Galera] Using CRC-32C for message checksums.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.942271Z 0 [Note] [MY-000000] [Galera] backend: asio\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.942407Z 0 [Note] [MY-000000] [Galera] gcomm thread scheduling priority set to other:0 \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.942580Z 0 [Note] [MY-000000] [Galera] Fail to access the file (/var/lib/mysql//gvwstate.dat) error (No such file or directory). It is possible if node is booting for first time or re-booting after a graceful shutdown\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.942596Z 0 [Note] [MY-000000] [Galera] Restoring primary-component from disk failed. Either node is booting for first time or re-booting after a graceful shutdown\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.942825Z 0 [Note] [MY-000000] [Galera] GMCast version 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.942936Z 0 [Note] [MY-000000] [Galera] (103a73c8-97fd, 'ssl://0.0.0.0:4567') listening at ssl://0.0.0.0:4567\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.942949Z 0 [Note] [MY-000000] [Galera] (103a73c8-97fd, 'ssl://0.0.0.0:4567') multicast: , ttl: 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.943342Z 0 [Note] [MY-000000] [Galera] EVS version 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.943469Z 0 [Note] [MY-000000] [Galera] gcomm: bootstrapping new group 'cluster1-pxc'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.943522Z 0 [Note] [MY-000000] [Galera] start_prim is enabled, turn off pc_recovery\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.943733Z 0 [Note] [MY-000000] [Galera] EVS version upgrade 0 -> 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.943755Z 0 [Note] [MY-000000] [Galera] PC protocol upgrade 0 -> 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.943789Z 0 [Note] [MY-000000] [Galera] Node 103a73c8-97fd state primary\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.943817Z 0 [Note] [MY-000000] [Galera] Current view of cluster as seen by this node\nview (view_id(PRIM,103a73c8-97fd,1)\nmemb {\n\t103a73c8-97fd,0\n\t}\njoined {\n\t}\nleft {\n\t}\npartitioned {\n\t}\n)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.943830Z 0 [Note] [MY-000000] [Galera] Save the discovered primary-component to disk\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.951484Z 0 [Note] [MY-000000] [Galera] gcomm: connected\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.951536Z 0 [Note] [MY-000000] [Galera] Changing maximum packet size to 64500, resulting msg size: 32636\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.951652Z 0 [Note] [MY-000000] [Galera] Shifting CLOSED -> OPEN (TO: 0)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.951667Z 0 [Note] [MY-000000] [Galera] Opened channel 'cluster1-pxc'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.951979Z 0 [Note] [MY-000000] [Galera] New COMPONENT: primary = yes, bootstrap = no, my_idx = 0, memb_num = 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952158Z 0 [Note] [MY-000000] [Galera] Starting new group from scratch: 103be6ae-c738-11ee-95d1-526d43d08e41\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952186Z 1 [Note] [MY-000000] [WSREP] Starting rollbacker thread 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952222Z 0 [Note] [MY-000000] [Galera] STATE_EXCHANGE: sent state UUID: 103be8a8-c738-11ee-b003-9e1d62117efe\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952264Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: sent state msg: 103be8a8-c738-11ee-b003-9e1d62117efe\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952258Z 2 [Note] [MY-000000] [WSREP] Starting applier thread 2\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952281Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: got state msg: 103be8a8-c738-11ee-b003-9e1d62117efe from 0 (cluster1-pxc-0)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952307Z 0 [Note] [MY-000000] [Galera] Quorum results:\n\tversion    = 6,\n\tcomponent  = PRIMARY,\n\tconf_id    = 0,\n\tmembers    = 1/1 (primary/total),\n\tact_id     = 0,\n\tlast_appl. = 0,\n\tprotocols  = 2/10/4 (gcs/repl/appl),\n\tvote policy= 0,\n\tgroup UUID = 103be6ae-c738-11ee-95d1-526d43d08e41\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952345Z 0 [Note] [MY-000000] [Galera] Flow-control interval: [100, 100]\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952352Z 0 [Note] [MY-000000] [Galera] Restored state OPEN -> JOINED (1)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952377Z 0 [Note] [MY-000000] [Galera] Member 0.0 (cluster1-pxc-0) synced with group.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952384Z 0 [Note] [MY-000000] [Galera] Shifting JOINED -> SYNCED (TO: 1)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952417Z 2 [Note] [MY-000000] [Galera] ####### processing CC 1, local, ordered\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952440Z 2 [Note] [MY-000000] [Galera] Maybe drain monitors from -1 upto current CC event 1 upto:-1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952453Z 2 [Note] [MY-000000] [Galera] Drain monitors from -1 up to -1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952473Z 2 [Note] [MY-000000] [Galera] Process first view: 103be6ae-c738-11ee-95d1-526d43d08e41 my uuid: 103a73c8-c738-11ee-97fd-4651f3f998ad\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952499Z 2 [Note] [MY-000000] [Galera] Server cluster1-pxc-0 connected to cluster at position 103be6ae-c738-11ee-95d1-526d43d08e41:1 with ID 103a73c8-c738-11ee-97fd-4651f3f998ad\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952511Z 2 [Note] [MY-000000] [WSREP] Server status change disconnected -> connected\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952558Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952591Z 2 [Note] [MY-000000] [Galera] ####### My UUID: 103a73c8-c738-11ee-97fd-4651f3f998ad\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952609Z 2 [Note] [MY-000000] [Galera] Cert index reset to 00000000-0000-0000-0000-000000000000:-1 (proto: 10), state transfer needed: no\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952786Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952888Z 2 [Note] [MY-000000] [Galera] ####### Assign initial position for certification: 00000000-0000-0000-0000-000000000000:-1, protocol version: -1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952917Z 2 [Note] [MY-000000] [Galera] REPL Protocols: 10 (5)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.952946Z 2 [Note] [MY-000000] [Galera] ####### Adjusting cert position: -1 -> 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.953056Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.960091Z 2 [Note] [MY-000000] [Galera] GCache history reset: 00000000-0000-0000-0000-000000000000:0 -> 103be6ae-c738-11ee-95d1-526d43d08e41:0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.968847Z 2 [Note] [MY-000000] [Galera] ================================================\nView:\n  id: 103be6ae-c738-11ee-95d1-526d43d08e41:1\n  status: primary\n  protocol_version: 4\n  capabilities: MULTI-MASTER, CERTIFICATION, PARALLEL_APPLYING, REPLAY, ISOLATION, PAUSE, CAUSAL_READ, INCREMENTAL_WS, UNORDERED, PREORDERED, STREAMING, NBO\n  final: no\n  own_index: 0\n  members(1):\n\t0: 103a73c8-c738-11ee-97fd-4651f3f998ad, cluster1-pxc-0\n=================================================\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.968948Z 2 [Note] [MY-000000] [WSREP] Server status change connected -> joiner\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.969005Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.969035Z 2 [Note] [MY-000000] [WSREP] Server status change joiner -> initializing\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.969050Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:29.984437Z 3 [System] [MY-013576] [InnoDB] InnoDB initialization has started.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:30.269363Z 3 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:30.470391Z 3 [Note] [MY-000000] [WSREP] wsrep_init_schema_and_SR (nil)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:30.607714Z 3 [System] [MY-000000] [WSREP] PXC upgrade completed successfully\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:30.952841Z 0 [Warning] [MY-010068] [Server] CA certificate /etc/mysql/ssl-internal/ca.crt is self signed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:30.952973Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:30.964446Z 0 [Warning] [MY-013595] [Server] Failed to initialize TLS for channel: mysql_admin. See below for the description of exact issue.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:30.964511Z 0 [Warning] [MY-010069] [Server] Failed to set up SSL because of the following SSL library error: SSL context is not usable without certificate and private key\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:30.964527Z 0 [System] [MY-013603] [Server] No TLS configuration was given for channel mysql_admin; re-using TLS configuration of channel mysql_main.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:30.975972Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/var/lib/mysql' in the path is accessible to all OS users. Consider choosing a different directory.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:30.998780Z 0 [Note] [MY-000000] [WSREP] Initialized wsrep sidno 2\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:30.998848Z 0 [Note] [MY-000000] [Galera] Server initialized\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:30.998871Z 0 [Note] [MY-000000] [WSREP] Server status change initializing -> initialized\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:30.998909Z 0 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:30.999021Z 2 [Note] [MY-000000] [Galera] Bootstrapping a new cluster, setting initial position to 00000000-0000-0000-0000-000000000000:-1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:31.013767Z 10 [Note] [MY-000000] [WSREP] Starting applier thread 10\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:31.015268Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Socket: /var/lib/mysql/mysqlx.sock\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:31.015474Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.32-24.2'  socket: '/tmp/mysql.sock'  port: 0  Percona XtraDB Cluster (GPL), Release rel24, Revision 2119e75, WSREP version 26.1.4.3.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:31.016089Z 8 [Note] [MY-000000] [WSREP] Cluster table is empty, not recovering transactions\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:31.016186Z 2 [Note] [MY-000000] [WSREP] Server status change initialized -> joined\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:31.016211Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:31.016243Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:31.042060Z 2 [Note] [MY-000000] [Galera] Recording CC from group: 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:31.042154Z 2 [Note] [MY-000000] [Galera] Lowest cert index boundary for CC from group: 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:31.042172Z 2 [Note] [MY-000000] [Galera] Min available from gcache for CC from group: 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:31.042201Z 2 [Note] [MY-000000] [Galera] Server cluster1-pxc-0 synced with group\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:31.042216Z 2 [Note] [MY-000000] [WSREP] Server status change joined -> synced\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:31.042226Z 2 [Note] [MY-000000] [WSREP] Synchronized with group, ready for connections\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:31.042236Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:31.662186Z 13 [Warning] [MY-000000] [WSREP] Toggling wsrep_on to OFF will affect sql_log_bin. Check manual for more details\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:33.599993Z 13 [Warning] [MY-000000] [WSREP] Toggling wsrep_on to ON will affect sql_log_bin. Check manual for more details\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:34.188146Z 0 [System] [MY-013172] [Server] Received SHUTDOWN from user <via user signal>. Shutting down mysqld (Version: 8.0.32-24.2).\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:34.188233Z 0 [Note] [MY-000000] [WSREP] Received shutdown signal. Will sleep for 10 secs before initiating shutdown. pxc_maint_mode switched to SHUTDOWN\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.189402Z 0 [Note] [MY-000000] [WSREP] Shutdown replication\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.189513Z 0 [Note] [MY-000000] [WSREP] Server status change synced -> disconnecting\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.189588Z 0 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.189662Z 0 [Note] [MY-000000] [Galera] Closing send monitor...\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.189689Z 0 [Note] [MY-000000] [Galera] Closed send monitor.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.189715Z 0 [Note] [MY-000000] [Galera] gcomm: terminating thread\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.189747Z 0 [Note] [MY-000000] [Galera] gcomm: joining thread\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.189916Z 0 [Note] [MY-000000] [Galera] gcomm: closing backend\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.190029Z 0 [Note] [MY-000000] [Galera] PC protocol downgrade 1 -> 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.190064Z 0 [Note] [MY-000000] [Galera] Current view of cluster as seen by this node\nview ((empty))\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.190388Z 0 [Note] [MY-000000] [Galera] gcomm: closed\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.190468Z 0 [Note] [MY-000000] [Galera] New SELF-LEAVE.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.190604Z 0 [Note] [MY-000000] [Galera] Flow-control interval: [0, 0]\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.190629Z 0 [Note] [MY-000000] [Galera] Received SELF-LEAVE. Closing connection.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.190649Z 0 [Note] [MY-000000] [Galera] Shifting SYNCED -> CLOSED (TO: 22)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.190674Z 0 [Note] [MY-000000] [Galera] RECV thread exiting 0: Success\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.190732Z 2 [Note] [MY-000000] [Galera] Maybe drain monitors from 22 upto current CC event 22 upto:22\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.190774Z 0 [Note] [MY-000000] [Galera] recv_thread() joined.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.190795Z 2 [Note] [MY-000000] [Galera] Drain monitors from 22 up to 22\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.190806Z 0 [Note] [MY-000000] [Galera] Closing replication queue.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.190830Z 0 [Note] [MY-000000] [Galera] Closing slave action queue.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.190831Z 2 [Note] [MY-000000] [Galera] ================================================\nView:\n  id: 103be6ae-c738-11ee-95d1-526d43d08e41:22\n  status: non-primary\n  protocol_version: 4\n  capabilities: MULTI-MASTER, CERTIFICATION, PARALLEL_APPLYING, REPLAY, ISOLATION, PAUSE, CAUSAL_READ, INCREMENTAL_WS, UNORDERED, PREORDERED, STREAMING, NBO\n  final: yes\n  own_index: -1\n  members(0):\n=================================================\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.190867Z 2 [Note] [MY-000000] [Galera] Non-primary view\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.190882Z 2 [Note] [MY-000000] [WSREP] Server status change disconnecting -> disconnected\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.190894Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.190909Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.197524Z 2 [Note] [MY-000000] [Galera] Waiting 600 seconds for 2 receivers to finish\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.200942Z 10 [Note] [MY-000000] [Galera] Slave thread exit. Return code: 6\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.201091Z 10 [Note] [MY-000000] [WSREP] Applier thread exiting ret: 6 thd: 10\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.201921Z 2 [Note] [MY-000000] [Galera] Slave thread exit. Return code: 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.201969Z 2 [Note] [MY-000000] [WSREP] Applier thread exiting ret: 0 thd: 2\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.202079Z 0 [Note] [MY-000000] [WSREP] Waiting for active wsrep applier to exit\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.202148Z 0 [Note] [MY-000000] [WSREP] All applier thread terminated. Will now terminate rollback thread\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.202180Z 0 [Note] [MY-000000] [WSREP] Waiting for rollback thread to terminate\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:44.202256Z 1 [Note] [MY-000000] [WSREP] rollbacker thread exiting 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:45.202293Z 0 [Note] [MY-000000] [WSREP] Rollback thread terminated\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:45.202964Z 0 [Note] [MY-000000] [Galera] dtor state: CLOSED\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:45.203037Z 0 [Note] [MY-000000] [Galera] MemPool(TrxHandleSlave): hit ratio: 0, misses: 21, in use: 21, in pool: 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:45.207205Z 0 [Note] [MY-000000] [Galera] mon: entered 21 oooe fraction 0 oool fraction 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:45.211371Z 0 [Note] [MY-000000] [Galera] mon: entered 21 oooe fraction 0 oool fraction 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:45.215687Z 0 [Note] [MY-000000] [Galera] mon: entered 24 oooe fraction 0 oool fraction 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:45.215751Z 0 [Note] [MY-000000] [Galera] cert index usage at exit 2\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:45.215771Z 0 [Note] [MY-000000] [Galera] cert trx map usage at exit 21\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:45.215790Z 0 [Note] [MY-000000] [Galera] deps set usage at exit 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:45.215810Z 0 [Note] [MY-000000] [Galera] avg deps dist 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:45.215829Z 0 [Note] [MY-000000] [Galera] avg cert interval 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:45.215846Z 0 [Note] [MY-000000] [Galera] cert index size 2\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:45.215929Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:45.215995Z 0 [Note] [MY-000000] [Galera] wsdb trx map usage 0 conn query map usage 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:45.216024Z 0 [Note] [MY-000000] [Galera] MemPool(LocalTrxHandle): hit ratio: 0.952381, misses: 1, in use: 0, in pool: 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:45.227168Z 0 [Note] [MY-000000] [Galera] Flushing memory map to disk...\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:46.563893Z 0 [System] [MY-010910] [Server] /usr/sbin/mysqld: Shutdown complete (mysqld 8.0.32-24.2)  Percona XtraDB Cluster (GPL), Release rel24, Revision 2119e75, WSREP version 26.1.4.3.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.462124Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.462168Z 0 [Warning] [MY-011068] [Server] The syntax 'wsrep_slave_threads' is deprecated and will be removed in a future release. Please use wsrep_applier_threads instead.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.464316Z 0 [Warning] [MY-010097] [Server] Insecure configuration for --secure-log-path: Current value does not restrict location of generated files. Consider setting it to a valid, non-empty path.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.465095Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.32-24.2) starting as process 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.469957Z 0 [Warning] [MY-010068] [Server] CA certificate /etc/mysql/ssl-internal/ca.crt is self signed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.470008Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.470059Z 0 [Note] [MY-000000] [Galera] Loading provider /usr/lib64/galera4/libgalera_smm.so initial position: 103be6ae-c738-11ee-95d1-526d43d08e41:22\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.470074Z 0 [Note] [MY-000000] [Galera] wsrep_load(): loading provider library '/usr/lib64/galera4/libgalera_smm.so'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.470858Z 0 [Note] [MY-000000] [Galera] wsrep_load(): Galera 4.14(779b689) by Codership Oy <info@codership.com> (modified by Percona <https://percona.com/>) loaded successfully.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.470891Z 0 [Note] [MY-000000] [Galera] CRC-32C: using 64-bit x86 acceleration.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.471191Z 0 [Warning] [MY-000000] [Galera] SSL compression is not effective. The option socket.ssl_compression is deprecated and will be removed in future releases.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.471218Z 0 [Warning] [MY-000000] [Galera] Parameter 'socket.ssl_compression' is deprecated and will be removed in future versions\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.471892Z 0 [Note] [MY-000000] [Galera] Found saved state: 103be6ae-c738-11ee-95d1-526d43d08e41:22, safe_to_bootstrap: 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.472035Z 0 [Note] [MY-000000] [Galera] GCache DEBUG: opened preamble:\nVersion: 2\nUUID: 103be6ae-c738-11ee-95d1-526d43d08e41\nSeqno: 1 - 22\nOffset: 1280\nSynced: 1\nEncVersion: 1\nEncrypted: 0\nMasterKeyConst UUID: 1035fbcf-c738-11ee-9c9f-1781681b8dcf\nMasterKey UUID: 00000000-0000-0000-0000-000000000000\nMasterKey ID: 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.472056Z 0 [Note] [MY-000000] [Galera] Recovering GCache ring buffer: version: 2, UUID: 103be6ae-c738-11ee-95d1-526d43d08e41, offset: 1280\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.472170Z 0 [Note] [MY-000000] [Galera] GCache::RingBuffer initial scan...  0.0% (        0/134217752 bytes) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.472225Z 0 [Note] [MY-000000] [Galera] GCache::RingBuffer initial scan...100.0% (134217752/134217752 bytes) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.472236Z 0 [Note] [MY-000000] [Galera] Recovering GCache ring buffer: found gapless sequence 1-22\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.472267Z 0 [Note] [MY-000000] [Galera] GCache::RingBuffer unused buffers scan...  0.0% (   0/6680 bytes) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.472288Z 0 [Note] [MY-000000] [Galera] GCache::RingBuffer unused buffers scan...100.0% (6680/6680 bytes) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.472295Z 0 [Note] [MY-000000] [Galera] Recovering GCache ring buffer: found 0/22 locked buffers\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.472302Z 0 [Note] [MY-000000] [Galera] Recovering GCache ring buffer: free space: 134211048/134217728\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.474944Z 0 [Note] [MY-000000] [Galera] Passing config to GCS: allocator.disk_pages_encryption = no; allocator.encryption_cache_page_size = 32K; allocator.encryption_cache_size = 16777216; base_dir = /var/lib/mysql/; base_host = 10.42.0.5; base_port = 4567; cert.log_conflicts = no; cert.optimistic_pa = no; debug = no; evs.auto_evict = 0; evs.delay_margin = PT1S; evs.delayed_keep_period = PT30S; evs.inactive_check_period = PT0.5S; evs.inactive_timeout = PT15S; evs.join_retrans_period = PT1S; evs.max_install_timeouts = 3; evs.send_window = 10; evs.stats_report_period = PT1M; evs.suspect_timeout = PT5S; evs.user_send_window = 4; evs.view_forget_timeout = PT24H; gcache.dir = /var/lib/mysql/; gcache.encryption = no; gcache.encryption_cache_page_size = 32K; gcache.encryption_cache_size = 16777216; gcache.freeze_purge_at_seqno = -1; gcache.keep_pages_count = 0; gcache.keep_pages_size = 0; gcache.mem_size = 0; gcache.name = galera.cache; gcache.page_size = 128M; gcache.recover = yes; gcache.size = 128M; gcomm.thread_prio = ; gcs.fc_debug = 0; gcs.fc_factor = 1.0; gcs.fc_limit = 100; gcs.fc_master_slave = no; gcs.fc_single_primary = no; gcs.max_packet_size = 64500; gcs.max_throttle = 0.25; gcs.recv_q_hard_limit = 9223372036854775807; gcs.recv_q_soft_limit = 0.25; gcs.sync_donor = no; gmcast.segment = 0; gmcast.version = 0; pc.announce_timeout = PT3S; pc.checksum = false; pc.ignore_quorum = false; pc.ignore_sb = false; pc.npvo = false; pc.recovery = true; pc.version = 0; pc.wait_prim = true; pc.wait_prim_timeout = PT30S; pc.weight = 10; protonet.backend = asio; protonet.version = 0; repl.causal_read_timeout = PT30S; repl.commit_order = 3; repl.key_format = FLAT8; repl.max_ws_size = 2147483647; repl.proto_max = 10; socket.checksum = 2; socket.recv_buf_size = auto; socket.send_buf_size = auto; socket.ssl = YES; socket.ssl_ca = /etc/mysql/ssl-internal/ca.crt; socket.ssl_cert = /etc/mysql/ssl-internal/tls.crt; socket.ssl_cipher = ; socket.ssl_compression = YES; socket.ssl_key = /etc/mysql/ssl-internal/tls.key; socket.ssl_reload = 1; \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.489525Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.489754Z 0 [Note] [MY-000000] [Galera] ####### Assign initial position for certification: 103be6ae-c738-11ee-95d1-526d43d08e41:22, protocol version: -1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.489913Z 0 [Note] [MY-000000] [WSREP] Starting replication\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.489964Z 0 [Note] [MY-000000] [Galera] Connecting with bootstrap option: 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.489986Z 0 [Note] [MY-000000] [Galera] Setting GCS initial position to 103be6ae-c738-11ee-95d1-526d43d08e41:22\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.490053Z 0 [Note] [MY-000000] [Galera] protonet asio version 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.490770Z 0 [Note] [MY-000000] [Galera] Using CRC-32C for message checksums.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.490800Z 0 [Note] [MY-000000] [Galera] backend: asio\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.490930Z 0 [Note] [MY-000000] [Galera] gcomm thread scheduling priority set to other:0 \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.491068Z 0 [Note] [MY-000000] [Galera] Fail to access the file (/var/lib/mysql//gvwstate.dat) error (No such file or directory). It is possible if node is booting for first time or re-booting after a graceful shutdown\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.491081Z 0 [Note] [MY-000000] [Galera] Restoring primary-component from disk failed. Either node is booting for first time or re-booting after a graceful shutdown\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.491304Z 0 [Note] [MY-000000] [Galera] GMCast version 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.491412Z 0 [Note] [MY-000000] [Galera] (213e9b53-8c4d, 'ssl://0.0.0.0:4567') listening at ssl://0.0.0.0:4567\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.491425Z 0 [Note] [MY-000000] [Galera] (213e9b53-8c4d, 'ssl://0.0.0.0:4567') multicast: , ttl: 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.491842Z 0 [Note] [MY-000000] [Galera] EVS version 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.491964Z 0 [Note] [MY-000000] [Galera] gcomm: bootstrapping new group 'cluster1-pxc'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.492006Z 0 [Note] [MY-000000] [Galera] start_prim is enabled, turn off pc_recovery\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.492228Z 0 [Note] [MY-000000] [Galera] EVS version upgrade 0 -> 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.492257Z 0 [Note] [MY-000000] [Galera] PC protocol upgrade 0 -> 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.492283Z 0 [Note] [MY-000000] [Galera] Node 213e9b53-8c4d state primary\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.492308Z 0 [Note] [MY-000000] [Galera] Current view of cluster as seen by this node\nview (view_id(PRIM,213e9b53-8c4d,1)\nmemb {\n\t213e9b53-8c4d,0\n\t}\njoined {\n\t}\nleft {\n\t}\npartitioned {\n\t}\n)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.492316Z 0 [Note] [MY-000000] [Galera] Save the discovered primary-component to disk\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.499317Z 0 [Note] [MY-000000] [Galera] gcomm: connected\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.499366Z 0 [Note] [MY-000000] [Galera] Changing maximum packet size to 64500, resulting msg size: 32636\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.499487Z 0 [Note] [MY-000000] [Galera] Shifting CLOSED -> OPEN (TO: 0)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.499503Z 0 [Note] [MY-000000] [Galera] Opened channel 'cluster1-pxc'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.499690Z 0 [Note] [MY-000000] [Galera] New COMPONENT: primary = yes, bootstrap = no, my_idx = 0, memb_num = 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.499867Z 0 [Note] [MY-000000] [Galera] STATE_EXCHANGE: sent state UUID: 213fef25-c738-11ee-bdb4-9a13ab034e12\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.499886Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: sent state msg: 213fef25-c738-11ee-bdb4-9a13ab034e12\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.499903Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: got state msg: 213fef25-c738-11ee-bdb4-9a13ab034e12 from 0 (cluster1-pxc-0)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.499921Z 0 [Note] [MY-000000] [Galera] Quorum results:\n\tversion    = 6,\n\tcomponent  = PRIMARY,\n\tconf_id    = 0,\n\tmembers    = 1/1 (primary/total),\n\tact_id     = 22,\n\tlast_appl. = 22,\n\tprotocols  = 2/10/4 (gcs/repl/appl),\n\tvote policy= 0,\n\tgroup UUID = 103be6ae-c738-11ee-95d1-526d43d08e41\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.499956Z 0 [Note] [MY-000000] [Galera] Flow-control interval: [100, 100]\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.499964Z 0 [Note] [MY-000000] [Galera] Restored state OPEN -> JOINED (23)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.499985Z 0 [Note] [MY-000000] [Galera] Member 0.0 (cluster1-pxc-0) synced with group.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.499994Z 0 [Note] [MY-000000] [Galera] Shifting JOINED -> SYNCED (TO: 23)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.500005Z 1 [Note] [MY-000000] [WSREP] Starting rollbacker thread 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.500079Z 2 [Note] [MY-000000] [WSREP] Starting applier thread 2\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.500190Z 2 [Note] [MY-000000] [Galera] ####### processing CC 23, local, ordered\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.500225Z 2 [Note] [MY-000000] [Galera] Maybe drain monitors from 22 upto current CC event 23 upto:22\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.500245Z 2 [Note] [MY-000000] [Galera] Drain monitors from 22 up to 22\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.500271Z 2 [Note] [MY-000000] [Galera] Process first view: 103be6ae-c738-11ee-95d1-526d43d08e41 my uuid: 213e9b53-c738-11ee-8c4d-03cb16bd2d32\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.500303Z 2 [Note] [MY-000000] [Galera] Server cluster1-pxc-0 connected to cluster at position 103be6ae-c738-11ee-95d1-526d43d08e41:23 with ID 213e9b53-c738-11ee-8c4d-03cb16bd2d32\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.500320Z 2 [Note] [MY-000000] [WSREP] Server status change disconnected -> connected\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.500369Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.500408Z 2 [Note] [MY-000000] [Galera] ####### My UUID: 213e9b53-c738-11ee-8c4d-03cb16bd2d32\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.500433Z 2 [Note] [MY-000000] [Galera] Cert index reset to 00000000-0000-0000-0000-000000000000:-1 (proto: 10), state transfer needed: no\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.500487Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.500551Z 2 [Note] [MY-000000] [Galera] ####### Assign initial position for certification: 00000000-0000-0000-0000-000000000000:-1, protocol version: -1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.500573Z 2 [Note] [MY-000000] [Galera] REPL Protocols: 10 (5)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.500592Z 2 [Note] [MY-000000] [Galera] ####### Adjusting cert position: -1 -> 23\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.500619Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.507205Z 2 [Note] [MY-000000] [Galera] ================================================\nView:\n  id: 103be6ae-c738-11ee-95d1-526d43d08e41:23\n  status: primary\n  protocol_version: 4\n  capabilities: MULTI-MASTER, CERTIFICATION, PARALLEL_APPLYING, REPLAY, ISOLATION, PAUSE, CAUSAL_READ, INCREMENTAL_WS, UNORDERED, PREORDERED, STREAMING, NBO\n  final: no\n  own_index: 0\n  members(1):\n\t0: 213e9b53-c738-11ee-8c4d-03cb16bd2d32, cluster1-pxc-0\n=================================================\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.507279Z 2 [Note] [MY-000000] [WSREP] Server status change connected -> joiner\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.507309Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.507327Z 2 [Note] [MY-000000] [WSREP] Server status change joiner -> initializing\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.507340Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.513019Z 3 [System] [MY-013576] [InnoDB] InnoDB initialization has started.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.789058Z 3 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.966675Z 3 [Note] [MY-000000] [WSREP] wsrep_init_schema_and_SR (nil)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:58.981806Z 3 [System] [MY-000000] [WSREP] PXC upgrade completed successfully\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.237585Z 0 [Warning] [MY-010068] [Server] CA certificate /etc/mysql/ssl-internal/ca.crt is self signed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.237639Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.248915Z 0 [Warning] [MY-013595] [Server] Failed to initialize TLS for channel: mysql_admin. See below for the description of exact issue.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.248973Z 0 [Warning] [MY-010069] [Server] Failed to set up SSL because of the following SSL library error: SSL context is not usable without certificate and private key\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.248988Z 0 [System] [MY-013603] [Server] No TLS configuration was given for channel mysql_admin; re-using TLS configuration of channel mysql_main.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.256144Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/var/lib/mysql' in the path is accessible to all OS users. Consider choosing a different directory.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.288543Z 0 [Note] [MY-000000] [WSREP] Initialized wsrep sidno 2\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.288625Z 0 [Note] [MY-000000] [Galera] Server initialized\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.288678Z 0 [Note] [MY-000000] [WSREP] Server status change initializing -> initialized\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.288717Z 0 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.288790Z 2 [Note] [MY-000000] [Galera] Bootstrapping a new cluster, setting initial position to 00000000-0000-0000-0000-000000000000:-1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.297404Z 10 [Note] [MY-000000] [WSREP] Starting applier thread 10\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.299102Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Bind-address: '::' port: 33060, socket: /var/lib/mysql/mysqlx.sock\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.299272Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.32-24.2'  socket: '/tmp/mysql.sock'  port: 3306  Percona XtraDB Cluster (GPL), Release rel24, Revision 2119e75, WSREP version 26.1.4.3.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.299316Z 0 [System] [MY-013292] [Server] Admin interface ready for connections, address: '10.42.0.5'  port: 33062\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.300842Z 8 [Note] [MY-000000] [WSREP] Recovered cluster id 103be6ae-c738-11ee-95d1-526d43d08e41\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.302671Z 2 [Note] [MY-000000] [WSREP] Server status change initialized -> joined\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.302727Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.302763Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.314177Z 2 [Note] [MY-000000] [Galera] Recording CC from group: 23\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.314247Z 2 [Note] [MY-000000] [Galera] Lowest cert index boundary for CC from group: 23\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.314274Z 2 [Note] [MY-000000] [Galera] Min available from gcache for CC from group: 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.314314Z 2 [Note] [MY-000000] [Galera] Server cluster1-pxc-0 synced with group\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.314335Z 2 [Note] [MY-000000] [WSREP] Server status change joined -> synced\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.314349Z 2 [Note] [MY-000000] [WSREP] Synchronized with group, ready for connections\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:43:59.314363Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:44:09.280629Z 16 [Warning] [MY-010235] [Server] Following users were specified in CREATE USER IF NOT EXISTS but they already exist. Corresponding entry in binary log used default authentication plugin 'caching_sha2_password' to rewrite authentication information (if any) for them: 'monitor'@'%'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:44:09.474167Z 19 [Warning] [MY-010235] [Server] Following users were specified in CREATE USER IF NOT EXISTS but they already exist. Corresponding entry in binary log used default authentication plugin 'caching_sha2_password' to rewrite authentication information (if any) for them: 'xtrabackup'@'%'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.229301Z 0 [Note] [MY-000000] [Galera] (213e9b53-8c4d, 'ssl://0.0.0.0:4567') connection established to 486b248f-8ac6 ssl://10.42.2.8:4567\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.229865Z 0 [Note] [MY-000000] [Galera] (213e9b53-8c4d, 'ssl://0.0.0.0:4567') turning message relay requesting on, nonlive peers: \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.719407Z 0 [Note] [MY-000000] [Galera] declaring 486b248f-8ac6 at ssl://10.42.2.8:4567 stable\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.720083Z 0 [Note] [MY-000000] [Galera] Node 213e9b53-8c4d state primary\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.720653Z 0 [Note] [MY-000000] [Galera] Current view of cluster as seen by this node\nview (view_id(PRIM,213e9b53-8c4d,2)\nmemb {\n\t213e9b53-8c4d,0\n\t486b248f-8ac6,0\n\t}\njoined {\n\t}\nleft {\n\t}\npartitioned {\n\t}\n)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.720737Z 0 [Note] [MY-000000] [Galera] Save the discovered primary-component to disk\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.737264Z 0 [Note] [MY-000000] [Galera] New COMPONENT: primary = yes, bootstrap = no, my_idx = 0, memb_num = 2\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.737539Z 0 [Note] [MY-000000] [Galera] STATE_EXCHANGE: sent state UUID: 48bafabb-c738-11ee-b32d-b39bab1609ac\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.745858Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: sent state msg: 48bafabb-c738-11ee-b32d-b39bab1609ac\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.746323Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: got state msg: 48bafabb-c738-11ee-b32d-b39bab1609ac from 0 (cluster1-pxc-0)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.219575Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: got state msg: 48bafabb-c738-11ee-b32d-b39bab1609ac from 1 (cluster1-pxc-1)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.219669Z 0 [Note] [MY-000000] [Galera] Quorum results:\n\tversion    = 6,\n\tcomponent  = PRIMARY,\n\tconf_id    = 1,\n\tmembers    = 1/2 (primary/total),\n\tact_id     = 34,\n\tlast_appl. = 22,\n\tprotocols  = 2/10/4 (gcs/repl/appl),\n\tvote policy= 0,\n\tgroup UUID = 103be6ae-c738-11ee-95d1-526d43d08e41\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.219773Z 0 [Note] [MY-000000] [Galera] Flow-control interval: [141, 141]\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.219924Z 2 [Note] [MY-000000] [Galera] ####### processing CC 35, local, ordered\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.219990Z 2 [Note] [MY-000000] [Galera] Maybe drain monitors from 34 upto current CC event 35 upto:34\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.220014Z 2 [Note] [MY-000000] [Galera] Drain monitors from 34 up to 34\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.220039Z 2 [Note] [MY-000000] [Galera] ####### My UUID: 213e9b53-c738-11ee-8c4d-03cb16bd2d32\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.220067Z 2 [Note] [MY-000000] [Galera] Skipping cert index reset\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.220086Z 2 [Note] [MY-000000] [Galera] REPL Protocols: 10 (5)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.220106Z 2 [Note] [MY-000000] [Galera] ####### Adjusting cert position: 34 -> 35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.220186Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.242438Z 2 [Note] [MY-000000] [Galera] ================================================\nView:\n  id: 103be6ae-c738-11ee-95d1-526d43d08e41:35\n  status: primary\n  protocol_version: 4\n  capabilities: MULTI-MASTER, CERTIFICATION, PARALLEL_APPLYING, REPLAY, ISOLATION, PAUSE, CAUSAL_READ, INCREMENTAL_WS, UNORDERED, PREORDERED, STREAMING, NBO\n  final: no\n  own_index: 0\n  members(2):\n\t0: 213e9b53-c738-11ee-8c4d-03cb16bd2d32, cluster1-pxc-0\n\t1: 486b248f-c738-11ee-8ac6-0a8a79d0dabd, cluster1-pxc-1\n=================================================\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.242527Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.251299Z 2 [Note] [MY-000000] [Galera] Recording CC from group: 35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.251372Z 2 [Note] [MY-000000] [Galera] Lowest cert index boundary for CC from group: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.251390Z 2 [Note] [MY-000000] [Galera] Min available from gcache for CC from group: 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.302828Z 0 [Note] [MY-000000] [Galera] Member 1.0 (cluster1-pxc-1) requested state transfer from '*any*'. Selected 0.0 (cluster1-pxc-0)(SYNCED) as donor.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.302913Z 0 [Note] [MY-000000] [Galera] Shifting SYNCED -> DONOR/DESYNCED (TO: 35)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.302990Z 2 [Note] [MY-000000] [Galera] Detected STR version: 1, req_len: 125, req: STRv1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.303075Z 2 [Note] [MY-000000] [Galera] Cert index preload: 24 -> 35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.312335Z 2 [Note] [MY-000000] [WSREP] Server status change synced -> donor\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.312385Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.312458Z 0 [Note] [MY-000000] [Galera] async IST sender starting to serve ssl://10.42.2.8:4568 sending 24-35, preload starts from 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.312744Z 0 [Note] [MY-000000] [WSREP] Initiating SST/IST transfer on DONOR side (wsrep_sst_xtrabackup-v2 --role 'donor' --address '10.42.2.8:4444/xtrabackup_sst//1' --socket '/tmp/mysql.sock' --datadir '/var/lib/mysql/' --basedir '/usr/' --plugindir '/usr/lib64/mysql/plugin/' --defaults-file '/etc/my.cnf' --defaults-group-suffix '' --mysqld-version '8.0.32-24.2'  --binlog 'binlog' --gtid '103be6ae-c738-11ee-95d1-526d43d08e41:35' )\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.313438Z 0 [Note] [MY-000000] [Galera] IST sender 24 -> 35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.318236Z 2 [Note] [MY-000000] [WSREP] DONOR thread signaled with 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:07.137867Z 171 [Warning] [MY-013712] [Server] No suitable 'keyring_component_metadata_query' service implementation found to fulfill the request.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:07.508985Z 0 [Note] [MY-000000] [Galera] (213e9b53-8c4d, 'ssl://0.0.0.0:4567') turning message relay requesting off\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:18.201951Z 0 [Note] [MY-000000] [WSREP-SST] Streaming the backup to joiner at 10.42.2.8 4444\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:18.272434Z 210 [Warning] [MY-013712] [Server] No suitable 'keyring_component_metadata_query' service implementation found to fulfill the request.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:21.258499Z 0 [Note] [MY-000000] [WSREP-SST]     donor: => Rate:[24.9MiB/s] Avg:[24.9MiB/s] Elapsed:0:00:03            \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:21.264689Z 0 [Note] [MY-000000] [Galera] SST sent: 103be6ae-c738-11ee-95d1-526d43d08e41:35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:21.264777Z 0 [Note] [MY-000000] [WSREP] Server status change donor -> joined\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:21.264825Z 0 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:21.265590Z 0 [Note] [MY-000000] [Galera] 0.0 (cluster1-pxc-0): State transfer to 1.0 (cluster1-pxc-1) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:21.265656Z 0 [Note] [MY-000000] [Galera] Shifting DONOR/DESYNCED -> JOINED (TO: 35)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:21.265779Z 0 [Note] [MY-000000] [Galera] Processing event queue:... -nan% (0/0 events) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:21.266243Z 0 [Note] [MY-000000] [Galera] Member 0.0 (cluster1-pxc-0) synced with group.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:21.266310Z 0 [Note] [MY-000000] [Galera] Processing event queue:...100.0% (1/1 events) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:21.266336Z 0 [Note] [MY-000000] [Galera] Shifting JOINED -> SYNCED (TO: 35)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:21.266409Z 2 [Note] [MY-000000] [Galera] Server cluster1-pxc-0 synced with group\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:21.266457Z 2 [Note] [MY-000000] [WSREP] Server status change joined -> synced\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:21.266469Z 2 [Note] [MY-000000] [WSREP] Synchronized with group, ready for connections\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:18.224024-00:00 0 [Note] [MY-011825] [Xtrabackup] recognized server arguments: --datadir=/var/lib/mysql --server-id=32109360 --innodb_flush_log_at_trx_commit=0 --innodb_flush_method=O_DIRECT --innodb_file_per_table=1 --defaults_group=mysqld \n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.224288-00:00 0 [Note] [MY-011825] [Xtrabackup] recognized client arguments: --socket=/tmp/mysql.sock --no-version-check=1 --parallel=4 --user=mysql.pxc.sst.user --password=* --socket=/tmp/mysql.sock --lock-ddl=1 --backup=1 --galera-info=1 --stream=xbstream --xtrabackup-plugin-dir=/usr/bin/pxc_extra/pxb-8.0/lib/plugin --target-dir=/tmp/pxc_sst_7zdb/donor_xb_pMxh \n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"/usr/bin/pxc_extra/pxb-8.0/bin/xtrabackup version 8.0.32-26 based on MySQL server 8.0.32 Linux (x86_64) (revision id: 34cf2908)\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.224315-00:00 0 [Note] [MY-011825] [Xtrabackup] Connecting to MySQL server host: localhost, user: mysql.pxc.sst.user, password: set, port: not set, socket: /tmp/mysql.sock\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.242982-00:00 0 [Note] [MY-011825] [Xtrabackup] Using server version 8.0.32-24.2\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.249366-00:00 0 [Note] [MY-011825] [Xtrabackup] Executing LOCK TABLES FOR BACKUP ...\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.270020-00:00 0 [Note] [MY-011825] [Xtrabackup] uses posix_fadvise().\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.270096-00:00 0 [Note] [MY-011825] [Xtrabackup] cd to /var/lib/mysql\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.270111-00:00 0 [Note] [MY-011825] [Xtrabackup] open files limit requested 0, set to 1048576\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.271192-00:00 0 [Note] [MY-011825] [Xtrabackup] using the following InnoDB configuration:\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.271240-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_data_home_dir = .\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.271259-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_data_file_path = ibdata1:12M:autoextend\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.271312-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_group_home_dir = ./\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.271329-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_files_in_group = 2\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.271348-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_file_size = 50331648\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.271378-00:00 0 [Note] [MY-011825] [Xtrabackup] using O_DIRECT\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.273191-00:00 0 [Note] [MY-011825] [Xtrabackup] inititialize_service_handles suceeded\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.427032-00:00 0 [Note] [MY-011825] [Xtrabackup] Connecting to MySQL server host: localhost, user: mysql.pxc.sst.user, password: set, port: not set, socket: /tmp/mysql.sock\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.432691-00:00 0 [Note] [MY-011825] [Xtrabackup] Redo Log Archiving is not set up.\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.527891-00:00 1 [Note] [MY-011825] [Xtrabackup] >> log scanned up to (32174401)\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.731310-00:00 0 [Note] [MY-011825] [Xtrabackup] Generating a list of tablespaces\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.731376-00:00 0 [Note] [MY-012204] [InnoDB] Scanning './'\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.740213-00:00 0 [Note] [MY-012208] [InnoDB] Completed space ID check of 2 files.\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.740996-00:00 0 [Warning] [MY-012091] [InnoDB] Allocated tablespace ID 1 for sys/sys_config, old maximum was 0\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.742154-00:00 0 [Note] [MY-013252] [InnoDB] Using undo tablespace './undo_001'.\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.742424-00:00 0 [Note] [MY-013252] [InnoDB] Using undo tablespace './undo_002'.\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.742943-00:00 0 [Note] [MY-012910] [InnoDB] Opened 2 existing undo tablespaces.\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.742961-00:00 0 [Note] [MY-011825] [Xtrabackup] Starting 4 threads for parallel data files transfer\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.743621-00:00 2 [Note] [MY-011825] [Xtrabackup] Streaming ./ibdata1\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.743644-00:00 4 [Note] [MY-011825] [Xtrabackup] Streaming ./mysql/wsrep_cluster.ibd\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.743622-00:00 3 [Note] [MY-011825] [Xtrabackup] Streaming ./sys/sys_config.ibd\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.744293-00:00 3 [Note] [MY-011825] [Xtrabackup] Done: Streaming ./sys/sys_config.ibd\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.744440-00:00 4 [Note] [MY-011825] [Xtrabackup] Done: Streaming ./mysql/wsrep_cluster.ibd\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.745296-00:00 5 [Note] [MY-011825] [Xtrabackup] Streaming ./mysql/wsrep_cluster_members.ibd\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.747107-00:00 5 [Note] [MY-011825] [Xtrabackup] Done: Streaming ./mysql/wsrep_cluster_members.ibd\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.748217-00:00 3 [Note] [MY-011825] [Xtrabackup] Streaming ./mysql/wsrep_streaming_log.ibd\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.749099-00:00 4 [Note] [MY-011825] [Xtrabackup] Streaming ./mysql.ibd\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.749910-00:00 3 [Note] [MY-011825] [Xtrabackup] Done: Streaming ./mysql/wsrep_streaming_log.ibd\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.750843-00:00 5 [Note] [MY-011825] [Xtrabackup] Streaming ./undo_002\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.761558-00:00 3 [Note] [MY-011825] [Xtrabackup] Streaming ./undo_001\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:18.979487-00:00 2 [Note] [MY-011825] [Xtrabackup] Done: Streaming ./ibdata1\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.033614-00:00 5 [Note] [MY-011825] [Xtrabackup] Done: Streaming ./undo_002\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.088398-00:00 3 [Note] [MY-011825] [Xtrabackup] Done: Streaming ./undo_001\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.212615-00:00 4 [Note] [MY-011825] [Xtrabackup] Done: Streaming ./mysql.ibd\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.528133-00:00 1 [Note] [MY-011825] [Xtrabackup] >> log scanned up to (32174401)\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.743499-00:00 0 [Note] [MY-011825] [Xtrabackup] Starting to backup non-InnoDB tables and files\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.745327-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming mysql/slow_log.CSM to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.745566-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming mysql/slow_log.CSM to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.746550-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming mysql/slow_log_226.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.746719-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming mysql/slow_log_226.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.746912-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming mysql/general_log_225.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.746952-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming mysql/general_log_225.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.751099-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming mysql/general_log.CSV to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.751235-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming mysql/general_log.CSV to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.751515-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/malloc_stats_tot_200.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.751610-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/malloc_stats_tot_200.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.755591-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming mysql/general_log.CSM to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.755965-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming mysql/slow_log.CSV to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.756029-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming mysql/slow_log.CSV to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.756038-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming mysql/general_log.CSM to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.756237-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/memory_summary_b_164.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.756296-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/memory_summary_b_164.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.756367-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_131.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.756469-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_131.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.756881-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_asyn_182.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.756998-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_asyn_182.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.758796-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/session_variable_194.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.758843-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/session_variable_194.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.760398-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_conn_171.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.760468-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_conn_171.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.762154-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/malloc_stats_201.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.762303-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_transacti_143.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.762309-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/malloc_stats_201.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.762418-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_transacti_143.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.765477-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/file_summary_by__104.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.765745-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/file_summary_by__104.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.766312-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_waits_sum_97.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.766380-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/pxc_cluster_view_203.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.766460-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_waits_sum_97.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.766484-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/pxc_cluster_view_203.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.767550-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/table_io_waits_s_117.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.767677-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/table_io_waits_s_117.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.768028-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/setup_instrument_113.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.768154-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/setup_instrument_113.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.769293-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_132.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.769425-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_132.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.771284-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_conn_173.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.771453-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_conn_173.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.771975-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/threads_119.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.771960-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/mutex_instances_106.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.772092-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/mutex_instances_106.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.772103-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/threads_119.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.773182-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_stages_cu_120.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.773261-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_stages_cu_120.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.773500-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/status_by_thread_188.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.773613-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/status_by_thread_188.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.775012-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/memory_summary_b_165.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.775085-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/memory_summary_b_165.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.777082-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_transacti_145.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.777244-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_transacti_145.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.777414-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_130.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.777414-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/processlist_109.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.777546-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/processlist_109.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.777587-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_130.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.778840-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/user_defined_fun_197.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.779011-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/user_defined_fun_197.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.779506-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_asyn_181.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.779611-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_asyn_181.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.780898-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_errors_su_152.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.781103-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_errors_su_152.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.781777-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/persisted_variab_196.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.781841-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/persisted_variab_196.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.783458-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/session_status_191.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.783571-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/session_status_191.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.783904-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_errors_su_148.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.783988-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_errors_su_148.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.784177-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/accounts_154.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.784250-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/accounts_154.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.785459-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_133.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.785685-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_133.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.786703-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/keyring_componen_202.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.786720-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/rwlock_instances_110.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.786859-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/rwlock_instances_110.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.786863-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/keyring_componen_202.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.789053-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/log_status_183.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.789162-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/log_status_183.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.789172-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_transacti_146.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.789174-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/setup_threads_115.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.789244-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_transacti_146.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.789266-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/setup_threads_115.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.790903-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/socket_summary_b_158.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.791085-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/socket_summary_b_158.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.791372-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_waits_his_94.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.791450-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_waits_his_94.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.791679-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_stages_hi_122.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.791746-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_stages_hi_122.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.793779-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/socket_instances_156.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.794192-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/socket_instances_156.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.794426-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/cond_instances_91.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.794523-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/cond_instances_91.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.794876-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/data_locks_169.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.795045-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/data_locks_169.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.796555-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/table_lock_waits_118.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.796905-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/table_lock_waits_118.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.797094-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_129.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.797097-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/setup_objects_114.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.797183-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_129.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.797195-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/setup_objects_114.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.798614-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/objects_summary__107.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.798685-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/objects_summary__107.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.800279-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_errors_su_151.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.800320-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_139.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.800369-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_errors_su_151.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.800426-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_139.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.802471-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_stages_su_124.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.802560-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_stages_su_124.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.802668-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_appl_176.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.802831-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_appl_176.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.802842-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/status_by_accoun_186.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.802907-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/status_by_accoun_186.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.804207-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_appl_175.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.804298-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_appl_175.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.805391-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/file_summary_by__103.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.805510-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/file_summary_by__103.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.805968-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_stages_su_127.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.806024-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_stages_su_127.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.807868-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/table_io_waits_s_116.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.807878-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_128.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.807894-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_appl_174.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.808009-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_appl_174.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.808025-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/table_io_waits_s_116.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.808048-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_128.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.810064-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/setup_actors_111.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.810163-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/setup_actors_111.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.810316-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/session_account__160.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.810419-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/session_account__160.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.811874-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/status_by_user_189.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.811951-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/status_by_user_189.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.813626-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_errors_su_150.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.813628-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_waits_sum_100.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.813799-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_waits_sum_100.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.813797-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/tls_channel_stat_199.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.813798-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_errors_su_150.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.813878-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/tls_channel_stat_199.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.813999-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_grou_178.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.814112-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_grou_178.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.816135-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/global_variables_193.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.816146-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/performance_time_108.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.816241-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/global_variables_193.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.816242-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/performance_time_108.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.818107-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_138.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.818197-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_138.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.819599-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/memory_summary_b_163.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.819599-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_grou_172.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.819764-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/memory_summary_b_163.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.819765-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_grou_172.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.819900-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/setup_consumers_112.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.819970-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/setup_consumers_112.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.821618-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_137.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.821728-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_137.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.821772-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/hosts_155.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.821935-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/hosts_155.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.823978-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_stages_su_126.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.824086-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_stages_su_126.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.824191-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/binary_log_trans_198.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.824337-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/binary_log_trans_198.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.825703-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/user_variables_b_185.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.825704-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_stages_su_125.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.825850-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/user_variables_b_185.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.825863-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_stages_su_125.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.826227-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/socket_summary_b_157.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.826298-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/socket_summary_b_157.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.826811-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_appl_180.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.826912-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_appl_180.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.828531-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/session_connect__159.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.828602-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/session_connect__159.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.829054-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/global_status_190.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.829121-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/global_status_190.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.830873-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/metadata_locks_168.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.830942-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/metadata_locks_168.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.831137-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/status_by_host_187.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.831187-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/status_by_host_187.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.831932-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_waits_sum_99.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.831964-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/keyring_keys_161.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.832133-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_waits_sum_99.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.832134-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/keyring_keys_161.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.833579-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/table_handles_167.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.833595-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/error_log_92.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.833665-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/table_handles_167.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.833680-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/error_log_92.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.836100-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_errors_su_149.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.836265-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_errors_su_149.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.836305-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_waits_sum_101.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.836383-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_waits_sum_101.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.837709-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_136.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.837896-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_136.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.838137-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_appl_177.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.838273-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_appl_177.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.838449-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/users_153.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.838511-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/users_153.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.838544-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_transacti_142.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.838609-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_transacti_142.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.840918-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/data_lock_waits_170.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.841516-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/data_lock_waits_170.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.841569-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_transacti_147.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.841660-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_transacti_147.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.842096-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_stages_su_123.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.842153-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_stages_su_123.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.844155-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_stages_hi_121.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.844245-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/variables_info_195.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.844238-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_transacti_141.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.844285-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_stages_hi_121.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.844354-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_transacti_141.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.844303-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/variables_info_195.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.846654-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/variables_by_thr_192.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.846642-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_waits_his_95.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.846738-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/variables_by_thr_192.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.846740-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_waits_his_95.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.848112-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_135.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.848531-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_135.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.848865-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_transacti_140.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.848999-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_transacti_140.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.849089-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_waits_cur_93.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.849144-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_waits_cur_93.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.851210-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_waits_sum_96.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.851293-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/file_instances_102.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.851395-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/file_instances_102.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.851418-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_waits_sum_96.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.851855-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_waits_sum_98.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.852063-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_waits_sum_98.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.853452-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_transacti_144.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.853546-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_transacti_144.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.854320-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/host_cache_105.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.854430-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/host_cache_105.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.855761-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_134.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.855857-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_134.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.856171-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/memory_summary_b_166.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.856307-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/memory_summary_b_166.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.856709-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/prepared_stateme_184.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.856797-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/prepared_stateme_184.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.857289-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_appl_179.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.857369-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_appl_179.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.857729-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/memory_summary_g_162.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.857762-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/memory_summary_g_162.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.946739-00:00 0 [Note] [MY-011825] [Xtrabackup] Finished backing up non-InnoDB tables and files\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:19.946801-00:00 0 [Note] [MY-011825] [Xtrabackup] Executing FLUSH NO_WRITE_TO_BINLOG BINARY LOGS\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:20.002876-00:00 0 [Note] [MY-011825] [Xtrabackup] Selecting LSN and binary log position from p_s.log_status\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:20.009232-00:00 0 [Note] [MY-011825] [Xtrabackup] Streaming /var/lib/mysql/binlog.000003 to <STDOUT> up to position 197\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:20.009278-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Streaming /var/lib/mysql/binlog.000003 to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:20.009437-00:00 0 [Note] [MY-011825] [Xtrabackup] Streaming <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:20.009447-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Streaming file <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:20.018588-00:00 0 [Note] [MY-011825] [Xtrabackup] Streaming <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:20.018660-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Streaming file <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:20.018690-00:00 0 [Note] [MY-011825] [Xtrabackup] Executing FLUSH NO_WRITE_TO_BINLOG ENGINE LOGS...\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:20.032672-00:00 0 [Note] [MY-011825] [Xtrabackup] The latest check point (for incremental): '32174401'\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:20.032746-00:00 0 [Note] [MY-011825] [Xtrabackup] Stopping log copying thread at LSN 32174401\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:20.032928-00:00 1 [Note] [MY-011825] [Xtrabackup] Starting to parse redo log at lsn = 32174179\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:20.034519-00:00 0 [Note] [MY-011825] [Xtrabackup] Executing UNLOCK TABLES\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:20.034931-00:00 0 [Note] [MY-011825] [Xtrabackup] All tables unlocked\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:20.035198-00:00 0 [Note] [MY-011825] [Xtrabackup] Streaming ib_buffer_pool to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:20.035251-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Streaming ib_buffer_pool to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:20.036025-00:00 0 [Note] [MY-011825] [Xtrabackup] Backup created in directory '/tmp/pxc_sst_7zdb/donor_xb_pMxh/'\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:20.036038-00:00 0 [Note] [MY-011825] [Xtrabackup] MySQL binlog position: filename 'binlog.000003', position '197', GTID of the last change '103be6ae-c738-11ee-95d1-526d43d08e41:1-11'\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:20.036126-00:00 0 [Note] [MY-011825] [Xtrabackup] Streaming <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:20.036136-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Streaming file <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:20.042679-00:00 0 [Note] [MY-011825] [Xtrabackup] Streaming <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:20.042727-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Streaming file <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:21.044123-00:00 0 [Note] [MY-011825] [Xtrabackup] Transaction log of lsn (32174346) to (32174411) was copied.\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:21.254821-00:00 0 [Note] [MY-011825] [Xtrabackup] completed OK!\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:45:21.266476Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.707877Z 0 [Note] [MY-000000] [Galera] async IST sender served\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.708554Z 0 [Note] [MY-000000] [Galera] 1.0 (cluster1-pxc-1): State transfer from 0.0 (cluster1-pxc-0) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.709172Z 0 [Note] [MY-000000] [Galera] Member 1.0 (cluster1-pxc-1) synced with group.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.684773Z 0 [Note] [MY-000000] [Galera] (213e9b53-8c4d, 'ssl://0.0.0.0:4567') turning message relay requesting on, nonlive peers: ssl://10.42.1.6:4567 \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.685695Z 0 [Note] [MY-000000] [Galera] (213e9b53-8c4d, 'ssl://0.0.0.0:4567') connection established to 7eee9476-83f9 ssl://10.42.1.6:4567\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:36.177674Z 0 [Note] [MY-000000] [Galera] declaring 486b248f-8ac6 at ssl://10.42.2.8:4567 stable\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:36.177738Z 0 [Note] [MY-000000] [Galera] declaring 7eee9476-83f9 at ssl://10.42.1.6:4567 stable\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.179110Z 0 [Note] [MY-000000] [Galera] Node 213e9b53-8c4d state primary\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.179880Z 0 [Note] [MY-000000] [Galera] Current view of cluster as seen by this node\nview (view_id(PRIM,213e9b53-8c4d,3)\nmemb {\n\t213e9b53-8c4d,0\n\t486b248f-8ac6,0\n\t7eee9476-83f9,0\n\t}\njoined {\n\t}\nleft {\n\t}\npartitioned {\n\t}\n)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.179936Z 0 [Note] [MY-000000] [Galera] Save the discovered primary-component to disk\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.195858Z 0 [Note] [MY-000000] [Galera] New COMPONENT: primary = yes, bootstrap = no, my_idx = 0, memb_num = 3\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.196119Z 0 [Note] [MY-000000] [Galera] STATE_EXCHANGE: sent state UUID: 7fd70a41-c738-11ee-8cb8-0a31c2c73e26\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.197532Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: sent state msg: 7fd70a41-c738-11ee-8cb8-0a31c2c73e26\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.198801Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: got state msg: 7fd70a41-c738-11ee-8cb8-0a31c2c73e26 from 0 (cluster1-pxc-0)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.198877Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: got state msg: 7fd70a41-c738-11ee-8cb8-0a31c2c73e26 from 1 (cluster1-pxc-1)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679137Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: got state msg: 7fd70a41-c738-11ee-8cb8-0a31c2c73e26 from 2 (cluster1-pxc-2)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679302Z 0 [Note] [MY-000000] [Galera] Quorum results:\n\tversion    = 6,\n\tcomponent  = PRIMARY,\n\tconf_id    = 2,\n\tmembers    = 2/3 (primary/total),\n\tact_id     = 35,\n\tlast_appl. = 22,\n\tprotocols  = 2/10/4 (gcs/repl/appl),\n\tvote policy= 0,\n\tgroup UUID = 103be6ae-c738-11ee-95d1-526d43d08e41\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679518Z 0 [Note] [MY-000000] [Galera] Flow-control interval: [173, 173]\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679802Z 10 [Note] [MY-000000] [Galera] ####### processing CC 36, local, ordered\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679948Z 10 [Note] [MY-000000] [Galera] Maybe drain monitors from 35 upto current CC event 36 upto:35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679986Z 10 [Note] [MY-000000] [Galera] Drain monitors from 35 up to 35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.680024Z 10 [Note] [MY-000000] [Galera] ####### My UUID: 213e9b53-c738-11ee-8c4d-03cb16bd2d32\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.680055Z 10 [Note] [MY-000000] [Galera] Skipping cert index reset\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.680084Z 10 [Note] [MY-000000] [Galera] REPL Protocols: 10 (5)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.680114Z 10 [Note] [MY-000000] [Galera] ####### Adjusting cert position: 35 -> 36\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.680228Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.702542Z 10 [Note] [MY-000000] [Galera] ================================================\nView:\n  id: 103be6ae-c738-11ee-95d1-526d43d08e41:36\n  status: primary\n  protocol_version: 4\n  capabilities: MULTI-MASTER, CERTIFICATION, PARALLEL_APPLYING, REPLAY, ISOLATION, PAUSE, CAUSAL_READ, INCREMENTAL_WS, UNORDERED, PREORDERED, STREAMING, NBO\n  final: no\n  own_index: 0\n  members(3):\n\t0: 213e9b53-c738-11ee-8c4d-03cb16bd2d32, cluster1-pxc-0\n\t1: 486b248f-c738-11ee-8ac6-0a8a79d0dabd, cluster1-pxc-1\n\t2: 7eee9476-c738-11ee-83f9-e3e1dce47b60, cluster1-pxc-2\n=================================================\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.702668Z 10 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.717907Z 10 [Note] [MY-000000] [Galera] Recording CC from group: 36\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.717992Z 10 [Note] [MY-000000] [Galera] Lowest cert index boundary for CC from group: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.718018Z 10 [Note] [MY-000000] [Galera] Min available from gcache for CC from group: 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.732325Z 0 [Note] [MY-000000] [Galera] (213e9b53-8c4d, 'ssl://0.0.0.0:4567') turning message relay requesting off\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.764189Z 0 [Note] [MY-000000] [Galera] Member 2.0 (cluster1-pxc-2) requested state transfer from 'cluster1-pxc-1,'. Selected 1.0 (cluster1-pxc-1)(SYNCED) as donor.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:53.708271Z 0 [Note] [MY-000000] [Galera] 1.0 (cluster1-pxc-1): State transfer to 2.0 (cluster1-pxc-2) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:53.709285Z 0 [Note] [MY-000000] [Galera] Member 1.0 (cluster1-pxc-1) synced with group.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.622943Z 0 [Note] [MY-000000] [Galera] 2.0 (cluster1-pxc-2): State transfer from 1.0 (cluster1-pxc-1) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.623596Z 0 [Note] [MY-000000] [Galera] Member 2.0 (cluster1-pxc-2) synced with group.\n","file":"/var/lib/mysql/mysqld-error.log"}
++ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/fluent-bit/bin
++ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/fluent-bit/bin
++ '[' logrotate = logrotate ']'
++ [[ 1001 != 1001 ]]
++ exec go-cron '0 0 * * *' sh -c 'logrotate -s /opt/percona/logrotate/logrotate.status /opt/percona/logrotate/logrotate-mysql.conf;/usr/bin/find /var/lib/mysql/ -name GRA_*.log -mtime +7 -delete'
+new cron: 0 0 * * *

--- a/src/go/pt-galera-log-explainer/tests/logs/operator_split/node1.log
+++ b/src/go/pt-galera-log-explainer/tests/logs/operator_split/node1.log
@@ -1,0 +1,1145 @@
++ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/fluent-bit/bin
++ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/fluent-bit/bin
++ '[' logrotate = logrotate ']'
++ [[ 1001 != 1001 ]]
++ exec go-cron '0 0 * * *' sh -c 'logrotate -s /opt/percona/logrotate/logrotate.status /opt/percona/logrotate/logrotate-mysql.conf;/usr/bin/find /var/lib/mysql/ -name GRA_*.log -mtime +7 -delete'
+new cron: 0 0 * * *
++ trap exit SIGTERM
++ '[' m = - ']'
++ CFG=/etc/mysql/node.cnf
++ wantHelp=
++ for arg in "$@"
++ case "$arg" in
+++ mysqld -V
+++ awk '{print $3}'
+++ awk -F. '{print $1"."$2}'
++ MYSQL_VERSION=8.0
+++ mysqld -V
+++ awk '{print $3}'
+++ awk -F. '{print $3}'
+++ awk -F- '{print $1}'
++ MYSQL_PATCH_VERSION=32
++ vault_secret=/etc/mysql/vault-keyring-secret/keyring_vault.conf
++ '[' -f /etc/mysql/vault-keyring-secret/keyring_vault.conf ']'
++ '[' -f /usr/lib64/mysql/plugin/binlog_utils_udf.so ']'
++ sed -i '/\[mysqld\]/a plugin_load="binlog_utils_udf=binlog_utils_udf.so"' /etc/mysql/node.cnf
++ sed -i '/\[mysqld\]/a gtid-mode=ON' /etc/mysql/node.cnf
++ sed -i '/\[mysqld\]/a enforce-gtid-consistency' /etc/mysql/node.cnf
++ grep -q '^progress=' /etc/mysql/node.cnf
++ sed -i 's|^progress=.*|progress=1|' /etc/mysql/node.cnf
++ grep -q '^\[sst\]' /etc/mysql/node.cnf
++ grep -q '^cpat=' /etc/mysql/node.cnf
++ sed '/^\[sst\]/a cpat=.*\\.pem$\\|.*init\\.ok$\\|.*galera\\.cache$\\|.*wsrep_recovery_verbose\\.log$\\|.*readiness-check\\.sh$\\|.*liveness-check\\.sh$\\|.*get-pxc-state$\\|.*sst_in_progress$\\|.*pmm-prerun\\.sh$\\|.*sst-xb-tmpdir$\\|.*\\.sst$\\|.*gvwstate\\.dat$\\|.*grastate\\.dat$\\|.*\\.err$\\|.*\\.log$\\|.*RPM_UPGRADE_MARKER$\\|.*RPM_UPGRADE_HISTORY$\\|.*pxc-entrypoint\\.sh$\\|.*unsafe-bootstrap\\.sh$\\|.*pxc-configure-pxc\\.sh\\|.*peer-list$\\|.*auth_plugin$' /etc/mysql/node.cnf
++ [[ 8.0 == \8\.\0 ]]
++ [[ 32 -ge 26 ]]
++ grep -q '^skip_replica_start=ON' /etc/mysql/node.cnf
++ sed -i '/\[mysqld\]/a skip_replica_start=ON' /etc/mysql/node.cnf
++ auth_plugin=caching_sha2_password
++ [[ -f /var/lib/mysql/auth_plugin ]]
++ [[ -z caching_sha2_password ]]
++ [[ 8.0 == \5\.\7 ]]
++ echo caching_sha2_password
++ sed -i /default_authentication_plugin/d /etc/mysql/node.cnf
++ [[ 8.0 == \8\.\0 ]]
++ [[ 32 -ge 27 ]]
++ sed -i '/\[mysqld\]/a authentication_policy=caching_sha2_password,,' /etc/mysql/node.cnf
++ file_env XTRABACKUP_PASSWORD xtrabackup xtrabackup
+Percona XtraDB Cluster: Finding peers
+2024/02/09 10:44:51 Peer finder enter
+2024/02/09 10:44:51 Determined Domain to be pxc.svc.cluster.local
+2024/02/09 10:44:51 Peer list updated
+was []
+now [10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local 10-42-2-8.cluster1-pxc-unready.pxc.svc.cluster.local]
+2024/02/09 10:44:51 execing: /var/lib/mysql/pxc-configure-pxc.sh with stdin: 10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local
+10-42-2-8.cluster1-pxc-unready.pxc.svc.cluster.local
+2024/02/09 10:44:51 ++ awk ' { print $1 } '
+++ hostname -I
++ NODE_IP=10.42.2.8
+++ hostname -f
+++ cut -d. -f2
++ CLUSTER_NAME=cluster1-pxc
++ SERVER_NUM=1
++ SERVER_ID=32109361
+++ hostname -f
++ NODE_NAME=cluster1-pxc-1.cluster1-pxc.pxc.svc.cluster.local
++ NODE_PORT=3306
++ read -ra LINE
++ echo 'read line 10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local'
+read line 10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local
+++ getent hosts 10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local
+++ awk '{ print $1 }'
++ LINE_IP=10.42.0.5
++ '[' 10.42.0.5 '!=' 10.42.2.8 ']'
+++ mysql_root_exec 10.42.0.5 'select @@hostname'
+++ local server=10.42.0.5
+++ local 'query=select @@hostname'
++ LINE_HOST=cluster1-pxc-0
++ '[' -n cluster1-pxc-0 ']'
++ PEERS=("${PEERS[@]}" $LINE_HOST)
++ PEERS_FULL=("${PEERS_FULL[@]}" "$LINE_HOST.$CLUSTER_NAME")
++ read -ra LINE
++ echo 'read line 10-42-2-8.cluster1-pxc-unready.pxc.svc.cluster.local'
+read line 10-42-2-8.cluster1-pxc-unready.pxc.svc.cluster.local
+++ getent hosts 10-42-2-8.cluster1-pxc-unready.pxc.svc.cluster.local
+++ awk '{ print $1 }'
++ LINE_IP=10.42.2.8
++ '[' 10.42.2.8 '!=' 10.42.2.8 ']'
++ read -ra LINE
++ '[' 1 '!=' 0 ']'
+++ printf '%s\n' cluster1-pxc-0 cluster1-pxc-1
+++ sort --version-sort
+++ uniq
+++ grep -v -- '-0$'
+++ sed '$d'
+++ tr '\n' ,
+++ sed 's/^,$//'
++ DONOR_ADDRESS=
++ '[' 1 '!=' 0 ']'
+++ printf '%s\n' cluster1-pxc-0.cluster1-pxc
+++ sort --version-sort
+++ tr '\n' ,
+++ sed 's/,$//'
++ WSREP_CLUSTER_ADDRESS=cluster1-pxc-0.cluster1-pxc
++ CFG=/etc/mysql/node.cnf
+++ mysqld -V
+++ awk '{print $3}'
+++ awk -F. '{print $1"."$2}'
++ MYSQL_VERSION=8.0
++ '[' 8.0 == 8.0 ']'
++ grep -E -q '^[#]?admin-address' /etc/mysql/node.cnf
++ sed '/^\[mysqld\]/a admin-address=\n' /etc/mysql/node.cnf
++ grep -E -q '^[#]?log_error_suppression_list' /etc/mysql/node.cnf
++ sed '/^\[mysqld\]/a log_error_suppression_list="MY-010055"\n' /etc/mysql/node.cnf
++ '[' yes == yes ']'
++ grep -E -q '^[#]?log-error' /etc/mysql/node.cnf
++ sed '/^\[mysqld\]/a log-error=/var/lib/mysql/mysqld-error.log\n' /etc/mysql/node.cnf
++ grep -E -q '^[#]?wsrep_sst_donor' /etc/mysql/node.cnf
++ sed '/^\[mysqld\]/a wsrep_sst_donor=\n' /etc/mysql/node.cnf
++ grep -E -q '^[#]?wsrep_node_incoming_address' /etc/mysql/node.cnf
++ grep -E -q '^[#]?wsrep_provider_options' /etc/mysql/node.cnf
++ sed '/^\[mysqld\]/a wsrep_provider_options="pc.weight=10"\n' /etc/mysql/node.cnf
++ sed -r 's|^[#]?server_id=.*$|server_id=32109361|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?coredumper$|coredumper|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?wsrep_node_address=.*$|wsrep_node_address=10.42.2.8|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?wsrep_cluster_name=.*$|wsrep_cluster_name=cluster1-pxc|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?wsrep_sst_donor=.*$|wsrep_sst_donor=|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?wsrep_cluster_address=.*$|wsrep_cluster_address=gcomm://cluster1-pxc-0.cluster1-pxc|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?wsrep_node_incoming_address=.*$|wsrep_node_incoming_address=cluster1-pxc-1.cluster1-pxc.pxc.svc.cluster.local:3306|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?admin-address=.*$|admin-address=10.42.2.8|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?extra_max_connections=.*$|extra_max_connections=100|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?extra_port=.*$|extra_port=33062|' /etc/mysql/node.cnf
++ CA=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
++ '[' -f /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt ']'
++ SSL_DIR=/etc/mysql/ssl
++ '[' -f /etc/mysql/ssl/ca.crt ']'
++ CA=/etc/mysql/ssl/ca.crt
++ SSL_INTERNAL_DIR=/etc/mysql/ssl-internal
++ '[' -f /etc/mysql/ssl-internal/ca.crt ']'
++ CA=/etc/mysql/ssl-internal/ca.crt
++ KEY=/etc/mysql/ssl/tls.key
++ CERT=/etc/mysql/ssl/tls.crt
++ '[' -f /etc/mysql/ssl-internal/tls.key -a -f /etc/mysql/ssl-internal/tls.crt ']'
++ KEY=/etc/mysql/ssl-internal/tls.key
++ CERT=/etc/mysql/ssl-internal/tls.crt
++ '[' -f /etc/mysql/ssl-internal/ca.crt -a -f /etc/mysql/ssl-internal/tls.key -a -f /etc/mysql/ssl-internal/tls.crt ']'
++ sed '/^\[mysqld\]/a pxc-encrypt-cluster-traffic=ON\nssl-ca=/etc/mysql/ssl-internal/ca.crt\nssl-key=/etc/mysql/ssl-internal/tls.key\nssl-cert=/etc/mysql/ssl-internal/tls.crt' /etc/mysql/node.cnf
+2024/02/09 10:44:52 Peer finder exiting
+Cluster address set to: cluster1-pxc-0.cluster1-pxc
+/usr/sbin/mysqld  Ver 8.0.32-24.2 for Linux on x86_64 (Percona XtraDB Cluster (GPL), Release rel24, Revision 2119e75, WSREP version 26.1.4.3)
+[mysqld]
+pxc-encrypt-cluster-traffic=ON
+ssl-ca=/etc/mysql/ssl-internal/ca.crt
+ssl-key=/etc/mysql/ssl-internal/tls.key
+ssl-cert=/etc/mysql/ssl-internal/tls.crt
+wsrep_provider_options="pc.weight=10"
+
+wsrep_sst_donor=
+
+log-error=/var/lib/mysql/mysqld-error.log
+
+log_error_suppression_list="MY-010055"
+
+admin-address=10.42.2.8
+
+authentication_policy=caching_sha2_password,,
+skip_replica_start=ON
+enforce-gtid-consistency
+gtid-mode=ON
+plugin_load="binlog_utils_udf=binlog_utils_udf.so"
+
+datadir=/var/lib/mysql
+socket=/tmp/mysql.sock
+skip-host-cache
+
+coredumper
+server_id=32109361
+binlog_format=ROW
+default_storage_engine=InnoDB
+
+innodb_flush_log_at_trx_commit  = 0
+innodb_flush_method             = O_DIRECT
+innodb_file_per_table           = 1
+innodb_autoinc_lock_mode=2
+
+bind_address = 0.0.0.0
+
+wsrep_slave_threads=2
+wsrep_cluster_address=gcomm://cluster1-pxc-0.cluster1-pxc
+wsrep_provider=/usr/lib64/galera4/libgalera_smm.so
+
+wsrep_cluster_name=cluster1-pxc
+wsrep_node_address=10.42.2.8
+wsrep_node_incoming_address=cluster1-pxc-1.cluster1-pxc.pxc.svc.cluster.local:3306
+
+wsrep_sst_method=xtrabackup-v2
+
+[client]
+socket=/tmp/mysql.sock
+
+[sst]
+cpat=.*\.pem$\|.*init\.ok$\|.*galera\.cache$\|.*wsrep_recovery_verbose\.log$\|.*readiness-check\.sh$\|.*liveness-check\.sh$\|.*get-pxc-state$\|.*sst_in_progress$\|.*pmm-prerun\.sh$\|.*sst-xb-tmpdir$\|.*\.sst$\|.*gvwstate\.dat$\|.*grastate\.dat$\|.*\.err$\|.*\.log$\|.*RPM_UPGRADE_MARKER$\|.*RPM_UPGRADE_HISTORY$\|.*pxc-entrypoint\.sh$\|.*unsafe-bootstrap\.sh$\|.*pxc-configure-pxc\.sh\|.*peer-list$\|.*auth_plugin$
+progress=1
+
++ [[ -z node:10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local:wsrep_ready:ON:wsrep_connected:ON:wsrep_local_state_comment:Synced:wsrep_cluster_status:Primary ]]
++ [[ -z node:10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local:wsrep_ready:ON:wsrep_connected:ON:wsrep_local_state_comment:Synced:wsrep_cluster_status:Primary ]]
++ [[ -z node:10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local:wsrep_ready:ON:wsrep_connected:ON:wsrep_local_state_comment:Synced:wsrep_cluster_status:Primary ]]
++ test -e /opt/percona/hookscript/hook.sh
++ exec mysqld
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /pxc-entrypoint.sh /var/lib/mysql/pxc-entrypoint.sh
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /unsafe-bootstrap.sh /var/lib/mysql/unsafe-bootstrap.sh
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /pxc-configure-pxc.sh /var/lib/mysql/pxc-configure-pxc.sh
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /liveness-check.sh /var/lib/mysql/liveness-check.sh
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /readiness-check.sh /var/lib/mysql/readiness-check.sh
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /peer-list /var/lib/mysql/peer-list
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /get-pxc-state /var/lib/mysql/get-pxc-state
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /pmm-prerun.sh /var/lib/mysql/pmm-prerun.sh
++ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/fluent-bit/bin
++ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/fluent-bit/bin
++ '[' fluent-bit = logrotate ']'
++ '[' fluent-bit = fluent-bit ']'
++ fluentbit_opt+='-c /etc/fluentbit/fluentbit.conf'
++ test -e /opt/percona/hookscript/hook.sh
++ exec fluent-bit -c /etc/fluentbit/fluentbit.conf
+Fluent Bit v2.1.5
+* Copyright (C) 2015-2022 The Fluent Bit Authors
+* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
+* https://fluentbit.io
+
+{"log":"2024-02-09T10:45:04.172471Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.172504Z 0 [Warning] [MY-011068] [Server] The syntax 'wsrep_slave_threads' is deprecated and will be removed in a future release. Please use wsrep_applier_threads instead.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.174569Z 0 [Warning] [MY-010097] [Server] Insecure configuration for --secure-log-path: Current value does not restrict location of generated files. Consider setting it to a valid, non-empty path.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.175273Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.32-24.2) starting as process 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.179461Z 0 [Warning] [MY-010068] [Server] CA certificate /etc/mysql/ssl-internal/ca.crt is self signed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.179495Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.179504Z 0 [Note] [MY-000000] [WSREP] New joining cluster node configured to use specified SSL artifacts\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.179541Z 0 [Note] [MY-000000] [Galera] Loading provider /usr/lib64/galera4/libgalera_smm.so initial position: 00000000-0000-0000-0000-000000000000:-1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.179554Z 0 [Note] [MY-000000] [Galera] wsrep_load(): loading provider library '/usr/lib64/galera4/libgalera_smm.so'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.180344Z 0 [Note] [MY-000000] [Galera] wsrep_load(): Galera 4.14(779b689) by Codership Oy <info@codership.com> (modified by Percona <https://percona.com/>) loaded successfully.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.180372Z 0 [Note] [MY-000000] [Galera] CRC-32C: using 64-bit x86 acceleration.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.180640Z 0 [Warning] [MY-000000] [Galera] SSL compression is not effective. The option socket.ssl_compression is deprecated and will be removed in future releases.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.180651Z 0 [Warning] [MY-000000] [Galera] Parameter 'socket.ssl_compression' is deprecated and will be removed in future versions\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.181272Z 0 [Warning] [MY-000000] [Galera] Could not open state file for reading: '/var/lib/mysql//grastate.dat'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.181292Z 0 [Warning] [MY-000000] [Galera] No persistent state found. Bootstraping with default state\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.181350Z 0 [Note] [MY-000000] [Galera] Found saved state: 00000000-0000-0000-0000-000000000000:-1, safe_to_bootstrap: 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.181724Z 0 [Note] [MY-000000] [Galera] Generated new GCache ID: 486630e6-c738-11ee-b2ec-bb49adcea9ff\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.181741Z 0 [Note] [MY-000000] [Galera] GCache DEBUG: opened preamble:\nVersion: 0\nUUID: 00000000-0000-0000-0000-000000000000\nSeqno: -1 - -1\nOffset: -1\nSynced: 0\nEncVersion: 0\nEncrypted: 0\nMasterKeyConst UUID: 486630e6-c738-11ee-b2ec-bb49adcea9ff\nMasterKey UUID: 00000000-0000-0000-0000-000000000000\nMasterKey ID: 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.181748Z 0 [Note] [MY-000000] [Galera] Skipped GCache ring buffer recovery: could not determine history UUID.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.198327Z 0 [Note] [MY-000000] [Galera] Passing config to GCS: allocator.disk_pages_encryption = no; allocator.encryption_cache_page_size = 32K; allocator.encryption_cache_size = 16777216; base_dir = /var/lib/mysql/; base_host = 10.42.2.8; base_port = 4567; cert.log_conflicts = no; cert.optimistic_pa = no; debug = no; evs.auto_evict = 0; evs.delay_margin = PT1S; evs.delayed_keep_period = PT30S; evs.inactive_check_period = PT0.5S; evs.inactive_timeout = PT15S; evs.join_retrans_period = PT1S; evs.max_install_timeouts = 3; evs.send_window = 10; evs.stats_report_period = PT1M; evs.suspect_timeout = PT5S; evs.user_send_window = 4; evs.view_forget_timeout = PT24H; gcache.dir = /var/lib/mysql/; gcache.encryption = no; gcache.encryption_cache_page_size = 32K; gcache.encryption_cache_size = 16777216; gcache.freeze_purge_at_seqno = -1; gcache.keep_pages_count = 0; gcache.keep_pages_size = 0; gcache.mem_size = 0; gcache.name = galera.cache; gcache.page_size = 128M; gcache.recover = yes; gcache.size = 128M; gcomm.thread_prio = ; gcs.fc_debug = 0; gcs.fc_factor = 1.0; gcs.fc_limit = 100; gcs.fc_master_slave = no; gcs.fc_single_primary = no; gcs.max_packet_size = 64500; gcs.max_throttle = 0.25; gcs.recv_q_hard_limit = 9223372036854775807; gcs.recv_q_soft_limit = 0.25; gcs.sync_donor = no; gmcast.segment = 0; gmcast.version = 0; pc.announce_timeout = PT3S; pc.checksum = false; pc.ignore_quorum = false; pc.ignore_sb = false; pc.npvo = false; pc.recovery = true; pc.version = 0; pc.wait_prim = true; pc.wait_prim_timeout = PT30S; pc.weight = 10; protonet.backend = asio; protonet.version = 0; repl.causal_read_timeout = PT30S; repl.commit_order = 3; repl.key_format = FLAT8; repl.max_ws_size = 2147483647; repl.proto_max = 10; socket.checksum = 2; socket.recv_buf_size = auto; socket.send_buf_size = auto; socket.ssl = YES; socket.ssl_ca = /etc/mysql/ssl-internal/ca.crt; socket.ssl_cert = /etc/mysql/ssl-internal/tls.crt; socket.ssl_cipher = ; socket.ssl_compression = YES; socket.ssl_key = /etc/mysql/ssl-internal/tls.key; socket.ssl_reload = 1; \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.213007Z 0 [Note] [MY-000000] [WSREP] Starting replication\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.213061Z 0 [Note] [MY-000000] [Galera] Connecting with bootstrap option: 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.213077Z 0 [Note] [MY-000000] [Galera] Setting GCS initial position to 00000000-0000-0000-0000-000000000000:-1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.213126Z 0 [Note] [MY-000000] [Galera] protonet asio version 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.213811Z 0 [Note] [MY-000000] [Galera] Using CRC-32C for message checksums.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.213834Z 0 [Note] [MY-000000] [Galera] backend: asio\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.213933Z 0 [Note] [MY-000000] [Galera] gcomm thread scheduling priority set to other:0 \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.214085Z 0 [Note] [MY-000000] [Galera] Fail to access the file (/var/lib/mysql//gvwstate.dat) error (No such file or directory). It is possible if node is booting for first time or re-booting after a graceful shutdown\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.214098Z 0 [Note] [MY-000000] [Galera] Restoring primary-component from disk failed. Either node is booting for first time or re-booting after a graceful shutdown\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.214362Z 0 [Note] [MY-000000] [Galera] GMCast version 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.215771Z 0 [Note] [MY-000000] [Galera] (486b248f-8ac6, 'ssl://0.0.0.0:4567') listening at ssl://0.0.0.0:4567\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.215826Z 0 [Note] [MY-000000] [Galera] (486b248f-8ac6, 'ssl://0.0.0.0:4567') multicast: , ttl: 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.216488Z 0 [Note] [MY-000000] [Galera] EVS version 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.216653Z 0 [Note] [MY-000000] [Galera] gcomm: connecting to group 'cluster1-pxc', peer 'cluster1-pxc-0.cluster1-pxc:'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.229574Z 0 [Note] [MY-000000] [Galera] (486b248f-8ac6, 'ssl://0.0.0.0:4567') connection established to 213e9b53-8c4d ssl://10.42.0.5:4567\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.229798Z 0 [Note] [MY-000000] [Galera] (486b248f-8ac6, 'ssl://0.0.0.0:4567') turning message relay requesting on, nonlive peers: \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.719459Z 0 [Note] [MY-000000] [Galera] EVS version upgrade 0 -> 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.719538Z 0 [Note] [MY-000000] [Galera] declaring 213e9b53-8c4d at ssl://10.42.0.5:4567 stable\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.719575Z 0 [Note] [MY-000000] [Galera] PC protocol upgrade 0 -> 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.720008Z 0 [Note] [MY-000000] [Galera] Node 213e9b53-8c4d state primary\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.737635Z 0 [Note] [MY-000000] [Galera] Current view of cluster as seen by this node\nview (view_id(PRIM,213e9b53-8c4d,2)\nmemb {\n\t213e9b53-8c4d,0\n\t486b248f-8ac6,0\n\t}\njoined {\n\t}\nleft {\n\t}\npartitioned {\n\t}\n)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:04.737708Z 0 [Note] [MY-000000] [Galera] Save the discovered primary-component to disk\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.217987Z 0 [Note] [MY-000000] [Galera] gcomm: connected\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.218059Z 0 [Note] [MY-000000] [Galera] Changing maximum packet size to 64500, resulting msg size: 32636\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.218295Z 0 [Note] [MY-000000] [Galera] Shifting CLOSED -> OPEN (TO: 0)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.218319Z 0 [Note] [MY-000000] [Galera] Opened channel 'cluster1-pxc'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.218502Z 0 [Note] [MY-000000] [Galera] New COMPONENT: primary = yes, bootstrap = no, my_idx = 1, memb_num = 2\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.218583Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: Waiting for state UUID.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.218641Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: sent state msg: 48bafabb-c738-11ee-b32d-b39bab1609ac\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.218677Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: got state msg: 48bafabb-c738-11ee-b32d-b39bab1609ac from 0 (cluster1-pxc-0)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.218998Z 1 [Note] [MY-000000] [WSREP] Starting rollbacker thread 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.219073Z 2 [Note] [MY-000000] [WSREP] Starting applier thread 2\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.219462Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: got state msg: 48bafabb-c738-11ee-b32d-b39bab1609ac from 1 (cluster1-pxc-1)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.219503Z 0 [Note] [MY-000000] [Galera] Quorum results:\n\tversion    = 6,\n\tcomponent  = PRIMARY,\n\tconf_id    = 1,\n\tmembers    = 1/2 (primary/total),\n\tact_id     = 34,\n\tlast_appl. = 22,\n\tprotocols  = 2/10/4 (gcs/repl/appl),\n\tvote policy= 0,\n\tgroup UUID = 103be6ae-c738-11ee-95d1-526d43d08e41\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.219581Z 0 [Note] [MY-000000] [Galera] Flow-control interval: [141, 141]\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.219600Z 0 [Note] [MY-000000] [Galera] Shifting OPEN -> PRIMARY (TO: 35)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.219695Z 2 [Note] [MY-000000] [Galera] ####### processing CC 35, local, ordered\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.219730Z 2 [Note] [MY-000000] [Galera] Maybe drain monitors from -1 upto current CC event 35 upto:-1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.219749Z 2 [Note] [MY-000000] [Galera] Drain monitors from -1 up to -1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.219773Z 2 [Note] [MY-000000] [Galera] Process first view: 103be6ae-c738-11ee-95d1-526d43d08e41 my uuid: 486b248f-c738-11ee-8ac6-0a8a79d0dabd\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.219809Z 2 [Note] [MY-000000] [Galera] Server cluster1-pxc-1 connected to cluster at position 103be6ae-c738-11ee-95d1-526d43d08e41:35 with ID 486b248f-c738-11ee-8ac6-0a8a79d0dabd\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.219825Z 2 [Note] [MY-000000] [WSREP] Server status change disconnected -> connected\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.219875Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.219916Z 2 [Note] [MY-000000] [Galera] ####### My UUID: 486b248f-c738-11ee-8ac6-0a8a79d0dabd\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.219942Z 2 [Note] [MY-000000] [Galera] Cert index reset to 00000000-0000-0000-0000-000000000000:-1 (proto: 10), state transfer needed: yes\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.220083Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.220218Z 2 [Note] [MY-000000] [Galera] ####### Assign initial position for certification: 00000000-0000-0000-0000-000000000000:-1, protocol version: -1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.220261Z 2 [Note] [MY-000000] [Galera] State transfer required: \n\tGroup state: 103be6ae-c738-11ee-95d1-526d43d08e41:35\n\tLocal state: 00000000-0000-0000-0000-000000000000:-1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.220280Z 2 [Note] [MY-000000] [WSREP] Server status change connected -> joiner\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.220293Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:05.220562Z 0 [Note] [MY-000000] [WSREP] Initiating SST/IST transfer on JOINER side (wsrep_sst_xtrabackup-v2 --role 'joiner' --address '10.42.2.8' --datadir '/var/lib/mysql/' --basedir '/usr/' --plugindir '/usr/lib64/mysql/plugin/' --defaults-file '/etc/my.cnf' --defaults-group-suffix '' --parent '1' --mysqld-version '8.0.32-24.2'  --binlog 'binlog' )\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.301029Z 2 [Note] [MY-000000] [WSREP] Prepared SST request: xtrabackup-v2|10.42.2.8:4444/xtrabackup_sst//1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.301119Z 2 [Note] [MY-000000] [Galera] Check if state gap can be serviced using IST\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.301153Z 2 [Note] [MY-000000] [Galera] Local UUID: 00000000-0000-0000-0000-000000000000 != Group UUID: 103be6ae-c738-11ee-95d1-526d43d08e41\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.301177Z 2 [Note] [MY-000000] [Galera] ####### IST uuid:00000000-0000-0000-0000-000000000000 f: 0, l: 35, STRv: 3\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.301296Z 2 [Note] [MY-000000] [Galera] IST receiver addr using ssl://10.42.2.8:4568\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.301380Z 2 [Note] [MY-000000] [Galera] IST receiver using ssl\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.301742Z 2 [Note] [MY-000000] [Galera] Prepared IST receiver for 0-35, listening at: ssl://10.42.2.8:4568\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.302574Z 0 [Note] [MY-000000] [Galera] Member 1.0 (cluster1-pxc-1) requested state transfer from '*any*'. Selected 0.0 (cluster1-pxc-0)(SYNCED) as donor.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.302624Z 0 [Note] [MY-000000] [Galera] Shifting PRIMARY -> JOINER (TO: 35)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.302698Z 2 [Note] [MY-000000] [Galera] Requesting state transfer: success, donor: 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.302710Z 2 [Note] [MY-000000] [Galera] Resetting GCache seqno map due to different histories.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:06.302721Z 2 [Note] [MY-000000] [Galera] GCache history reset: 00000000-0000-0000-0000-000000000000:0 -> 103be6ae-c738-11ee-95d1-526d43d08e41:35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:07.176825Z 0 [Note] [MY-000000] [WSREP-SST]    joiner: => Rate:[ 143 B/s] Avg:[ 143 B/s] Elapsed:0:00:01  Bytes:  167 B \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:07.718570Z 0 [Note] [MY-000000] [Galera] (486b248f-8ac6, 'ssl://0.0.0.0:4567') turning message relay requesting off\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:08.158143Z 0 [Note] [MY-000000] [WSREP-SST] Proceeding with SST.........\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:08.185635Z 0 [Note] [MY-000000] [WSREP-SST] ............Waiting for SST streaming to complete!\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:21.260291Z 0 [Note] [MY-000000] [WSREP-SST]    joiner: => Rate:[0.00 B/s] Avg:[0.00 B/s] Elapsed:0:00:10  Bytes: 0.00 B \r   joiner: => Rate:[5.80MiB/s] Avg:[5.80MiB/s] Elapsed:0:00:13  Bytes: 75.9MiB \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:21.265687Z 0 [Note] [MY-000000] [Galera] 0.0 (cluster1-pxc-0): State transfer to 1.0 (cluster1-pxc-1) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:21.266254Z 0 [Note] [MY-000000] [Galera] Member 0.0 (cluster1-pxc-0) synced with group.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:21.272868Z 0 [Note] [MY-000000] [WSREP-SST] Preparing the backup at /var/lib/mysql//sst-xb-tmpdir\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:22.982493Z 0 [Note] [MY-000000] [WSREP-SST] Moving the backup to /var/lib/mysql/\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:23.113370Z 0 [Note] [MY-000000] [WSREP-SST] Running post-processing...........\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:23.126484Z 0 [Note] [MY-000000] [WSREP-SST] Skipping mysql_upgrade (sst): local version (8.0.32) == donor version (8.0.32)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:23.223765Z 0 [Note] [MY-000000] [WSREP-SST] Waiting for server instance to start.....  This may take some time\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:26.840285Z 0 [Note] [MY-000000] [WSREP-SST] ...........post-processing done\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:26.844627Z 0 [Note] [MY-000000] [WSREP-SST] Galera co-ords from recovery: 103be6ae-c738-11ee-95d1-526d43d08e41:35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:26.865518Z 3 [Note] [MY-000000] [Galera] Processing SST received\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:26.865595Z 3 [Note] [MY-000000] [WSREP] Server status change joiner -> initializing\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:26.865655Z 3 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:26.872451Z 4 [System] [MY-013576] [InnoDB] InnoDB initialization has started.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.146632Z 4 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.366461Z 4 [Note] [MY-000000] [WSREP] wsrep_init_schema_and_SR (nil)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.392440Z 4 [System] [MY-000000] [WSREP] PXC upgrade completed successfully\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.635693Z 0 [Warning] [MY-010068] [Server] CA certificate /etc/mysql/ssl-internal/ca.crt is self signed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.635764Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.648708Z 0 [Warning] [MY-013595] [Server] Failed to initialize TLS for channel: mysql_admin. See below for the description of exact issue.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.648761Z 0 [Warning] [MY-010069] [Server] Failed to set up SSL because of the following SSL library error: SSL context is not usable without certificate and private key\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.648780Z 0 [System] [MY-013603] [Server] No TLS configuration was given for channel mysql_admin; re-using TLS configuration of channel mysql_main.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.655965Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/var/lib/mysql' in the path is accessible to all OS users. Consider choosing a different directory.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.690390Z 0 [Note] [MY-000000] [WSREP] Initialized wsrep sidno 2\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.690442Z 0 [Note] [MY-000000] [Galera] Server initialized\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.690454Z 0 [Note] [MY-000000] [WSREP] Server status change initializing -> initialized\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.690472Z 0 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.690579Z 3 [Note] [MY-000000] [Galera] Recovered position from storage: 103be6ae-c738-11ee-95d1-526d43d08e41:35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.690632Z 3 [Note] [MY-000000] [WSREP] Server status change initialized -> joined\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.690651Z 3 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.690851Z 10 [Note] [MY-000000] [WSREP] Starting applier thread 10\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.691733Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Bind-address: '::' port: 33060, socket: /var/lib/mysql/mysqlx.sock\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.691810Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.32-24.2'  socket: '/tmp/mysql.sock'  port: 3306  Percona XtraDB Cluster (GPL), Release rel24, Revision 2119e75, WSREP version 26.1.4.3.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.691828Z 0 [System] [MY-013292] [Server] Admin interface ready for connections, address: '10.42.2.8'  port: 33062\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.695732Z 3 [Note] [MY-000000] [Galera] Recovered view from SST:\n  id: 103be6ae-c738-11ee-95d1-526d43d08e41:35\n  status: primary\n  protocol_version: 4\n  capabilities: MULTI-MASTER, CERTIFICATION, PARALLEL_APPLYING, REPLAY, ISOLATION, PAUSE, CAUSAL_READ, INCREMENTAL_WS, UNORDERED, PREORDERED, STREAMING, NBO\n  final: no\n  own_index: 1\n  members(2):\n\t0: 213e9b53-c738-11ee-8c4d-03cb16bd2d32, cluster1-pxc-0\n\t1: 486b248f-c738-11ee-8ac6-0a8a79d0dabd, cluster1-pxc-1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.695799Z 3 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.696022Z 12 [Note] [MY-000000] [WSREP] Recovered cluster id 103be6ae-c738-11ee-95d1-526d43d08e41\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.699389Z 3 [Note] [MY-000000] [Galera] SST received: 103be6ae-c738-11ee-95d1-526d43d08e41:35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.699458Z 3 [System] [MY-000000] [WSREP] SST completed\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.699479Z 2 [Note] [MY-000000] [Galera]  str_proto_ver_: 3 sst_seqno_: 35 cc_seqno: 35 req->ist_len(): 64\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.699515Z 2 [Note] [MY-000000] [Galera] Installed new state from SST: 103be6ae-c738-11ee-95d1-526d43d08e41:35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.705986Z 2 [Note] [MY-000000] [Galera] Cert. index preload up to 35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.706067Z 0 [Note] [MY-000000] [Galera] ####### IST applying starts with 36\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.706282Z 0 [Note] [MY-000000] [Galera] ####### IST current seqno initialized to 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.706410Z 0 [Note] [MY-000000] [Galera] Receiving IST...  0.0% ( 0/12 events) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.706435Z 0 [Note] [MY-000000] [Galera] IST preload starting at 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.706488Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.706565Z 0 [Note] [MY-000000] [Galera] ####### Assign initial position for certification: 00000000-0000-0000-0000-000000000000:23, protocol version: 5\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.706973Z 0 [Note] [MY-000000] [Galera] ####### Passing IST CC 35, must_apply: 0, preload: true\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.707033Z 0 [Note] [MY-000000] [Galera] REPL Protocols: 10 (5)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.707059Z 0 [Note] [MY-000000] [Galera] ####### Adjusting cert position: 34 -> 35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.707105Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.707173Z 0 [Note] [MY-000000] [Galera] Recording CC from preload: 35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.707197Z 0 [Note] [MY-000000] [Galera] Lowest cert index boundary for CC from preload: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.707215Z 0 [Note] [MY-000000] [Galera] Min available from gcache for CC from preload: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.707272Z 0 [Note] [MY-000000] [Galera] Receiving IST...100.0% (12/12 events) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.707754Z 2 [Note] [MY-000000] [Galera] IST received: 103be6ae-c738-11ee-95d1-526d43d08e41:35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.707812Z 2 [Note] [MY-000000] [Galera] Recording CC from sst: 35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.707826Z 2 [Note] [MY-000000] [Galera] Lowest cert index boundary for CC from sst: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.707836Z 2 [Note] [MY-000000] [Galera] Min available from gcache for CC from sst: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.708377Z 0 [Note] [MY-000000] [Galera] 1.0 (cluster1-pxc-1): State transfer from 0.0 (cluster1-pxc-0) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.708423Z 0 [Note] [MY-000000] [Galera] SST leaving flow control\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.708442Z 0 [Note] [MY-000000] [Galera] Shifting JOINER -> JOINED (TO: 35)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.708518Z 0 [Note] [MY-000000] [Galera] Processing event queue:... -nan% (0/0 events) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.709000Z 0 [Note] [MY-000000] [Galera] Member 1.0 (cluster1-pxc-1) synced with group.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.709063Z 0 [Note] [MY-000000] [Galera] Processing event queue:...100.0% (1/1 events) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.709084Z 0 [Note] [MY-000000] [Galera] Shifting JOINED -> SYNCED (TO: 35)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.709112Z 2 [Note] [MY-000000] [Galera] Server cluster1-pxc-1 synced with group\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.709130Z 2 [Note] [MY-000000] [WSREP] Server status change joined -> synced\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.709138Z 2 [Note] [MY-000000] [WSREP] Synchronized with group, ready for connections\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:27.709144Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:45:21.289494-00:00 0 [Note] [MY-011825] [Xtrabackup] recognized server arguments: --innodb_checksum_algorithm=crc32 --innodb_log_checksums=1 --innodb_data_file_path=ibdata1:12M:autoextend --innodb_log_file_size=50331648 --innodb_page_size=16384 --innodb_undo_directory=./ --innodb_undo_tablespaces=2 --server-id=32109360 --innodb_log_checksums=ON --innodb_redo_log_encrypt=0 --innodb_undo_log_encrypt=0 \n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.289646-00:00 0 [Note] [MY-011825] [Xtrabackup] recognized client arguments: --no-version-check=1 --prepare=1 --rollback-prepared-trx=1 --xtrabackup-plugin-dir=/usr/bin/pxc_extra/pxb-8.0/lib/plugin --target-dir=/var/lib/mysql//sst-xb-tmpdir \n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"/usr/bin/pxc_extra/pxb-8.0/bin/xtrabackup version 8.0.32-26 based on MySQL server 8.0.32 Linux (x86_64) (revision id: 34cf2908)\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.289679-00:00 0 [Note] [MY-011825] [Xtrabackup] cd to /var/lib/mysql/sst-xb-tmpdir/\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.289734-00:00 0 [Note] [MY-011825] [Xtrabackup] This target seems to be not prepared yet.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.299942-00:00 0 [Note] [MY-011825] [Xtrabackup] xtrabackup_logfile detected: size=8388608, start_lsn=(32174346)\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.300895-00:00 0 [Note] [MY-011825] [Xtrabackup] using the following InnoDB configuration for recovery:\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.300911-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_data_home_dir = .\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.300917-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_data_file_path = ibdata1:12M:autoextend\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.300966-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_group_home_dir = .\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.300978-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_files_in_group = 1\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.300987-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_file_size = 8388608\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.301247-00:00 0 [Note] [MY-011825] [Xtrabackup] inititialize_service_handles suceeded\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.301447-00:00 0 [Note] [MY-011825] [Xtrabackup] using the following InnoDB configuration for recovery:\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.301456-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_data_home_dir = .\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.301462-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_data_file_path = ibdata1:12M:autoextend\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.301472-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_group_home_dir = .\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.301478-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_files_in_group = 1\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.301484-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_file_size = 8388608\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.301492-00:00 0 [Note] [MY-011825] [Xtrabackup] Starting InnoDB instance for recovery.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.301499-00:00 0 [Note] [MY-011825] [Xtrabackup] Using 104857600 bytes for buffer pool (set by --use-memory parameter)\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.301541-00:00 0 [Note] [MY-012932] [InnoDB] PUNCH HOLE support available\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.301558-00:00 0 [Note] [MY-012944] [InnoDB] Uses event mutexes\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.301564-00:00 0 [Note] [MY-012945] [InnoDB] GCC builtin __atomic_thread_fence() is used for memory barrier\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.301575-00:00 0 [Note] [MY-012948] [InnoDB] Compressed tables use zlib 1.2.13\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.301791-00:00 0 [Note] [MY-012951] [InnoDB] Using hardware accelerated crc32 and polynomial multiplication.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.302125-00:00 0 [Note] [MY-012203] [InnoDB] Directories to scan './'\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.302221-00:00 0 [Note] [MY-012204] [InnoDB] Scanning './'\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.303603-00:00 0 [Note] [MY-012208] [InnoDB] Completed space ID check of 7 files.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.304142-00:00 0 [Note] [MY-012955] [InnoDB] Initializing buffer pool, total size = 128.000000M, instances = 1, chunk size =128.000000M \n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.314068-00:00 0 [Note] [MY-012957] [InnoDB] Completed initialization of buffer pool\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.316665-00:00 0 [Note] [MY-011952] [InnoDB] If the mysqld execution user is authorized, page cleaner thread priority can be changed. See the man page of setpriority().\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.444274-00:00 0 [Note] [MY-013883] [InnoDB] The latest found checkpoint is at lsn = 32174346 in redo log file ./#innodb_redo/#ib_redo0.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.444364-00:00 0 [Note] [MY-012560] [InnoDB] The log sequence number 32090239 in the system tablespace does not match the log sequence number 32174346 in the redo log files!\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.444374-00:00 0 [Note] [MY-012551] [InnoDB] Database was not shutdown normally!\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.444383-00:00 0 [Note] [MY-012552] [InnoDB] Starting crash recovery.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.444520-00:00 0 [Note] [MY-013086] [InnoDB] Starting to parse redo log at lsn = 32174179, whereas checkpoint_lsn = 32174346 and start_lsn = 32174080\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.444530-00:00 0 [Note] [MY-012550] [InnoDB] Doing recovery: scanned up to log sequence number 32174401\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.458695-00:00 0 [Note] [MY-013083] [InnoDB] Log background threads are being started...\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.459238-00:00 0 [Note] [MY-012532] [InnoDB] Applying a batch of 1 redo log records ...\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.459318-00:00 0 [Note] [MY-012533] [InnoDB] 100%\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.459330-00:00 0 [Note] [MY-012535] [InnoDB] Apply batch completed!\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.568440-00:00 0 [Note] [MY-013084] [InnoDB] Log background threads are being closed...\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.570030-00:00 0 [Note] [MY-013041] [InnoDB] Resizing redo log from 8M to 1024M (LSN=32174401) synchronously. If this takes too long, consider starting the server with large --innodb_redo_log_capacity, and resizing the redo log online using SET.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.576849-00:00 0 [Note] [MY-012968] [InnoDB] Starting to delete and rewrite redo log files.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.577143-00:00 0 [Note] [MY-011825] [InnoDB] Removing redo log file: ./#innodb_redo/#ib_redo0\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.704552-00:00 0 [Note] [MY-011825] [InnoDB] Creating redo log file at ./#innodb_redo/#ib_redo0_tmp with file_id 0 with size 33554432 bytes\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.727226-00:00 0 [Note] [MY-011825] [InnoDB] Renaming redo log file from ./#innodb_redo/#ib_redo0_tmp to ./#innodb_redo/#ib_redo0\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.741108-00:00 0 [Note] [MY-012893] [InnoDB] New redo log files created, LSN=32174604\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.741304-00:00 0 [Note] [MY-013083] [InnoDB] Log background threads are being started...\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.742120-00:00 0 [Note] [MY-013252] [InnoDB] Using undo tablespace './undo_001'.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.742781-00:00 0 [Note] [MY-013252] [InnoDB] Using undo tablespace './undo_002'.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.744371-00:00 0 [Note] [MY-012910] [InnoDB] Opened 2 existing undo tablespaces.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.744456-00:00 0 [Note] [MY-011980] [InnoDB] GTID recovery trx_no: 2156\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.766656-00:00 0 [Note] [MY-013776] [InnoDB] Parallel initialization of rseg complete\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.766740-00:00 0 [Note] [MY-013777] [InnoDB] Time taken to initialize rseg using 4 thread: 22291 ms.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.766869-00:00 0 [Note] [MY-012923] [InnoDB] Creating shared tablespace for temporary tables\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.767031-00:00 0 [Note] [MY-012265] [InnoDB] Setting file './ibtmp1' size to 12 MB. Physically writing the file full; Please wait ...\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.794414-00:00 0 [Note] [MY-012266] [InnoDB] File './ibtmp1' size is now 12 MB.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.794841-00:00 0 [Note] [MY-013627] [InnoDB] Scanning temp tablespace dir:'./#innodb_temp/'\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.874107-00:00 0 [Note] [MY-013018] [InnoDB] Created 128 and tracked 128 new rollback segment(s) in the temporary tablespace. 128 are now active.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.874696-00:00 0 [Note] [MY-012976] [InnoDB] 8.0.32 started; log sequence number 32174614\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.875027-00:00 0 [Warning] [MY-012091] [InnoDB] Allocated tablespace ID 3 for mysql/wsrep_cluster_members, old maximum was 0\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.902889-00:00 0 [Note] [MY-011825] [Xtrabackup] Recovered WSREP position: 103be6ae-c738-11ee-95d1-526d43d08e41:35\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.902959-00:00 0 [Note] [MY-011825] [Xtrabackup] starting shutdown with innodb_fast_shutdown = 1\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:21.903068-00:00 0 [Note] [MY-012330] [InnoDB] FTS optimize thread exiting.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:22.902745-00:00 0 [Note] [MY-013072] [InnoDB] Starting shutdown...\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:22.930340-00:00 0 [Note] [MY-013084] [InnoDB] Log background threads are being closed...\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:22.957824-00:00 0 [Note] [MY-012980] [InnoDB] Shutdown completed; log sequence number 32174614\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:22.961969-00:00 0 [Note] [MY-011825] [Xtrabackup] completed OK!\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:45:23.002705-00:00 0 [Note] [MY-011825] [Xtrabackup] recognized server arguments: --datadir=/var/lib/mysql --server-id=32109361 --innodb_flush_log_at_trx_commit=0 --innodb_flush_method=O_DIRECT --innodb_file_per_table=1 --defaults_group=mysqld --datadir=/var/lib/mysql/ \n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.002950-00:00 0 [Note] [MY-011825] [Xtrabackup] recognized client arguments: --socket=/tmp/mysql.sock --no-version-check=1 --move-back=1 --force-non-empty-directories=1 --xtrabackup-plugin-dir=/usr/bin/pxc_extra/pxb-8.0/lib/plugin --target-dir=/var/lib/mysql//sst-xb-tmpdir \n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"/usr/bin/pxc_extra/pxb-8.0/bin/xtrabackup version 8.0.32-26 based on MySQL server 8.0.32 Linux (x86_64) (revision id: 34cf2908)\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.002984-00:00 0 [Note] [MY-011825] [Xtrabackup] cd to /var/lib/mysql/sst-xb-tmpdir/\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.003719-00:00 0 [Note] [MY-011825] [Xtrabackup] Moving undo_001 to /var/lib/mysql//undo_001\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.003796-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Moving file undo_001 to /var/lib/mysql//undo_001\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.003825-00:00 0 [Note] [MY-011825] [Xtrabackup] Moving undo_002 to /var/lib/mysql//undo_002\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.003868-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Moving file undo_002 to /var/lib/mysql//undo_002\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.004058-00:00 0 [Note] [MY-011825] [Xtrabackup] Moving ibdata1 to /var/lib/mysql//ibdata1\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.004102-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Moving file ibdata1 to /var/lib/mysql//ibdata1\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.004358-00:00 0 [Note] [MY-011825] [Xtrabackup] Moving binlog.000003 to /var/lib/mysql//binlog.000003\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.004403-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Moving file binlog.000003 to /var/lib/mysql//binlog.000003\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.004494-00:00 0 [Note] [MY-011825] [Xtrabackup] Moving binlog.index to /var/lib/mysql//binlog.index\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.004535-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Moving file binlog.index to /var/lib/mysql//binlog.index\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.005220-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/slow_log_226.sdi to /var/lib/mysql//mysql/slow_log_226.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.005389-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/slow_log_226.sdi to /var/lib/mysql//mysql/slow_log_226.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.005482-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/wsrep_streaming_log.ibd to /var/lib/mysql//mysql/wsrep_streaming_log.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.005576-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/wsrep_streaming_log.ibd to /var/lib/mysql//mysql/wsrep_streaming_log.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.005646-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/slow_log.CSM to /var/lib/mysql//mysql/slow_log.CSM\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.005732-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/slow_log.CSM to /var/lib/mysql//mysql/slow_log.CSM\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.005798-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/general_log.CSM to /var/lib/mysql//mysql/general_log.CSM\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.005882-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/general_log.CSM to /var/lib/mysql//mysql/general_log.CSM\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.005946-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/general_log.CSV to /var/lib/mysql//mysql/general_log.CSV\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.006028-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/general_log.CSV to /var/lib/mysql//mysql/general_log.CSV\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.006092-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/slow_log.CSV to /var/lib/mysql//mysql/slow_log.CSV\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.006175-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/slow_log.CSV to /var/lib/mysql//mysql/slow_log.CSV\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.006242-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/wsrep_cluster_members.ibd to /var/lib/mysql//mysql/wsrep_cluster_members.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.006325-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/wsrep_cluster_members.ibd to /var/lib/mysql//mysql/wsrep_cluster_members.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.006388-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/general_log_225.sdi to /var/lib/mysql//mysql/general_log_225.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.006485-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/general_log_225.sdi to /var/lib/mysql//mysql/general_log_225.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.006551-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/wsrep_cluster.ibd to /var/lib/mysql//mysql/wsrep_cluster.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.006643-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/wsrep_cluster.ibd to /var/lib/mysql//mysql/wsrep_cluster.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.006664-00:00 1 [Note] [MY-011825] [Xtrabackup] Creating directory ./#innodb_redo\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.006687-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: creating directory ./#innodb_redo\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.006750-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./ibtmp1 to /var/lib/mysql//ibtmp1\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.006838-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./ibtmp1 to /var/lib/mysql//ibtmp1\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.006977-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./sys/sys_config.ibd to /var/lib/mysql//sys/sys_config.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.007070-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./sys/sys_config.ibd to /var/lib/mysql//sys/sys_config.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.007139-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql.ibd to /var/lib/mysql//mysql.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.007224-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql.ibd to /var/lib/mysql//mysql.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.007291-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./xtrabackup_info to /var/lib/mysql//xtrabackup_info\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.007375-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./xtrabackup_info to /var/lib/mysql//xtrabackup_info\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.007435-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./innobackup.prepare.log to /var/lib/mysql//innobackup.prepare.log\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.007520-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./innobackup.prepare.log to /var/lib/mysql//innobackup.prepare.log\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.007579-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./innobackup.move.log to /var/lib/mysql//innobackup.move.log\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.007663-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./innobackup.move.log to /var/lib/mysql//innobackup.move.log\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.007721-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./xtrabackup_galera_info to /var/lib/mysql//xtrabackup_galera_info\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.007806-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./xtrabackup_galera_info to /var/lib/mysql//xtrabackup_galera_info\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.007938-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_asyn_182.sdi to /var/lib/mysql//performance_schema/replication_asyn_182.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.008032-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_asyn_182.sdi to /var/lib/mysql//performance_schema/replication_asyn_182.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.008100-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/malloc_stats_tot_200.sdi to /var/lib/mysql//performance_schema/malloc_stats_tot_200.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.008186-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/malloc_stats_tot_200.sdi to /var/lib/mysql//performance_schema/malloc_stats_tot_200.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.008253-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/malloc_stats_201.sdi to /var/lib/mysql//performance_schema/malloc_stats_201.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.008339-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/malloc_stats_201.sdi to /var/lib/mysql//performance_schema/malloc_stats_201.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.008405-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/memory_summary_b_164.sdi to /var/lib/mysql//performance_schema/memory_summary_b_164.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.008490-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/memory_summary_b_164.sdi to /var/lib/mysql//performance_schema/memory_summary_b_164.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.008570-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_131.sdi to /var/lib/mysql//performance_schema/events_statement_131.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.008656-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_131.sdi to /var/lib/mysql//performance_schema/events_statement_131.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.008723-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/file_summary_by__104.sdi to /var/lib/mysql//performance_schema/file_summary_by__104.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.008824-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/file_summary_by__104.sdi to /var/lib/mysql//performance_schema/file_summary_by__104.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.008895-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/setup_instrument_113.sdi to /var/lib/mysql//performance_schema/setup_instrument_113.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.008999-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/setup_instrument_113.sdi to /var/lib/mysql//performance_schema/setup_instrument_113.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.009071-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/session_variable_194.sdi to /var/lib/mysql//performance_schema/session_variable_194.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.009156-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/session_variable_194.sdi to /var/lib/mysql//performance_schema/session_variable_194.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.009221-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_conn_171.sdi to /var/lib/mysql//performance_schema/replication_conn_171.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.009306-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_conn_171.sdi to /var/lib/mysql//performance_schema/replication_conn_171.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.009368-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_143.sdi to /var/lib/mysql//performance_schema/events_transacti_143.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.009452-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_143.sdi to /var/lib/mysql//performance_schema/events_transacti_143.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.009517-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_sum_97.sdi to /var/lib/mysql//performance_schema/events_waits_sum_97.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.009602-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_sum_97.sdi to /var/lib/mysql//performance_schema/events_waits_sum_97.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.009665-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/pxc_cluster_view_203.sdi to /var/lib/mysql//performance_schema/pxc_cluster_view_203.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.009750-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/pxc_cluster_view_203.sdi to /var/lib/mysql//performance_schema/pxc_cluster_view_203.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.009814-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/table_io_waits_s_117.sdi to /var/lib/mysql//performance_schema/table_io_waits_s_117.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.009899-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/table_io_waits_s_117.sdi to /var/lib/mysql//performance_schema/table_io_waits_s_117.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.009965-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/mutex_instances_106.sdi to /var/lib/mysql//performance_schema/mutex_instances_106.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.010055-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/mutex_instances_106.sdi to /var/lib/mysql//performance_schema/mutex_instances_106.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.010119-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/threads_119.sdi to /var/lib/mysql//performance_schema/threads_119.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.010206-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/threads_119.sdi to /var/lib/mysql//performance_schema/threads_119.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.010288-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_132.sdi to /var/lib/mysql//performance_schema/events_statement_132.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.010379-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_132.sdi to /var/lib/mysql//performance_schema/events_statement_132.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.010451-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/status_by_thread_188.sdi to /var/lib/mysql//performance_schema/status_by_thread_188.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.010549-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/status_by_thread_188.sdi to /var/lib/mysql//performance_schema/status_by_thread_188.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.010634-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_conn_173.sdi to /var/lib/mysql//performance_schema/replication_conn_173.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.010722-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_conn_173.sdi to /var/lib/mysql//performance_schema/replication_conn_173.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.010787-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_cu_120.sdi to /var/lib/mysql//performance_schema/events_stages_cu_120.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.010872-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_cu_120.sdi to /var/lib/mysql//performance_schema/events_stages_cu_120.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.010936-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_130.sdi to /var/lib/mysql//performance_schema/events_statement_130.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.011021-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_130.sdi to /var/lib/mysql//performance_schema/events_statement_130.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.011085-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/processlist_109.sdi to /var/lib/mysql//performance_schema/processlist_109.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.011170-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/processlist_109.sdi to /var/lib/mysql//performance_schema/processlist_109.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.011234-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/memory_summary_b_165.sdi to /var/lib/mysql//performance_schema/memory_summary_b_165.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.011319-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/memory_summary_b_165.sdi to /var/lib/mysql//performance_schema/memory_summary_b_165.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.011383-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/user_defined_fun_197.sdi to /var/lib/mysql//performance_schema/user_defined_fun_197.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.011468-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/user_defined_fun_197.sdi to /var/lib/mysql//performance_schema/user_defined_fun_197.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.011533-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_145.sdi to /var/lib/mysql//performance_schema/events_transacti_145.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.011622-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_145.sdi to /var/lib/mysql//performance_schema/events_transacti_145.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.011697-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_asyn_181.sdi to /var/lib/mysql//performance_schema/replication_asyn_181.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.011793-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_asyn_181.sdi to /var/lib/mysql//performance_schema/replication_asyn_181.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.011864-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_errors_su_152.sdi to /var/lib/mysql//performance_schema/events_errors_su_152.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.011958-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_errors_su_152.sdi to /var/lib/mysql//performance_schema/events_errors_su_152.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.012036-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/session_status_191.sdi to /var/lib/mysql//performance_schema/session_status_191.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.012125-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/session_status_191.sdi to /var/lib/mysql//performance_schema/session_status_191.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.012191-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_133.sdi to /var/lib/mysql//performance_schema/events_statement_133.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.012280-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_133.sdi to /var/lib/mysql//performance_schema/events_statement_133.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.012345-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/persisted_variab_196.sdi to /var/lib/mysql//performance_schema/persisted_variab_196.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.012440-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/persisted_variab_196.sdi to /var/lib/mysql//performance_schema/persisted_variab_196.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.012506-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_errors_su_148.sdi to /var/lib/mysql//performance_schema/events_errors_su_148.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.012593-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_errors_su_148.sdi to /var/lib/mysql//performance_schema/events_errors_su_148.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.012657-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/accounts_154.sdi to /var/lib/mysql//performance_schema/accounts_154.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.012744-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/accounts_154.sdi to /var/lib/mysql//performance_schema/accounts_154.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.012811-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/setup_threads_115.sdi to /var/lib/mysql//performance_schema/setup_threads_115.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.012902-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/setup_threads_115.sdi to /var/lib/mysql//performance_schema/setup_threads_115.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.012994-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/rwlock_instances_110.sdi to /var/lib/mysql//performance_schema/rwlock_instances_110.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.013101-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/rwlock_instances_110.sdi to /var/lib/mysql//performance_schema/rwlock_instances_110.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.013180-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/keyring_componen_202.sdi to /var/lib/mysql//performance_schema/keyring_componen_202.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.013273-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/keyring_componen_202.sdi to /var/lib/mysql//performance_schema/keyring_componen_202.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.013340-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/socket_summary_b_158.sdi to /var/lib/mysql//performance_schema/socket_summary_b_158.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.013429-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/socket_summary_b_158.sdi to /var/lib/mysql//performance_schema/socket_summary_b_158.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.013493-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_146.sdi to /var/lib/mysql//performance_schema/events_transacti_146.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.013581-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_146.sdi to /var/lib/mysql//performance_schema/events_transacti_146.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.013646-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/log_status_183.sdi to /var/lib/mysql//performance_schema/log_status_183.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.013734-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/log_status_183.sdi to /var/lib/mysql//performance_schema/log_status_183.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.013814-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_his_94.sdi to /var/lib/mysql//performance_schema/events_waits_his_94.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.013904-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_his_94.sdi to /var/lib/mysql//performance_schema/events_waits_his_94.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.013972-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_hi_122.sdi to /var/lib/mysql//performance_schema/events_stages_hi_122.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.014062-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_hi_122.sdi to /var/lib/mysql//performance_schema/events_stages_hi_122.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.014128-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/data_locks_169.sdi to /var/lib/mysql//performance_schema/data_locks_169.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.014216-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/data_locks_169.sdi to /var/lib/mysql//performance_schema/data_locks_169.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.014290-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/setup_objects_114.sdi to /var/lib/mysql//performance_schema/setup_objects_114.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.014381-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/setup_objects_114.sdi to /var/lib/mysql//performance_schema/setup_objects_114.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.014446-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/socket_instances_156.sdi to /var/lib/mysql//performance_schema/socket_instances_156.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.014535-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/socket_instances_156.sdi to /var/lib/mysql//performance_schema/socket_instances_156.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.014602-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/cond_instances_91.sdi to /var/lib/mysql//performance_schema/cond_instances_91.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.014692-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/cond_instances_91.sdi to /var/lib/mysql//performance_schema/cond_instances_91.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.014758-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/table_lock_waits_118.sdi to /var/lib/mysql//performance_schema/table_lock_waits_118.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.014847-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/table_lock_waits_118.sdi to /var/lib/mysql//performance_schema/table_lock_waits_118.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.014913-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_129.sdi to /var/lib/mysql//performance_schema/events_statement_129.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.015007-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_129.sdi to /var/lib/mysql//performance_schema/events_statement_129.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.015079-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_139.sdi to /var/lib/mysql//performance_schema/events_statement_139.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.015174-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_139.sdi to /var/lib/mysql//performance_schema/events_statement_139.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.015246-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_appl_176.sdi to /var/lib/mysql//performance_schema/replication_appl_176.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.015344-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_appl_176.sdi to /var/lib/mysql//performance_schema/replication_appl_176.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.015415-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/objects_summary__107.sdi to /var/lib/mysql//performance_schema/objects_summary__107.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.015508-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/objects_summary__107.sdi to /var/lib/mysql//performance_schema/objects_summary__107.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.015585-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/status_by_accoun_186.sdi to /var/lib/mysql//performance_schema/status_by_accoun_186.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.015682-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/status_by_accoun_186.sdi to /var/lib/mysql//performance_schema/status_by_accoun_186.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.015754-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_errors_su_151.sdi to /var/lib/mysql//performance_schema/events_errors_su_151.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.015853-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_errors_su_151.sdi to /var/lib/mysql//performance_schema/events_errors_su_151.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.015924-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_su_124.sdi to /var/lib/mysql//performance_schema/events_stages_su_124.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.016018-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_su_124.sdi to /var/lib/mysql//performance_schema/events_stages_su_124.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.016086-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/file_summary_by__103.sdi to /var/lib/mysql//performance_schema/file_summary_by__103.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.016187-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/file_summary_by__103.sdi to /var/lib/mysql//performance_schema/file_summary_by__103.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.016256-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_appl_175.sdi to /var/lib/mysql//performance_schema/replication_appl_175.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.016348-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_appl_175.sdi to /var/lib/mysql//performance_schema/replication_appl_175.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.016416-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_128.sdi to /var/lib/mysql//performance_schema/events_statement_128.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.016509-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_128.sdi to /var/lib/mysql//performance_schema/events_statement_128.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.016577-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/table_io_waits_s_116.sdi to /var/lib/mysql//performance_schema/table_io_waits_s_116.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.016670-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/table_io_waits_s_116.sdi to /var/lib/mysql//performance_schema/table_io_waits_s_116.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.016738-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_su_127.sdi to /var/lib/mysql//performance_schema/events_stages_su_127.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.016841-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_su_127.sdi to /var/lib/mysql//performance_schema/events_stages_su_127.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.016910-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/session_account__160.sdi to /var/lib/mysql//performance_schema/session_account__160.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.017019-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/session_account__160.sdi to /var/lib/mysql//performance_schema/session_account__160.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.017098-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_appl_174.sdi to /var/lib/mysql//performance_schema/replication_appl_174.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.017195-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_appl_174.sdi to /var/lib/mysql//performance_schema/replication_appl_174.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.017265-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/setup_actors_111.sdi to /var/lib/mysql//performance_schema/setup_actors_111.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.017360-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/setup_actors_111.sdi to /var/lib/mysql//performance_schema/setup_actors_111.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.017440-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_errors_su_150.sdi to /var/lib/mysql//performance_schema/events_errors_su_150.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.017536-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_errors_su_150.sdi to /var/lib/mysql//performance_schema/events_errors_su_150.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.017607-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_sum_100.sdi to /var/lib/mysql//performance_schema/events_waits_sum_100.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.017708-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_sum_100.sdi to /var/lib/mysql//performance_schema/events_waits_sum_100.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.017786-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/status_by_user_189.sdi to /var/lib/mysql//performance_schema/status_by_user_189.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.017884-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/status_by_user_189.sdi to /var/lib/mysql//performance_schema/status_by_user_189.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.017957-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_grou_178.sdi to /var/lib/mysql//performance_schema/replication_grou_178.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.018058-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_grou_178.sdi to /var/lib/mysql//performance_schema/replication_grou_178.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.018144-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/tls_channel_stat_199.sdi to /var/lib/mysql//performance_schema/tls_channel_stat_199.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.018244-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/tls_channel_stat_199.sdi to /var/lib/mysql//performance_schema/tls_channel_stat_199.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.018318-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_grou_172.sdi to /var/lib/mysql//performance_schema/replication_grou_172.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.018418-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_grou_172.sdi to /var/lib/mysql//performance_schema/replication_grou_172.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.018489-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/memory_summary_b_163.sdi to /var/lib/mysql//performance_schema/memory_summary_b_163.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.018586-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/memory_summary_b_163.sdi to /var/lib/mysql//performance_schema/memory_summary_b_163.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.018656-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/performance_time_108.sdi to /var/lib/mysql//performance_schema/performance_time_108.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.018753-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/performance_time_108.sdi to /var/lib/mysql//performance_schema/performance_time_108.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.018822-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/global_variables_193.sdi to /var/lib/mysql//performance_schema/global_variables_193.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.018918-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/global_variables_193.sdi to /var/lib/mysql//performance_schema/global_variables_193.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.018992-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_138.sdi to /var/lib/mysql//performance_schema/events_statement_138.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.019091-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_138.sdi to /var/lib/mysql//performance_schema/events_statement_138.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.019161-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/hosts_155.sdi to /var/lib/mysql//performance_schema/hosts_155.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.019259-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/hosts_155.sdi to /var/lib/mysql//performance_schema/hosts_155.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.019343-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/setup_consumers_112.sdi to /var/lib/mysql//performance_schema/setup_consumers_112.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.019441-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/setup_consumers_112.sdi to /var/lib/mysql//performance_schema/setup_consumers_112.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.019512-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_su_125.sdi to /var/lib/mysql//performance_schema/events_stages_su_125.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.019611-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_su_125.sdi to /var/lib/mysql//performance_schema/events_stages_su_125.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.019682-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/user_variables_b_185.sdi to /var/lib/mysql//performance_schema/user_variables_b_185.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.019779-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/user_variables_b_185.sdi to /var/lib/mysql//performance_schema/user_variables_b_185.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.019849-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_137.sdi to /var/lib/mysql//performance_schema/events_statement_137.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.019946-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_137.sdi to /var/lib/mysql//performance_schema/events_statement_137.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.020015-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_su_126.sdi to /var/lib/mysql//performance_schema/events_stages_su_126.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.020123-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_su_126.sdi to /var/lib/mysql//performance_schema/events_stages_su_126.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.020196-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/binary_log_trans_198.sdi to /var/lib/mysql//performance_schema/binary_log_trans_198.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.020293-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/binary_log_trans_198.sdi to /var/lib/mysql//performance_schema/binary_log_trans_198.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.020368-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/socket_summary_b_157.sdi to /var/lib/mysql//performance_schema/socket_summary_b_157.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.020472-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/socket_summary_b_157.sdi to /var/lib/mysql//performance_schema/socket_summary_b_157.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.020548-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_appl_180.sdi to /var/lib/mysql//performance_schema/replication_appl_180.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.020647-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_appl_180.sdi to /var/lib/mysql//performance_schema/replication_appl_180.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.020718-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_sum_99.sdi to /var/lib/mysql//performance_schema/events_waits_sum_99.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.020820-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_sum_99.sdi to /var/lib/mysql//performance_schema/events_waits_sum_99.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.020892-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/keyring_keys_161.sdi to /var/lib/mysql//performance_schema/keyring_keys_161.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.021007-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/keyring_keys_161.sdi to /var/lib/mysql//performance_schema/keyring_keys_161.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.021088-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/session_connect__159.sdi to /var/lib/mysql//performance_schema/session_connect__159.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.021188-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/session_connect__159.sdi to /var/lib/mysql//performance_schema/session_connect__159.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.021271-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/global_status_190.sdi to /var/lib/mysql//performance_schema/global_status_190.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.021369-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/global_status_190.sdi to /var/lib/mysql//performance_schema/global_status_190.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.021438-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/metadata_locks_168.sdi to /var/lib/mysql//performance_schema/metadata_locks_168.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.021535-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/metadata_locks_168.sdi to /var/lib/mysql//performance_schema/metadata_locks_168.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.021605-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/status_by_host_187.sdi to /var/lib/mysql//performance_schema/status_by_host_187.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.021702-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/status_by_host_187.sdi to /var/lib/mysql//performance_schema/status_by_host_187.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.021772-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/table_handles_167.sdi to /var/lib/mysql//performance_schema/table_handles_167.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.021869-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/table_handles_167.sdi to /var/lib/mysql//performance_schema/table_handles_167.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.021942-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/error_log_92.sdi to /var/lib/mysql//performance_schema/error_log_92.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.022040-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/error_log_92.sdi to /var/lib/mysql//performance_schema/error_log_92.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.022122-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_appl_177.sdi to /var/lib/mysql//performance_schema/replication_appl_177.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.022226-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_appl_177.sdi to /var/lib/mysql//performance_schema/replication_appl_177.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.022301-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_136.sdi to /var/lib/mysql//performance_schema/events_statement_136.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.022402-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_136.sdi to /var/lib/mysql//performance_schema/events_statement_136.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.022476-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_sum_101.sdi to /var/lib/mysql//performance_schema/events_waits_sum_101.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.022577-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_sum_101.sdi to /var/lib/mysql//performance_schema/events_waits_sum_101.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.022650-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_errors_su_149.sdi to /var/lib/mysql//performance_schema/events_errors_su_149.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.022755-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_errors_su_149.sdi to /var/lib/mysql//performance_schema/events_errors_su_149.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.022831-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/users_153.sdi to /var/lib/mysql//performance_schema/users_153.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.022930-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/users_153.sdi to /var/lib/mysql//performance_schema/users_153.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.023004-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_142.sdi to /var/lib/mysql//performance_schema/events_transacti_142.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.023107-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_142.sdi to /var/lib/mysql//performance_schema/events_transacti_142.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.023190-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_su_123.sdi to /var/lib/mysql//performance_schema/events_stages_su_123.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.023293-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_su_123.sdi to /var/lib/mysql//performance_schema/events_stages_su_123.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.023367-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_141.sdi to /var/lib/mysql//performance_schema/events_transacti_141.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.023470-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_141.sdi to /var/lib/mysql//performance_schema/events_transacti_141.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.023542-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/data_lock_waits_170.sdi to /var/lib/mysql//performance_schema/data_lock_waits_170.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.023643-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/data_lock_waits_170.sdi to /var/lib/mysql//performance_schema/data_lock_waits_170.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.023714-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_147.sdi to /var/lib/mysql//performance_schema/events_transacti_147.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.023816-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_147.sdi to /var/lib/mysql//performance_schema/events_transacti_147.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.023888-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_135.sdi to /var/lib/mysql//performance_schema/events_statement_135.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.023995-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_135.sdi to /var/lib/mysql//performance_schema/events_statement_135.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.024071-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_hi_121.sdi to /var/lib/mysql//performance_schema/events_stages_hi_121.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.024183-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_hi_121.sdi to /var/lib/mysql//performance_schema/events_stages_hi_121.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.024257-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/variables_info_195.sdi to /var/lib/mysql//performance_schema/variables_info_195.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.024358-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/variables_info_195.sdi to /var/lib/mysql//performance_schema/variables_info_195.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.024431-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/variables_by_thr_192.sdi to /var/lib/mysql//performance_schema/variables_by_thr_192.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.024535-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/variables_by_thr_192.sdi to /var/lib/mysql//performance_schema/variables_by_thr_192.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.024613-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_sum_96.sdi to /var/lib/mysql//performance_schema/events_waits_sum_96.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.024717-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_sum_96.sdi to /var/lib/mysql//performance_schema/events_waits_sum_96.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.024791-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_his_95.sdi to /var/lib/mysql//performance_schema/events_waits_his_95.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.024893-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_his_95.sdi to /var/lib/mysql//performance_schema/events_waits_his_95.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.024985-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_cur_93.sdi to /var/lib/mysql//performance_schema/events_waits_cur_93.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.025101-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_cur_93.sdi to /var/lib/mysql//performance_schema/events_waits_cur_93.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.025200-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_140.sdi to /var/lib/mysql//performance_schema/events_transacti_140.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.025308-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_140.sdi to /var/lib/mysql//performance_schema/events_transacti_140.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.025384-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/memory_summary_b_166.sdi to /var/lib/mysql//performance_schema/memory_summary_b_166.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.025494-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/memory_summary_b_166.sdi to /var/lib/mysql//performance_schema/memory_summary_b_166.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.025576-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/file_instances_102.sdi to /var/lib/mysql//performance_schema/file_instances_102.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.025684-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/file_instances_102.sdi to /var/lib/mysql//performance_schema/file_instances_102.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.025761-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_sum_98.sdi to /var/lib/mysql//performance_schema/events_waits_sum_98.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.025863-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_sum_98.sdi to /var/lib/mysql//performance_schema/events_waits_sum_98.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.025940-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_144.sdi to /var/lib/mysql//performance_schema/events_transacti_144.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.026049-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_144.sdi to /var/lib/mysql//performance_schema/events_transacti_144.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.026132-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_appl_179.sdi to /var/lib/mysql//performance_schema/replication_appl_179.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.026249-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_appl_179.sdi to /var/lib/mysql//performance_schema/replication_appl_179.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.026346-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/host_cache_105.sdi to /var/lib/mysql//performance_schema/host_cache_105.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.026453-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/host_cache_105.sdi to /var/lib/mysql//performance_schema/host_cache_105.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.026533-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_134.sdi to /var/lib/mysql//performance_schema/events_statement_134.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.026645-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_134.sdi to /var/lib/mysql//performance_schema/events_statement_134.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.026728-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/prepared_stateme_184.sdi to /var/lib/mysql//performance_schema/prepared_stateme_184.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.026846-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/prepared_stateme_184.sdi to /var/lib/mysql//performance_schema/prepared_stateme_184.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.026932-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/memory_summary_g_162.sdi to /var/lib/mysql//performance_schema/memory_summary_g_162.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.027051-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/memory_summary_g_162.sdi to /var/lib/mysql//performance_schema/memory_summary_g_162.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.027139-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./ib_buffer_pool to /var/lib/mysql//ib_buffer_pool\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.027254-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./ib_buffer_pool to /var/lib/mysql//ib_buffer_pool\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:45:23.105672-00:00 0 [Note] [MY-011825] [Xtrabackup] completed OK!\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"---- Starting the MySQL server used for post-processing ----\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:23.535444Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:23.535477Z 0 [Warning] [MY-011068] [Server] The syntax 'wsrep_slave_threads' is deprecated and will be removed in a future release. Please use wsrep_applier_threads instead.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:23.535507Z 0 [Warning] [MY-011068] [Server] The syntax 'skip_slave_start' is deprecated and will be removed in a future release. Please use skip_replica_start instead.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:23.537499Z 0 [Warning] [MY-010097] [Server] Insecure configuration for --secure-log-path: Current value does not restrict location of generated files. Consider setting it to a valid, non-empty path.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:23.537546Z 0 [Warning] [MY-000000] [WSREP] Node is not a cluster node. Disabling pxc_strict_mode\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:23.538218Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.32-24.2) starting as process 1018\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:23.542079Z 0 [Warning] [MY-010068] [Server] CA certificate /etc/mysql/ssl-internal/ca.crt is self signed.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:23.542129Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:23.559415Z 0 [Warning] [MY-010075] [Server] No existing UUID has been found, so we assume that this is the first time that this server has been started. Generating a new UUID: 53f2fc81-c738-11ee-a4f0-3a8855a67440.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:23.572632Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:23.877335Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:24.034274Z 1 [Note] [MY-000000] [WSREP] wsrep_init_schema_and_SR (nil)\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:24.060008Z 1 [System] [MY-000000] [WSREP] PXC upgrade completed successfully\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:24.162913Z 0 [System] [MY-010229] [Server] Starting XA crash recovery...\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:24.182498Z 0 [System] [MY-010232] [Server] XA crash recovery finished.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:24.305769Z 0 [Warning] [MY-010068] [Server] CA certificate /etc/mysql/ssl-internal/ca.crt is self signed.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:24.305813Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:24.317054Z 0 [Warning] [MY-013595] [Server] Failed to initialize TLS for channel: mysql_admin. See below for the description of exact issue.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:24.317102Z 0 [Warning] [MY-010069] [Server] Failed to set up SSL because of the following SSL library error: SSL context is not usable without certificate and private key\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:24.317113Z 0 [System] [MY-013603] [Server] No TLS configuration was given for channel mysql_admin; re-using TLS configuration of channel mysql_main.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:24.398697Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/tmp' in the path is accessible to all OS users. Consider choosing a different directory.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:24.441747Z 0 [Note] [MY-000000] [WSREP] Initialized wsrep sidno 3\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:24.441837Z 0 [Note] [MY-000000] [Galera] Loading provider none initial position: 00000000-0000-0000-0000-000000000000:-1\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:24.441865Z 0 [Note] [MY-000000] [Galera] wsrep_load(): loading provider library 'none'\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:24.461770Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Socket: /var/lib/mysql/mysqlx.sock\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:24.461960Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.32-24.2'  socket: '/tmp/upgrd.JBlS/my.sock'  port: 0  Percona XtraDB Cluster (GPL), Release rel24, Revision 2119e75, WSREP version 26.1.4.3.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:25.300390Z 11 [System] [MY-013172] [Server] Received SHUTDOWN from user mysql.pxc.sst.user. Shutting down mysqld (Version: 8.0.32-24.2).\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:45:26.683757Z 0 [System] [MY-010910] [Server] /usr/sbin/mysqld: Shutdown complete (mysqld 8.0.32-24.2)  Percona XtraDB Cluster (GPL), Release rel24, Revision 2119e75, WSREP version 26.1.4.3.\n---- Stopped the MySQL server used for post-processing ----\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:35.683651Z 0 [Note] [MY-000000] [Galera] (486b248f-8ac6, 'ssl://0.0.0.0:4567') connection established to 7eee9476-83f9 ssl://10.42.1.6:4567\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.684114Z 0 [Note] [MY-000000] [Galera] (486b248f-8ac6, 'ssl://0.0.0.0:4567') turning message relay requesting on, nonlive peers: \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:36.177246Z 0 [Note] [MY-000000] [Galera] declaring 213e9b53-8c4d at ssl://10.42.0.5:4567 stable\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:36.177345Z 0 [Note] [MY-000000] [Galera] declaring 7eee9476-83f9 at ssl://10.42.1.6:4567 stable\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.179035Z 0 [Note] [MY-000000] [Galera] Node 213e9b53-8c4d state primary\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.179931Z 0 [Note] [MY-000000] [Galera] Current view of cluster as seen by this node\nview (view_id(PRIM,213e9b53-8c4d,3)\nmemb {\n\t213e9b53-8c4d,0\n\t486b248f-8ac6,0\n\t7eee9476-83f9,0\n\t}\njoined {\n\t}\nleft {\n\t}\npartitioned {\n\t}\n)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.180002Z 0 [Note] [MY-000000] [Galera] Save the discovered primary-component to disk\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.195810Z 0 [Note] [MY-000000] [Galera] New COMPONENT: primary = yes, bootstrap = no, my_idx = 1, memb_num = 3\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.195900Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: Waiting for state UUID.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.197522Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: sent state msg: 7fd70a41-c738-11ee-8cb8-0a31c2c73e26\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.198797Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: got state msg: 7fd70a41-c738-11ee-8cb8-0a31c2c73e26 from 0 (cluster1-pxc-0)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.198885Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: got state msg: 7fd70a41-c738-11ee-8cb8-0a31c2c73e26 from 1 (cluster1-pxc-1)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679084Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: got state msg: 7fd70a41-c738-11ee-8cb8-0a31c2c73e26 from 2 (cluster1-pxc-2)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679214Z 0 [Note] [MY-000000] [Galera] Quorum results:\n\tversion    = 6,\n\tcomponent  = PRIMARY,\n\tconf_id    = 2,\n\tmembers    = 2/3 (primary/total),\n\tact_id     = 35,\n\tlast_appl. = 22,\n\tprotocols  = 2/10/4 (gcs/repl/appl),\n\tvote policy= 0,\n\tgroup UUID = 103be6ae-c738-11ee-95d1-526d43d08e41\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679382Z 0 [Note] [MY-000000] [Galera] Flow-control interval: [173, 173]\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679610Z 2 [Note] [MY-000000] [Galera] ####### processing CC 36, local, ordered\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679749Z 2 [Note] [MY-000000] [Galera] Maybe drain monitors from 35 upto current CC event 36 upto:35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679820Z 2 [Note] [MY-000000] [Galera] Drain monitors from 35 up to 35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679858Z 2 [Note] [MY-000000] [Galera] ####### My UUID: 486b248f-c738-11ee-8ac6-0a8a79d0dabd\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679915Z 2 [Note] [MY-000000] [Galera] Skipping cert index reset\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679938Z 2 [Note] [MY-000000] [Galera] REPL Protocols: 10 (5)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679964Z 2 [Note] [MY-000000] [Galera] ####### Adjusting cert position: 35 -> 36\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.680026Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.702536Z 2 [Note] [MY-000000] [Galera] ================================================\nView:\n  id: 103be6ae-c738-11ee-95d1-526d43d08e41:36\n  status: primary\n  protocol_version: 4\n  capabilities: MULTI-MASTER, CERTIFICATION, PARALLEL_APPLYING, REPLAY, ISOLATION, PAUSE, CAUSAL_READ, INCREMENTAL_WS, UNORDERED, PREORDERED, STREAMING, NBO\n  final: no\n  own_index: 1\n  members(3):\n\t0: 213e9b53-c738-11ee-8c4d-03cb16bd2d32, cluster1-pxc-0\n\t1: 486b248f-c738-11ee-8ac6-0a8a79d0dabd, cluster1-pxc-1\n\t2: 7eee9476-c738-11ee-83f9-e3e1dce47b60, cluster1-pxc-2\n=================================================\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.702628Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.711507Z 2 [Note] [MY-000000] [Galera] Recording CC from group: 36\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.711594Z 2 [Note] [MY-000000] [Galera] Lowest cert index boundary for CC from group: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.711621Z 2 [Note] [MY-000000] [Galera] Min available from gcache for CC from group: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.731842Z 0 [Note] [MY-000000] [Galera] (486b248f-8ac6, 'ssl://0.0.0.0:4567') turning message relay requesting off\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.764127Z 0 [Note] [MY-000000] [Galera] Member 2.0 (cluster1-pxc-2) requested state transfer from 'cluster1-pxc-1,'. Selected 1.0 (cluster1-pxc-1)(SYNCED) as donor.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.764195Z 0 [Note] [MY-000000] [Galera] Shifting SYNCED -> DONOR/DESYNCED (TO: 36)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.764251Z 2 [Note] [MY-000000] [Galera] Detected STR version: 1, req_len: 125, req: STRv1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.764318Z 2 [Note] [MY-000000] [Galera] Cert index preload: 24 -> 36\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.774855Z 2 [Note] [MY-000000] [WSREP] Server status change synced -> donor\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.774904Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.774983Z 0 [Note] [MY-000000] [Galera] async IST sender starting to serve ssl://10.42.1.6:4568 sending 24-36, preload starts from 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.775190Z 0 [Note] [MY-000000] [WSREP] Initiating SST/IST transfer on DONOR side (wsrep_sst_xtrabackup-v2 --role 'donor' --address '10.42.1.6:4444/xtrabackup_sst//1' --socket '/tmp/mysql.sock' --datadir '/var/lib/mysql/' --basedir '/usr/' --plugindir '/usr/lib64/mysql/plugin/' --defaults-file '/etc/my.cnf' --defaults-group-suffix '' --mysqld-version '8.0.32-24.2'  --binlog 'binlog' --gtid '103be6ae-c738-11ee-95d1-526d43d08e41:36' )\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.776741Z 0 [Note] [MY-000000] [Galera] IST sender 24 -> 36\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.789515Z 2 [Note] [MY-000000] [WSREP] DONOR thread signaled with 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:39.583123Z 92 [Warning] [MY-013712] [Server] No suitable 'keyring_component_metadata_query' service implementation found to fulfill the request.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:50.653965Z 0 [Note] [MY-000000] [WSREP-SST] Streaming the backup to joiner at 10.42.1.6 4444\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:50.707450Z 109 [Warning] [MY-013712] [Server] No suitable 'keyring_component_metadata_query' service implementation found to fulfill the request.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:50.674287-00:00 0 [Note] [MY-011825] [Xtrabackup] recognized server arguments: --datadir=/var/lib/mysql --server-id=32109361 --innodb_flush_log_at_trx_commit=0 --innodb_flush_method=O_DIRECT --innodb_file_per_table=1 --defaults_group=mysqld \n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:50.674556-00:00 0 [Note] [MY-011825] [Xtrabackup] recognized client arguments: --socket=/tmp/mysql.sock --no-version-check=1 --parallel=4 --user=mysql.pxc.sst.user --password=* --socket=/tmp/mysql.sock --lock-ddl=1 --backup=1 --galera-info=1 --stream=xbstream --xtrabackup-plugin-dir=/usr/bin/pxc_extra/pxb-8.0/lib/plugin --target-dir=/tmp/pxc_sst_QSOi/donor_xb_zd3X \n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"/usr/bin/pxc_extra/pxb-8.0/bin/xtrabackup version 8.0.32-26 based on MySQL server 8.0.32 Linux (x86_64) (revision id: 34cf2908)\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:50.674584-00:00 0 [Note] [MY-011825] [Xtrabackup] Connecting to MySQL server host: localhost, user: mysql.pxc.sst.user, password: set, port: not set, socket: /tmp/mysql.sock\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:50.695091-00:00 0 [Note] [MY-011825] [Xtrabackup] Using server version 8.0.32-24.2\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:50.703984-00:00 0 [Note] [MY-011825] [Xtrabackup] Executing LOCK TABLES FOR BACKUP ...\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:50.705762-00:00 0 [Note] [MY-011825] [Xtrabackup] uses posix_fadvise().\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:50.705805-00:00 0 [Note] [MY-011825] [Xtrabackup] cd to /var/lib/mysql\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:50.705818-00:00 0 [Note] [MY-011825] [Xtrabackup] open files limit requested 0, set to 1048576\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:50.706448-00:00 0 [Note] [MY-011825] [Xtrabackup] using the following InnoDB configuration:\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:50.706455-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_data_home_dir = .\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:50.706461-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_data_file_path = ibdata1:12M:autoextend\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:50.706494-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_group_home_dir = ./\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:50.706500-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_files_in_group = 2\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:50.706508-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_file_size = 50331648\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:50.706521-00:00 0 [Note] [MY-011825] [Xtrabackup] using O_DIRECT\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:50.708576-00:00 0 [Note] [MY-011825] [Xtrabackup] inititialize_service_handles suceeded\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:50.866647-00:00 0 [Note] [MY-011825] [Xtrabackup] Connecting to MySQL server host: localhost, user: mysql.pxc.sst.user, password: set, port: not set, socket: /tmp/mysql.sock\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:50.879648-00:00 0 [Note] [MY-011825] [Xtrabackup] Redo Log Archiving is not set up.\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:50.967791-00:00 1 [Note] [MY-011825] [Xtrabackup] >> log scanned up to (32368945)\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.172684-00:00 0 [Note] [MY-011825] [Xtrabackup] Generating a list of tablespaces\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.172827-00:00 0 [Note] [MY-012204] [InnoDB] Scanning './'\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.184427-00:00 0 [Note] [MY-012208] [InnoDB] Completed space ID check of 2 files.\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.185331-00:00 0 [Warning] [MY-012091] [InnoDB] Allocated tablespace ID 1 for sys/sys_config, old maximum was 0\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.185924-00:00 0 [Note] [MY-013252] [InnoDB] Using undo tablespace './undo_001'.\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.186231-00:00 0 [Note] [MY-013252] [InnoDB] Using undo tablespace './undo_002'.\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.186847-00:00 0 [Note] [MY-012910] [InnoDB] Opened 2 existing undo tablespaces.\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.186867-00:00 0 [Note] [MY-011825] [Xtrabackup] Starting 4 threads for parallel data files transfer\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.187621-00:00 2 [Note] [MY-011825] [Xtrabackup] Streaming ./ibdata1\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.188416-00:00 3 [Note] [MY-011825] [Xtrabackup] Streaming ./sys/sys_config.ibd\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.189581-00:00 4 [Note] [MY-011825] [Xtrabackup] Streaming ./mysql/wsrep_cluster.ibd\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.192179-00:00 5 [Note] [MY-011825] [Xtrabackup] Streaming ./mysql/wsrep_cluster_members.ibd\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.192932-00:00 3 [Note] [MY-011825] [Xtrabackup] Done: Streaming ./sys/sys_config.ibd\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.193084-00:00 4 [Note] [MY-011825] [Xtrabackup] Done: Streaming ./mysql/wsrep_cluster.ibd\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.193390-00:00 3 [Note] [MY-011825] [Xtrabackup] Streaming ./mysql/wsrep_streaming_log.ibd\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.193774-00:00 5 [Note] [MY-011825] [Xtrabackup] Done: Streaming ./mysql/wsrep_cluster_members.ibd\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.194070-00:00 3 [Note] [MY-011825] [Xtrabackup] Done: Streaming ./mysql/wsrep_streaming_log.ibd\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.195390-00:00 4 [Note] [MY-011825] [Xtrabackup] Streaming ./mysql.ibd\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.202552-00:00 5 [Note] [MY-011825] [Xtrabackup] Streaming ./undo_001\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.207056-00:00 3 [Note] [MY-011825] [Xtrabackup] Streaming ./undo_002\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.272045-00:00 2 [Note] [MY-011825] [Xtrabackup] Done: Streaming ./ibdata1\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.408213-00:00 5 [Note] [MY-011825] [Xtrabackup] Done: Streaming ./undo_001\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.445894-00:00 3 [Note] [MY-011825] [Xtrabackup] Done: Streaming ./undo_002\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.613923-00:00 4 [Note] [MY-011825] [Xtrabackup] Done: Streaming ./mysql.ibd\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:51.968101-00:00 1 [Note] [MY-011825] [Xtrabackup] >> log scanned up to (32368945)\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.187757-00:00 0 [Note] [MY-011825] [Xtrabackup] Starting to backup non-InnoDB tables and files\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.189703-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming mysql/slow_log.CSM to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.189866-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming mysql/slow_log.CSM to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.191944-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming mysql/general_log.CSV to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.192017-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming mysql/general_log.CSV to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.192168-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming mysql/general_log_225.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.192196-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming mysql/general_log_225.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.194930-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming mysql/slow_log_226.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.195078-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming mysql/slow_log_226.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.195335-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/malloc_stats_tot_200.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.195387-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/malloc_stats_tot_200.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.199515-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming mysql/slow_log.CSV to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.199609-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming mysql/slow_log.CSV to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.199676-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_asyn_182.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.199800-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_asyn_182.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.199825-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/memory_summary_b_164.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.199878-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/memory_summary_b_164.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.200227-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming mysql/general_log.CSM to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.200330-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming mysql/general_log.CSM to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.200582-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/setup_instrument_113.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.200632-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/setup_instrument_113.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.201695-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_131.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.201776-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_131.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.203626-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_conn_171.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.203693-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_conn_171.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.205441-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_transacti_143.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.205490-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_transacti_143.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.205790-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/malloc_stats_201.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.205867-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/malloc_stats_201.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.207383-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_waits_sum_97.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.207432-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_waits_sum_97.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.209363-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/pxc_cluster_view_203.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.209377-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/table_io_waits_s_117.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.209519-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/pxc_cluster_view_203.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.209566-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/table_io_waits_s_117.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.211430-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/threads_119.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.211488-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/threads_119.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.211776-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/file_summary_by__104.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.211922-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/file_summary_by__104.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.211965-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/session_variable_194.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.212023-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/session_variable_194.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.213374-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_132.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.213500-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_132.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.213814-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/mutex_instances_106.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.213902-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/mutex_instances_106.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.215400-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_stages_cu_120.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.215482-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_stages_cu_120.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.218394-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_conn_173.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.218394-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/status_by_thread_188.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.218617-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_conn_173.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.218658-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/status_by_thread_188.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.218677-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/processlist_109.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.218776-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/processlist_109.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.219243-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_130.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.219376-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_130.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.220853-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/user_defined_fun_197.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.221062-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/user_defined_fun_197.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.222952-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_errors_su_152.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.223075-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_errors_su_152.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.223556-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_transacti_145.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.223704-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_transacti_145.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.224105-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/memory_summary_b_165.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.224277-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/memory_summary_b_165.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.225190-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/session_status_191.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.225256-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/session_status_191.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.225344-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_asyn_181.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.225466-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_asyn_181.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.226727-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_errors_su_148.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.226797-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_errors_su_148.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.228303-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/setup_threads_115.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.228382-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/setup_threads_115.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.229374-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_133.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.229561-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_133.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.230436-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/persisted_variab_196.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.230554-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/persisted_variab_196.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.231390-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/accounts_154.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.231529-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/accounts_154.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.233396-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/rwlock_instances_110.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.233527-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/keyring_componen_202.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.233637-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/rwlock_instances_110.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.233645-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/keyring_componen_202.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.235344-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/log_status_183.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.235495-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/log_status_183.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.236585-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/socket_summary_b_158.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.236803-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/socket_summary_b_158.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.237159-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_transacti_146.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.237312-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_transacti_146.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.237382-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_stages_hi_122.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.237443-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_stages_hi_122.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.238967-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/socket_instances_156.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.239045-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/socket_instances_156.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.239329-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_waits_his_94.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.239495-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_waits_his_94.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.241144-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/cond_instances_91.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.241273-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/cond_instances_91.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.242868-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/data_locks_169.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.242899-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_129.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.243104-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_129.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.243099-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/data_locks_169.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.243357-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/setup_objects_114.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.243442-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/setup_objects_114.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.244673-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_139.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.244736-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_139.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.245201-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/table_lock_waits_118.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.245388-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/table_lock_waits_118.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.246706-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/status_by_accoun_186.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.246772-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/status_by_accoun_186.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.247933-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_errors_su_151.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.248047-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_errors_su_151.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.248845-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_appl_176.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.249019-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_appl_176.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.249121-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/objects_summary__107.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.249199-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/objects_summary__107.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.249411-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_stages_su_124.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.249464-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_stages_su_124.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.250902-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/table_io_waits_s_116.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.251041-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/table_io_waits_s_116.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.252118-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/file_summary_by__103.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.252303-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/file_summary_by__103.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.253140-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_stages_su_127.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.253234-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_stages_su_127.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.254446-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_128.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.254625-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_128.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.254678-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_appl_175.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.254758-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_appl_175.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.254928-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_appl_174.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.255027-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_appl_174.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.256916-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_waits_sum_100.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.257043-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_waits_sum_100.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.257128-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/session_account__160.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.257241-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/session_account__160.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.259143-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/status_by_user_189.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.259195-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/status_by_user_189.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.259239-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_grou_178.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.259310-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_grou_178.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.260127-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/setup_actors_111.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.260231-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/setup_actors_111.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.260314-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_errors_su_150.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.260398-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_errors_su_150.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.261524-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/tls_channel_stat_199.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.261579-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_grou_172.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.261599-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/tls_channel_stat_199.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.261634-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_grou_172.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.264065-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_138.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.264129-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/global_variables_193.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.264162-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_138.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.264176-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/global_variables_193.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.265928-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/memory_summary_b_163.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.266076-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/performance_time_108.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.266122-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/memory_summary_b_163.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.266134-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/performance_time_108.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.266161-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/hosts_155.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.266231-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/hosts_155.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.267690-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_137.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.267802-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_137.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.268234-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/setup_consumers_112.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.268357-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/setup_consumers_112.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.269768-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_stages_su_126.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.269862-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_stages_su_126.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.271224-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/binary_log_trans_198.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.271339-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/binary_log_trans_198.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.271481-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_stages_su_125.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.271575-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/user_variables_b_185.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.271602-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_stages_su_125.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.271657-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/user_variables_b_185.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.272179-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/socket_summary_b_157.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.272249-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/socket_summary_b_157.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.273468-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_appl_180.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.273552-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_appl_180.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.274452-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/session_connect__159.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.274502-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/session_connect__159.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.275820-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/global_status_190.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.275875-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/global_status_190.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.276567-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/metadata_locks_168.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.276627-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/metadata_locks_168.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.277155-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/keyring_keys_161.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.277261-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/keyring_keys_161.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.277728-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_waits_sum_99.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.277816-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_waits_sum_99.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.278220-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/table_handles_167.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.278287-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/table_handles_167.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.280131-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_136.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.280257-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_136.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.281168-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/status_by_host_187.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.281311-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/status_by_host_187.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.282255-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_waits_sum_101.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.282323-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_waits_sum_101.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.283074-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/error_log_92.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.283187-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/error_log_92.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.283518-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_appl_177.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.283642-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_appl_177.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.283738-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_errors_su_149.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.283792-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_errors_su_149.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.284429-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/users_153.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.284502-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/users_153.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.286086-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_transacti_141.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.286219-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_transacti_141.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.287064-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/data_lock_waits_170.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.287173-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/data_lock_waits_170.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.288661-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_transacti_147.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.288746-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_transacti_147.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.288810-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_transacti_142.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.289022-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_transacti_142.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.289290-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_135.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.289346-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_stages_su_123.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.289369-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_135.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.289429-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_stages_su_123.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.290893-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_stages_hi_121.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.290953-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_stages_hi_121.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.291534-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/variables_by_thr_192.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.291589-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/variables_by_thr_192.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.293887-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_waits_cur_93.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.294099-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_waits_cur_93.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.294155-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_waits_his_95.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.294312-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_waits_his_95.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.295456-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/variables_info_195.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.295605-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/variables_info_195.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.295824-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_transacti_140.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.295922-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_transacti_140.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.296316-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_waits_sum_96.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.296429-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_waits_sum_96.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.297525-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_waits_sum_98.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.297628-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_waits_sum_98.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.299432-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/replication_appl_179.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.299572-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/replication_appl_179.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.299695-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/memory_summary_b_166.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.299827-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/memory_summary_b_166.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.301503-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/host_cache_105.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.301587-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/file_instances_102.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.301648-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/host_cache_105.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.301688-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/file_instances_102.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.302320-00:00 6 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_transacti_144.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.302431-00:00 6 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_transacti_144.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.303342-00:00 7 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/events_statement_134.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.303470-00:00 7 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/events_statement_134.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.305277-00:00 8 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/memory_summary_g_162.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.305321-00:00 9 [Note] [MY-011825] [Xtrabackup] Streaming performance_schema/prepared_stateme_184.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.305393-00:00 8 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/memory_summary_g_162.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.305443-00:00 9 [Note] [MY-011825] [Xtrabackup] Done: Streaming performance_schema/prepared_stateme_184.sdi to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.391119-00:00 0 [Note] [MY-011825] [Xtrabackup] Finished backing up non-InnoDB tables and files\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.391229-00:00 0 [Note] [MY-011825] [Xtrabackup] Executing FLUSH NO_WRITE_TO_BINLOG BINARY LOGS\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.443292-00:00 0 [Note] [MY-011825] [Xtrabackup] Selecting LSN and binary log position from p_s.log_status\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.451057-00:00 0 [Note] [MY-011825] [Xtrabackup] Streaming /var/lib/mysql/binlog.000006 to <STDOUT> up to position 197\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.451155-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Streaming /var/lib/mysql/binlog.000006 to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.451431-00:00 0 [Note] [MY-011825] [Xtrabackup] Streaming <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.451470-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Streaming file <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.463263-00:00 0 [Note] [MY-011825] [Xtrabackup] Streaming <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.463331-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Streaming file <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.463358-00:00 0 [Note] [MY-011825] [Xtrabackup] Executing FLUSH NO_WRITE_TO_BINLOG ENGINE LOGS...\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.474827-00:00 0 [Note] [MY-011825] [Xtrabackup] The latest check point (for incremental): '32368945'\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.474943-00:00 0 [Note] [MY-011825] [Xtrabackup] Stopping log copying thread at LSN 32368945\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.475180-00:00 1 [Note] [MY-011825] [Xtrabackup] Starting to parse redo log at lsn = 32368663\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.477090-00:00 0 [Note] [MY-011825] [Xtrabackup] Executing UNLOCK TABLES\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.477307-00:00 0 [Note] [MY-011825] [Xtrabackup] All tables unlocked\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.477533-00:00 0 [Note] [MY-011825] [Xtrabackup] Streaming ib_buffer_pool to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.477566-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Streaming ib_buffer_pool to <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.478406-00:00 0 [Note] [MY-011825] [Xtrabackup] Backup created in directory '/tmp/pxc_sst_QSOi/donor_xb_zd3X/'\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.478423-00:00 0 [Note] [MY-011825] [Xtrabackup] MySQL binlog position: filename 'binlog.000006', position '197', GTID of the last change '103be6ae-c738-11ee-95d1-526d43d08e41:1-11'\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.478479-00:00 0 [Note] [MY-011825] [Xtrabackup] Streaming <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.478493-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Streaming file <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.485446-00:00 0 [Note] [MY-011825] [Xtrabackup] Streaming <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:52.485525-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Streaming file <STDOUT>\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:53.700884Z 0 [Note] [MY-000000] [WSREP-SST]     donor: => Rate:[24.9MiB/s] Avg:[24.9MiB/s] Elapsed:0:00:03            \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:53.706753Z 0 [Note] [MY-000000] [Galera] SST sent: 103be6ae-c738-11ee-95d1-526d43d08e41:36\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:53.707008Z 0 [Note] [MY-000000] [WSREP] Server status change donor -> joined\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:53.707047Z 0 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:53.708248Z 0 [Note] [MY-000000] [Galera] 1.0 (cluster1-pxc-1): State transfer to 2.0 (cluster1-pxc-2) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:53.708314Z 0 [Note] [MY-000000] [Galera] Shifting DONOR/DESYNCED -> JOINED (TO: 36)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:53.708437Z 0 [Note] [MY-000000] [Galera] Processing event queue:... -nan% (0/0 events) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:53.709384Z 0 [Note] [MY-000000] [Galera] Member 1.0 (cluster1-pxc-1) synced with group.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:53.709479Z 0 [Note] [MY-000000] [Galera] Processing event queue:...100.0% (1/1 events) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:53.709514Z 0 [Note] [MY-000000] [Galera] Shifting JOINED -> SYNCED (TO: 36)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:53.709633Z 2 [Note] [MY-000000] [Galera] Server cluster1-pxc-1 synced with group\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:53.709680Z 2 [Note] [MY-000000] [WSREP] Server status change joined -> synced\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:53.709690Z 2 [Note] [MY-000000] [WSREP] Synchronized with group, ready for connections\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:53.486780-00:00 0 [Note] [MY-011825] [Xtrabackup] Transaction log of lsn (32368935) to (32368955) was copied.\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:53.697315-00:00 0 [Note] [MY-011825] [Xtrabackup] completed OK!\n","file":"/var/lib/mysql/innobackup.backup.log"}
+{"log":"2024-02-09T10:46:53.709697Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.622212Z 0 [Note] [MY-000000] [Galera] async IST sender served\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.622889Z 0 [Note] [MY-000000] [Galera] 2.0 (cluster1-pxc-2): State transfer from 1.0 (cluster1-pxc-1) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.623564Z 0 [Note] [MY-000000] [Galera] Member 2.0 (cluster1-pxc-2) synced with group.\n","file":"/var/lib/mysql/mysqld-error.log"}

--- a/src/go/pt-galera-log-explainer/tests/logs/operator_split/node2.2.log
+++ b/src/go/pt-galera-log-explainer/tests/logs/operator_split/node2.2.log
@@ -1,0 +1,830 @@
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /pxc-entrypoint.sh /var/lib/mysql/pxc-entrypoint.sh
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /unsafe-bootstrap.sh /var/lib/mysql/unsafe-bootstrap.sh
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /pxc-configure-pxc.sh /var/lib/mysql/pxc-configure-pxc.sh
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /liveness-check.sh /var/lib/mysql/liveness-check.sh
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /readiness-check.sh /var/lib/mysql/readiness-check.sh
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /peer-list /var/lib/mysql/peer-list
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /get-pxc-state /var/lib/mysql/get-pxc-state
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /pmm-prerun.sh /var/lib/mysql/pmm-prerun.sh
++ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/fluent-bit/bin
++ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/fluent-bit/bin
++ '[' fluent-bit = logrotate ']'
++ '[' fluent-bit = fluent-bit ']'
++ fluentbit_opt+='-c /etc/fluentbit/fluentbit.conf'
++ test -e /opt/percona/hookscript/hook.sh
++ exec fluent-bit -c /etc/fluentbit/fluentbit.conf
+Fluent Bit v2.1.5
+* Copyright (C) 2015-2022 The Fluent Bit Authors
+* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
+* https://fluentbit.io
+
+{"log":"2024-02-09T10:57:00.558265Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.558298Z 0 [Warning] [MY-011068] [Server] The syntax 'wsrep_slave_threads' is deprecated and will be removed in a future release. Please use wsrep_applier_threads instead.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.560360Z 0 [Warning] [MY-010097] [Server] Insecure configuration for --secure-log-path: Current value does not restrict location of generated files. Consider setting it to a valid, non-empty path.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.561080Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.32-24.2) starting as process 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.565286Z 0 [Warning] [MY-010068] [Server] CA certificate /etc/mysql/ssl-internal/ca.crt is self signed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.565325Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.565335Z 0 [Note] [MY-000000] [WSREP] New joining cluster node configured to use specified SSL artifacts\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.565373Z 0 [Note] [MY-000000] [Galera] Loading provider /usr/lib64/galera4/libgalera_smm.so initial position: 00000000-0000-0000-0000-000000000000:-1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.565384Z 0 [Note] [MY-000000] [Galera] wsrep_load(): loading provider library '/usr/lib64/galera4/libgalera_smm.so'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.566163Z 0 [Note] [MY-000000] [Galera] wsrep_load(): Galera 4.14(779b689) by Codership Oy <info@codership.com> (modified by Percona <https://percona.com/>) loaded successfully.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.566188Z 0 [Note] [MY-000000] [Galera] CRC-32C: using 64-bit x86 acceleration.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.566456Z 0 [Warning] [MY-000000] [Galera] SSL compression is not effective. The option socket.ssl_compression is deprecated and will be removed in future releases.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.566465Z 0 [Warning] [MY-000000] [Galera] Parameter 'socket.ssl_compression' is deprecated and will be removed in future versions\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.567068Z 0 [Warning] [MY-000000] [Galera] Could not open state file for reading: '/var/lib/mysql//grastate.dat'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.567079Z 0 [Warning] [MY-000000] [Galera] No persistent state found. Bootstraping with default state\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.567139Z 0 [Note] [MY-000000] [Galera] Found saved state: 00000000-0000-0000-0000-000000000000:-1, safe_to_bootstrap: 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.567604Z 0 [Note] [MY-000000] [Galera] Generated new GCache ID: f365fffa-c739-11ee-9dc7-2fa20016a65b\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.567624Z 0 [Note] [MY-000000] [Galera] GCache DEBUG: opened preamble:\nVersion: 0\nUUID: 00000000-0000-0000-0000-000000000000\nSeqno: -1 - -1\nOffset: -1\nSynced: 0\nEncVersion: 0\nEncrypted: 0\nMasterKeyConst UUID: f365fffa-c739-11ee-9dc7-2fa20016a65b\nMasterKey UUID: 00000000-0000-0000-0000-000000000000\nMasterKey ID: 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.567631Z 0 [Note] [MY-000000] [Galera] Skipped GCache ring buffer recovery: could not determine history UUID.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.578295Z 0 [Note] [MY-000000] [Galera] Passing config to GCS: allocator.disk_pages_encryption = no; allocator.encryption_cache_page_size = 32K; allocator.encryption_cache_size = 16777216; base_dir = /var/lib/mysql/; base_host = 10.42.1.10; base_port = 4567; cert.log_conflicts = no; cert.optimistic_pa = no; debug = no; evs.auto_evict = 0; evs.delay_margin = PT1S; evs.delayed_keep_period = PT30S; evs.inactive_check_period = PT0.5S; evs.inactive_timeout = PT15S; evs.join_retrans_period = PT1S; evs.max_install_timeouts = 3; evs.send_window = 10; evs.stats_report_period = PT1M; evs.suspect_timeout = PT5S; evs.user_send_window = 4; evs.view_forget_timeout = PT24H; gcache.dir = /var/lib/mysql/; gcache.encryption = no; gcache.encryption_cache_page_size = 32K; gcache.encryption_cache_size = 16777216; gcache.freeze_purge_at_seqno = -1; gcache.keep_pages_count = 0; gcache.keep_pages_size = 0; gcache.mem_size = 0; gcache.name = galera.cache; gcache.page_size = 128M; gcache.recover = yes; gcache.size = 128M; gcomm.thread_prio = ; gcs.fc_debug = 0; gcs.fc_factor = 1.0; gcs.fc_limit = 100; gcs.fc_master_slave = no; gcs.fc_single_primary = no; gcs.max_packet_size = 64500; gcs.max_throttle = 0.25; gcs.recv_q_hard_limit = 9223372036854775807; gcs.recv_q_soft_limit = 0.25; gcs.sync_donor = no; gmcast.segment = 0; gmcast.version = 0; pc.announce_timeout = PT3S; pc.checksum = false; pc.ignore_quorum = false; pc.ignore_sb = false; pc.npvo = false; pc.recovery = true; pc.version = 0; pc.wait_prim = true; pc.wait_prim_timeout = PT30S; pc.weight = 10; protonet.backend = asio; protonet.version = 0; repl.causal_read_timeout = PT30S; repl.commit_order = 3; repl.key_format = FLAT8; repl.max_ws_size = 2147483647; repl.proto_max = 10; socket.checksum = 2; socket.recv_buf_size = auto; socket.send_buf_size = auto; socket.ssl = YES; socket.ssl_ca = /etc/mysql/ssl-internal/ca.crt; socket.ssl_cert = /etc/mysql/ssl-internal/tls.crt; socket.ssl_cipher = ; socket.ssl_compression = YES; socket.ssl_key = /etc/mysql/ssl-internal/tls.key; socket.ssl_reload = 1; \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.593231Z 0 [Note] [MY-000000] [WSREP] Starting replication\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.593275Z 0 [Note] [MY-000000] [Galera] Connecting with bootstrap option: 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.593292Z 0 [Note] [MY-000000] [Galera] Setting GCS initial position to 00000000-0000-0000-0000-000000000000:-1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.593359Z 0 [Note] [MY-000000] [Galera] protonet asio version 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.593995Z 0 [Note] [MY-000000] [Galera] Using CRC-32C for message checksums.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.594013Z 0 [Note] [MY-000000] [Galera] backend: asio\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.594096Z 0 [Note] [MY-000000] [Galera] gcomm thread scheduling priority set to other:0 \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.594208Z 0 [Note] [MY-000000] [Galera] Fail to access the file (/var/lib/mysql//gvwstate.dat) error (No such file or directory). It is possible if node is booting for first time or re-booting after a graceful shutdown\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.594217Z 0 [Note] [MY-000000] [Galera] Restoring primary-component from disk failed. Either node is booting for first time or re-booting after a graceful shutdown\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.594416Z 0 [Note] [MY-000000] [Galera] GMCast version 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.596205Z 0 [Note] [MY-000000] [Galera] (f36a12ae-9dca, 'ssl://0.0.0.0:4567') listening at ssl://0.0.0.0:4567\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.596233Z 0 [Note] [MY-000000] [Galera] (f36a12ae-9dca, 'ssl://0.0.0.0:4567') multicast: , ttl: 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.596575Z 0 [Note] [MY-000000] [Galera] EVS version 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.596657Z 0 [Note] [MY-000000] [Galera] gcomm: connecting to group 'cluster1-pxc', peer 'cluster1-pxc-0.cluster1-pxc:,cluster1-pxc-1.cluster1-pxc:'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.605314Z 0 [Note] [MY-000000] [Galera] (f36a12ae-9dca, 'ssl://0.0.0.0:4567') connection established to 213e9b53-8c4d ssl://10.42.0.5:4567\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.605453Z 0 [Note] [MY-000000] [Galera] (f36a12ae-9dca, 'ssl://0.0.0.0:4567') turning message relay requesting on, nonlive peers: \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:00.605842Z 0 [Note] [MY-000000] [Galera] (f36a12ae-9dca, 'ssl://0.0.0.0:4567') connection established to 486b248f-8ac6 ssl://10.42.2.8:4567\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.099033Z 0 [Note] [MY-000000] [Galera] EVS version upgrade 0 -> 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.099130Z 0 [Note] [MY-000000] [Galera] declaring 213e9b53-8c4d at ssl://10.42.0.5:4567 stable\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.099157Z 0 [Note] [MY-000000] [Galera] declaring 486b248f-8ac6 at ssl://10.42.2.8:4567 stable\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.099194Z 0 [Note] [MY-000000] [Galera] PC protocol upgrade 0 -> 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.099808Z 0 [Note] [MY-000000] [Galera] Node 213e9b53-8c4d state primary\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.100581Z 0 [Note] [MY-000000] [Galera] Current view of cluster as seen by this node\nview (view_id(PRIM,213e9b53-8c4d,7)\nmemb {\n\t213e9b53-8c4d,0\n\t486b248f-8ac6,0\n\tf36a12ae-9dca,0\n\t}\njoined {\n\t}\nleft {\n\t}\npartitioned {\n\t}\n)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.100624Z 0 [Note] [MY-000000] [Galera] Save the discovered primary-component to disk\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.597525Z 0 [Note] [MY-000000] [Galera] gcomm: connected\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.597665Z 0 [Note] [MY-000000] [Galera] Changing maximum packet size to 64500, resulting msg size: 32636\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.597877Z 0 [Note] [MY-000000] [Galera] Shifting CLOSED -> OPEN (TO: 0)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.597890Z 0 [Note] [MY-000000] [Galera] Opened channel 'cluster1-pxc'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.598280Z 0 [Note] [MY-000000] [Galera] New COMPONENT: primary = yes, bootstrap = no, my_idx = 2, memb_num = 3\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.598369Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: Waiting for state UUID.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.598458Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: sent state msg: f3bb1016-c739-11ee-8e76-22e59b565797\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.598500Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: got state msg: f3bb1016-c739-11ee-8e76-22e59b565797 from 0 (cluster1-pxc-0)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.598536Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: got state msg: f3bb1016-c739-11ee-8e76-22e59b565797 from 1 (cluster1-pxc-1)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.598625Z 1 [Note] [MY-000000] [WSREP] Starting rollbacker thread 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.598803Z 2 [Note] [MY-000000] [WSREP] Starting applier thread 2\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.600075Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: got state msg: f3bb1016-c739-11ee-8e76-22e59b565797 from 2 (cluster1-pxc-2)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.600134Z 0 [Note] [MY-000000] [Galera] Quorum results:\n\tversion    = 6,\n\tcomponent  = PRIMARY,\n\tconf_id    = 6,\n\tmembers    = 2/3 (primary/total),\n\tact_id     = 41,\n\tlast_appl. = 22,\n\tprotocols  = 2/10/4 (gcs/repl/appl),\n\tvote policy= 0,\n\tgroup UUID = 103be6ae-c738-11ee-95d1-526d43d08e41\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.600226Z 0 [Note] [MY-000000] [Galera] Flow-control interval: [173, 173]\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.600245Z 0 [Note] [MY-000000] [Galera] Shifting OPEN -> PRIMARY (TO: 42)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.600396Z 2 [Note] [MY-000000] [Galera] ####### processing CC 42, local, ordered\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.600442Z 2 [Note] [MY-000000] [Galera] Maybe drain monitors from -1 upto current CC event 42 upto:-1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.600463Z 2 [Note] [MY-000000] [Galera] Drain monitors from -1 up to -1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.600489Z 2 [Note] [MY-000000] [Galera] Process first view: 103be6ae-c738-11ee-95d1-526d43d08e41 my uuid: f36a12ae-c739-11ee-9dca-f75ddd6c940f\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.600536Z 2 [Note] [MY-000000] [Galera] Server cluster1-pxc-2 connected to cluster at position 103be6ae-c738-11ee-95d1-526d43d08e41:42 with ID f36a12ae-c739-11ee-9dca-f75ddd6c940f\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.600556Z 2 [Note] [MY-000000] [WSREP] Server status change disconnected -> connected\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.600608Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.600651Z 2 [Note] [MY-000000] [Galera] ####### My UUID: f36a12ae-c739-11ee-9dca-f75ddd6c940f\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.600676Z 2 [Note] [MY-000000] [Galera] Cert index reset to 00000000-0000-0000-0000-000000000000:-1 (proto: 10), state transfer needed: yes\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.600771Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.600842Z 2 [Note] [MY-000000] [Galera] ####### Assign initial position for certification: 00000000-0000-0000-0000-000000000000:-1, protocol version: -1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.600869Z 2 [Note] [MY-000000] [Galera] State transfer required: \n\tGroup state: 103be6ae-c738-11ee-95d1-526d43d08e41:42\n\tLocal state: 00000000-0000-0000-0000-000000000000:-1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.600884Z 2 [Note] [MY-000000] [WSREP] Server status change connected -> joiner\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.600896Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:01.601281Z 0 [Note] [MY-000000] [WSREP] Initiating SST/IST transfer on JOINER side (wsrep_sst_xtrabackup-v2 --role 'joiner' --address '10.42.1.10' --datadir '/var/lib/mysql/' --basedir '/usr/' --plugindir '/usr/lib64/mysql/plugin/' --defaults-file '/etc/my.cnf' --defaults-group-suffix '' --parent '1' --mysqld-version '8.0.32-24.2'  --binlog 'binlog' )\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:02.667508Z 2 [Note] [MY-000000] [WSREP] Prepared SST request: xtrabackup-v2|10.42.1.10:4444/xtrabackup_sst//1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:02.667605Z 2 [Note] [MY-000000] [Galera] Check if state gap can be serviced using IST\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:02.667657Z 2 [Note] [MY-000000] [Galera] Local UUID: 00000000-0000-0000-0000-000000000000 != Group UUID: 103be6ae-c738-11ee-95d1-526d43d08e41\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:02.667683Z 2 [Note] [MY-000000] [Galera] ####### IST uuid:00000000-0000-0000-0000-000000000000 f: 0, l: 42, STRv: 3\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:02.667802Z 2 [Note] [MY-000000] [Galera] IST receiver addr using ssl://10.42.1.10:4568\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:02.667878Z 2 [Note] [MY-000000] [Galera] IST receiver using ssl\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:02.668245Z 2 [Note] [MY-000000] [Galera] Prepared IST receiver for 0-42, listening at: ssl://10.42.1.10:4568\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:02.669659Z 0 [Note] [MY-000000] [Galera] Member 2.0 (cluster1-pxc-2) requested state transfer from 'cluster1-pxc-1,'. Selected 1.0 (cluster1-pxc-1)(SYNCED) as donor.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:02.669703Z 0 [Note] [MY-000000] [Galera] Shifting PRIMARY -> JOINER (TO: 42)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:02.669755Z 2 [Note] [MY-000000] [Galera] Requesting state transfer: success, donor: 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:02.669787Z 2 [Note] [MY-000000] [Galera] Resetting GCache seqno map due to different histories.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:02.669812Z 2 [Note] [MY-000000] [Galera] GCache history reset: 00000000-0000-0000-0000-000000000000:0 -> 103be6ae-c738-11ee-95d1-526d43d08e41:42\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:03.537531Z 0 [Note] [MY-000000] [WSREP-SST]    joiner: => Rate:[ 144 B/s] Avg:[ 144 B/s] Elapsed:0:00:01  Bytes:  167 B \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:04.098160Z 0 [Note] [MY-000000] [Galera] (f36a12ae-9dca, 'ssl://0.0.0.0:4567') turning message relay requesting off\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:04.525871Z 0 [Note] [MY-000000] [WSREP-SST] Proceeding with SST.........\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:04.551232Z 0 [Note] [MY-000000] [WSREP-SST] ............Waiting for SST streaming to complete!\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:17.598375Z 0 [Note] [MY-000000] [WSREP-SST]    joiner: => Rate:[0.00 B/s] Avg:[0.00 B/s] Elapsed:0:00:10  Bytes: 0.00 B \r   joiner: => Rate:[5.81MiB/s] Avg:[5.81MiB/s] Elapsed:0:00:13  Bytes: 75.9MiB \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:17.601741Z 0 [Note] [MY-000000] [Galera] 1.0 (cluster1-pxc-1): State transfer to 2.0 (cluster1-pxc-2) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:17.602875Z 0 [Note] [MY-000000] [Galera] Member 1.0 (cluster1-pxc-1) synced with group.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:17.610081Z 0 [Note] [MY-000000] [WSREP-SST] Preparing the backup at /var/lib/mysql//sst-xb-tmpdir\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:19.309359Z 0 [Note] [MY-000000] [WSREP-SST] Moving the backup to /var/lib/mysql/\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:19.439171Z 0 [Note] [MY-000000] [WSREP-SST] Running post-processing...........\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:19.452118Z 0 [Note] [MY-000000] [WSREP-SST] Skipping mysql_upgrade (sst): local version (8.0.32) == donor version (8.0.32)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:19.552187Z 0 [Note] [MY-000000] [WSREP-SST] Waiting for server instance to start.....  This may take some time\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:17.626258-00:00 0 [Note] [MY-011825] [Xtrabackup] recognized server arguments: --innodb_checksum_algorithm=crc32 --innodb_log_checksums=1 --innodb_data_file_path=ibdata1:12M:autoextend --innodb_log_file_size=50331648 --innodb_page_size=16384 --innodb_undo_directory=./ --innodb_undo_tablespaces=2 --server-id=32109361 --innodb_log_checksums=ON --innodb_redo_log_encrypt=0 --innodb_undo_log_encrypt=0 \n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.626420-00:00 0 [Note] [MY-011825] [Xtrabackup] recognized client arguments: --no-version-check=1 --prepare=1 --rollback-prepared-trx=1 --xtrabackup-plugin-dir=/usr/bin/pxc_extra/pxb-8.0/lib/plugin --target-dir=/var/lib/mysql//sst-xb-tmpdir \n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"/usr/bin/pxc_extra/pxb-8.0/bin/xtrabackup version 8.0.32-26 based on MySQL server 8.0.32 Linux (x86_64) (revision id: 34cf2908)\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.626455-00:00 0 [Note] [MY-011825] [Xtrabackup] cd to /var/lib/mysql/sst-xb-tmpdir/\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.626512-00:00 0 [Note] [MY-011825] [Xtrabackup] This target seems to be not prepared yet.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.636862-00:00 0 [Note] [MY-011825] [Xtrabackup] xtrabackup_logfile detected: size=8388608, start_lsn=(32418733)\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.637850-00:00 0 [Note] [MY-011825] [Xtrabackup] using the following InnoDB configuration for recovery:\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.637870-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_data_home_dir = .\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.637876-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_data_file_path = ibdata1:12M:autoextend\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.637916-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_group_home_dir = .\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.637922-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_files_in_group = 1\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.637931-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_file_size = 8388608\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.638210-00:00 0 [Note] [MY-011825] [Xtrabackup] inititialize_service_handles suceeded\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.638389-00:00 0 [Note] [MY-011825] [Xtrabackup] using the following InnoDB configuration for recovery:\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.638397-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_data_home_dir = .\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.638403-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_data_file_path = ibdata1:12M:autoextend\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.638413-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_group_home_dir = .\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.638419-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_files_in_group = 1\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.638424-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_file_size = 8388608\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.638433-00:00 0 [Note] [MY-011825] [Xtrabackup] Starting InnoDB instance for recovery.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.638439-00:00 0 [Note] [MY-011825] [Xtrabackup] Using 104857600 bytes for buffer pool (set by --use-memory parameter)\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.638487-00:00 0 [Note] [MY-012932] [InnoDB] PUNCH HOLE support available\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.638504-00:00 0 [Note] [MY-012944] [InnoDB] Uses event mutexes\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.638510-00:00 0 [Note] [MY-012945] [InnoDB] GCC builtin __atomic_thread_fence() is used for memory barrier\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.638521-00:00 0 [Note] [MY-012948] [InnoDB] Compressed tables use zlib 1.2.13\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.638743-00:00 0 [Note] [MY-012951] [InnoDB] Using hardware accelerated crc32 and polynomial multiplication.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.639080-00:00 0 [Note] [MY-012203] [InnoDB] Directories to scan './'\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.639180-00:00 0 [Note] [MY-012204] [InnoDB] Scanning './'\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.641067-00:00 0 [Note] [MY-012208] [InnoDB] Completed space ID check of 7 files.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.641931-00:00 0 [Note] [MY-012955] [InnoDB] Initializing buffer pool, total size = 128.000000M, instances = 1, chunk size =128.000000M \n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.652756-00:00 0 [Note] [MY-012957] [InnoDB] Completed initialization of buffer pool\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.656971-00:00 0 [Note] [MY-011952] [InnoDB] If the mysqld execution user is authorized, page cleaner thread priority can be changed. See the man page of setpriority().\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.783171-00:00 0 [Note] [MY-013883] [InnoDB] The latest found checkpoint is at lsn = 32418733 in redo log file ./#innodb_redo/#ib_redo0.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.783267-00:00 0 [Note] [MY-012560] [InnoDB] The log sequence number 32265428 in the system tablespace does not match the log sequence number 32418733 in the redo log files!\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.783278-00:00 0 [Note] [MY-012551] [InnoDB] Database was not shutdown normally!\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.783289-00:00 0 [Note] [MY-012552] [InnoDB] Starting crash recovery.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.783438-00:00 0 [Note] [MY-013086] [InnoDB] Starting to parse redo log at lsn = 32418318, whereas checkpoint_lsn = 32418733 and start_lsn = 32418304\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.783447-00:00 0 [Note] [MY-012550] [InnoDB] Doing recovery: scanned up to log sequence number 32418743\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.797057-00:00 0 [Note] [MY-013083] [InnoDB] Log background threads are being started...\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.797560-00:00 0 [Note] [MY-012532] [InnoDB] Applying a batch of 1 redo log records ...\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.797638-00:00 0 [Note] [MY-012533] [InnoDB] 100%\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.797651-00:00 0 [Note] [MY-012535] [InnoDB] Apply batch completed!\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.906437-00:00 0 [Note] [MY-013084] [InnoDB] Log background threads are being closed...\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.907911-00:00 0 [Note] [MY-013041] [InnoDB] Resizing redo log from 8M to 1024M (LSN=32418743) synchronously. If this takes too long, consider starting the server with large --innodb_redo_log_capacity, and resizing the redo log online using SET.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.914562-00:00 0 [Note] [MY-012968] [InnoDB] Starting to delete and rewrite redo log files.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:17.914779-00:00 0 [Note] [MY-011825] [InnoDB] Removing redo log file: ./#innodb_redo/#ib_redo0\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:18.046634-00:00 0 [Note] [MY-011825] [InnoDB] Creating redo log file at ./#innodb_redo/#ib_redo0_tmp with file_id 0 with size 33554432 bytes\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:18.069331-00:00 0 [Note] [MY-011825] [InnoDB] Renaming redo log file from ./#innodb_redo/#ib_redo0_tmp to ./#innodb_redo/#ib_redo0\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:18.083129-00:00 0 [Note] [MY-012893] [InnoDB] New redo log files created, LSN=32418828\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:18.083262-00:00 0 [Note] [MY-013083] [InnoDB] Log background threads are being started...\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:18.083839-00:00 0 [Note] [MY-013252] [InnoDB] Using undo tablespace './undo_001'.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:18.084408-00:00 0 [Note] [MY-013252] [InnoDB] Using undo tablespace './undo_002'.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:18.085518-00:00 0 [Note] [MY-012910] [InnoDB] Opened 2 existing undo tablespaces.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:18.085618-00:00 0 [Note] [MY-011980] [InnoDB] GTID recovery trx_no: 3709\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:18.109964-00:00 0 [Note] [MY-013776] [InnoDB] Parallel initialization of rseg complete\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:18.110035-00:00 0 [Note] [MY-013777] [InnoDB] Time taken to initialize rseg using 4 thread: 24429 ms.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:18.110139-00:00 0 [Note] [MY-012923] [InnoDB] Creating shared tablespace for temporary tables\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:18.110247-00:00 0 [Note] [MY-012265] [InnoDB] Setting file './ibtmp1' size to 12 MB. Physically writing the file full; Please wait ...\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:18.133632-00:00 0 [Note] [MY-012266] [InnoDB] File './ibtmp1' size is now 12 MB.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:18.133911-00:00 0 [Note] [MY-013627] [InnoDB] Scanning temp tablespace dir:'./#innodb_temp/'\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:18.204109-00:00 0 [Note] [MY-013018] [InnoDB] Created 128 and tracked 128 new rollback segment(s) in the temporary tablespace. 128 are now active.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:18.204535-00:00 0 [Note] [MY-012976] [InnoDB] 8.0.32 started; log sequence number 32418838\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:18.204815-00:00 0 [Warning] [MY-012091] [InnoDB] Allocated tablespace ID 3 for mysql/wsrep_cluster_members, old maximum was 0\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:18.228275-00:00 0 [Note] [MY-011825] [Xtrabackup] Recovered WSREP position: 103be6ae-c738-11ee-95d1-526d43d08e41:42\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:18.228351-00:00 0 [Note] [MY-011825] [Xtrabackup] starting shutdown with innodb_fast_shutdown = 1\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:18.228404-00:00 0 [Note] [MY-012330] [InnoDB] FTS optimize thread exiting.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:19.228358-00:00 0 [Note] [MY-013072] [InnoDB] Starting shutdown...\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:19.256755-00:00 0 [Note] [MY-013084] [InnoDB] Log background threads are being closed...\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:19.281140-00:00 0 [Note] [MY-012980] [InnoDB] Shutdown completed; log sequence number 32418838\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:19.285188-00:00 0 [Note] [MY-011825] [Xtrabackup] completed OK!\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:57:19.327261-00:00 0 [Note] [MY-011825] [Xtrabackup] recognized server arguments: --datadir=/var/lib/mysql --server-id=32109362 --innodb_flush_log_at_trx_commit=0 --innodb_flush_method=O_DIRECT --innodb_file_per_table=1 --defaults_group=mysqld --datadir=/var/lib/mysql/ \n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.327488-00:00 0 [Note] [MY-011825] [Xtrabackup] recognized client arguments: --socket=/tmp/mysql.sock --no-version-check=1 --move-back=1 --force-non-empty-directories=1 --xtrabackup-plugin-dir=/usr/bin/pxc_extra/pxb-8.0/lib/plugin --target-dir=/var/lib/mysql//sst-xb-tmpdir \n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"/usr/bin/pxc_extra/pxb-8.0/bin/xtrabackup version 8.0.32-26 based on MySQL server 8.0.32 Linux (x86_64) (revision id: 34cf2908)\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.327522-00:00 0 [Note] [MY-011825] [Xtrabackup] cd to /var/lib/mysql/sst-xb-tmpdir/\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.328237-00:00 0 [Note] [MY-011825] [Xtrabackup] Moving undo_001 to /var/lib/mysql//undo_001\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.328308-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Moving file undo_001 to /var/lib/mysql//undo_001\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.328335-00:00 0 [Note] [MY-011825] [Xtrabackup] Moving undo_002 to /var/lib/mysql//undo_002\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.328411-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Moving file undo_002 to /var/lib/mysql//undo_002\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.328600-00:00 0 [Note] [MY-011825] [Xtrabackup] Moving ibdata1 to /var/lib/mysql//ibdata1\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.328644-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Moving file ibdata1 to /var/lib/mysql//ibdata1\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.328902-00:00 0 [Note] [MY-011825] [Xtrabackup] Moving binlog.000007 to /var/lib/mysql//binlog.000007\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.328948-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Moving file binlog.000007 to /var/lib/mysql//binlog.000007\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.329126-00:00 0 [Note] [MY-011825] [Xtrabackup] Moving binlog.index to /var/lib/mysql//binlog.index\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.329173-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Moving file binlog.index to /var/lib/mysql//binlog.index\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.329847-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/slow_log_226.sdi to /var/lib/mysql//mysql/slow_log_226.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.330007-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/slow_log_226.sdi to /var/lib/mysql//mysql/slow_log_226.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.330099-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/wsrep_streaming_log.ibd to /var/lib/mysql//mysql/wsrep_streaming_log.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.330193-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/wsrep_streaming_log.ibd to /var/lib/mysql//mysql/wsrep_streaming_log.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.330263-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/slow_log.CSM to /var/lib/mysql//mysql/slow_log.CSM\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.330349-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/slow_log.CSM to /var/lib/mysql//mysql/slow_log.CSM\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.330413-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/general_log.CSM to /var/lib/mysql//mysql/general_log.CSM\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.330500-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/general_log.CSM to /var/lib/mysql//mysql/general_log.CSM\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.330564-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/general_log.CSV to /var/lib/mysql//mysql/general_log.CSV\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.330648-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/general_log.CSV to /var/lib/mysql//mysql/general_log.CSV\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.330711-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/slow_log.CSV to /var/lib/mysql//mysql/slow_log.CSV\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.330794-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/slow_log.CSV to /var/lib/mysql//mysql/slow_log.CSV\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.330861-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/wsrep_cluster_members.ibd to /var/lib/mysql//mysql/wsrep_cluster_members.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.330949-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/wsrep_cluster_members.ibd to /var/lib/mysql//mysql/wsrep_cluster_members.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.331014-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/general_log_225.sdi to /var/lib/mysql//mysql/general_log_225.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.331122-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/general_log_225.sdi to /var/lib/mysql//mysql/general_log_225.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.331189-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/wsrep_cluster.ibd to /var/lib/mysql//mysql/wsrep_cluster.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.331284-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/wsrep_cluster.ibd to /var/lib/mysql//mysql/wsrep_cluster.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.331305-00:00 1 [Note] [MY-011825] [Xtrabackup] Creating directory ./#innodb_redo\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.331328-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: creating directory ./#innodb_redo\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.331394-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./ibtmp1 to /var/lib/mysql//ibtmp1\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.331493-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./ibtmp1 to /var/lib/mysql//ibtmp1\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.331652-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./sys/sys_config.ibd to /var/lib/mysql//sys/sys_config.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.331750-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./sys/sys_config.ibd to /var/lib/mysql//sys/sys_config.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.331821-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql.ibd to /var/lib/mysql//mysql.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.331914-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql.ibd to /var/lib/mysql//mysql.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.331982-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./xtrabackup_info to /var/lib/mysql//xtrabackup_info\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.332069-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./xtrabackup_info to /var/lib/mysql//xtrabackup_info\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.332130-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./innobackup.prepare.log to /var/lib/mysql//innobackup.prepare.log\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.332225-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./innobackup.prepare.log to /var/lib/mysql//innobackup.prepare.log\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.332298-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./innobackup.move.log to /var/lib/mysql//innobackup.move.log\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.332387-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./innobackup.move.log to /var/lib/mysql//innobackup.move.log\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.332448-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./xtrabackup_galera_info to /var/lib/mysql//xtrabackup_galera_info\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.332538-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./xtrabackup_galera_info to /var/lib/mysql//xtrabackup_galera_info\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.332685-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_asyn_182.sdi to /var/lib/mysql//performance_schema/replication_asyn_182.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.332794-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_asyn_182.sdi to /var/lib/mysql//performance_schema/replication_asyn_182.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.332871-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/malloc_stats_tot_200.sdi to /var/lib/mysql//performance_schema/malloc_stats_tot_200.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.333003-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/malloc_stats_tot_200.sdi to /var/lib/mysql//performance_schema/malloc_stats_tot_200.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.333095-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/malloc_stats_201.sdi to /var/lib/mysql//performance_schema/malloc_stats_201.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.333195-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/malloc_stats_201.sdi to /var/lib/mysql//performance_schema/malloc_stats_201.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.333272-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/memory_summary_b_164.sdi to /var/lib/mysql//performance_schema/memory_summary_b_164.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.333365-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/memory_summary_b_164.sdi to /var/lib/mysql//performance_schema/memory_summary_b_164.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.333449-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_131.sdi to /var/lib/mysql//performance_schema/events_statement_131.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.333544-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_131.sdi to /var/lib/mysql//performance_schema/events_statement_131.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.333616-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/file_summary_by__104.sdi to /var/lib/mysql//performance_schema/file_summary_by__104.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.333718-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/file_summary_by__104.sdi to /var/lib/mysql//performance_schema/file_summary_by__104.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.333790-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/setup_instrument_113.sdi to /var/lib/mysql//performance_schema/setup_instrument_113.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.333879-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/setup_instrument_113.sdi to /var/lib/mysql//performance_schema/setup_instrument_113.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.333948-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/session_variable_194.sdi to /var/lib/mysql//performance_schema/session_variable_194.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.334034-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/session_variable_194.sdi to /var/lib/mysql//performance_schema/session_variable_194.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.334101-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_conn_171.sdi to /var/lib/mysql//performance_schema/replication_conn_171.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.334186-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_conn_171.sdi to /var/lib/mysql//performance_schema/replication_conn_171.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.334253-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_143.sdi to /var/lib/mysql//performance_schema/events_transacti_143.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.334349-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_143.sdi to /var/lib/mysql//performance_schema/events_transacti_143.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.334422-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_sum_97.sdi to /var/lib/mysql//performance_schema/events_waits_sum_97.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.334509-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_sum_97.sdi to /var/lib/mysql//performance_schema/events_waits_sum_97.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.334577-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/pxc_cluster_view_203.sdi to /var/lib/mysql//performance_schema/pxc_cluster_view_203.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.334663-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/pxc_cluster_view_203.sdi to /var/lib/mysql//performance_schema/pxc_cluster_view_203.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.334729-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/table_io_waits_s_117.sdi to /var/lib/mysql//performance_schema/table_io_waits_s_117.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.334820-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/table_io_waits_s_117.sdi to /var/lib/mysql//performance_schema/table_io_waits_s_117.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.334889-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/mutex_instances_106.sdi to /var/lib/mysql//performance_schema/mutex_instances_106.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.334976-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/mutex_instances_106.sdi to /var/lib/mysql//performance_schema/mutex_instances_106.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.335045-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/threads_119.sdi to /var/lib/mysql//performance_schema/threads_119.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.335134-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/threads_119.sdi to /var/lib/mysql//performance_schema/threads_119.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.335212-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_132.sdi to /var/lib/mysql//performance_schema/events_statement_132.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.335301-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_132.sdi to /var/lib/mysql//performance_schema/events_statement_132.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.335369-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/status_by_thread_188.sdi to /var/lib/mysql//performance_schema/status_by_thread_188.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.335463-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/status_by_thread_188.sdi to /var/lib/mysql//performance_schema/status_by_thread_188.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.335536-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_conn_173.sdi to /var/lib/mysql//performance_schema/replication_conn_173.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.335628-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_conn_173.sdi to /var/lib/mysql//performance_schema/replication_conn_173.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.335694-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_cu_120.sdi to /var/lib/mysql//performance_schema/events_stages_cu_120.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.335794-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_cu_120.sdi to /var/lib/mysql//performance_schema/events_stages_cu_120.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.335882-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_130.sdi to /var/lib/mysql//performance_schema/events_statement_130.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.335980-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_130.sdi to /var/lib/mysql//performance_schema/events_statement_130.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.336052-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/processlist_109.sdi to /var/lib/mysql//performance_schema/processlist_109.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.336144-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/processlist_109.sdi to /var/lib/mysql//performance_schema/processlist_109.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.336215-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/memory_summary_b_165.sdi to /var/lib/mysql//performance_schema/memory_summary_b_165.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.336303-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/memory_summary_b_165.sdi to /var/lib/mysql//performance_schema/memory_summary_b_165.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.336372-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/user_defined_fun_197.sdi to /var/lib/mysql//performance_schema/user_defined_fun_197.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.336459-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/user_defined_fun_197.sdi to /var/lib/mysql//performance_schema/user_defined_fun_197.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.336524-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_145.sdi to /var/lib/mysql//performance_schema/events_transacti_145.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.336615-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_145.sdi to /var/lib/mysql//performance_schema/events_transacti_145.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.336683-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_asyn_181.sdi to /var/lib/mysql//performance_schema/replication_asyn_181.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.336770-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_asyn_181.sdi to /var/lib/mysql//performance_schema/replication_asyn_181.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.336836-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_errors_su_152.sdi to /var/lib/mysql//performance_schema/events_errors_su_152.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.336923-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_errors_su_152.sdi to /var/lib/mysql//performance_schema/events_errors_su_152.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.337030-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/session_status_191.sdi to /var/lib/mysql//performance_schema/session_status_191.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.337132-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/session_status_191.sdi to /var/lib/mysql//performance_schema/session_status_191.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.337203-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_133.sdi to /var/lib/mysql//performance_schema/events_statement_133.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.337291-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_133.sdi to /var/lib/mysql//performance_schema/events_statement_133.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.337360-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/persisted_variab_196.sdi to /var/lib/mysql//performance_schema/persisted_variab_196.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.337458-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/persisted_variab_196.sdi to /var/lib/mysql//performance_schema/persisted_variab_196.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.337526-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_errors_su_148.sdi to /var/lib/mysql//performance_schema/events_errors_su_148.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.337615-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_errors_su_148.sdi to /var/lib/mysql//performance_schema/events_errors_su_148.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.337681-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/accounts_154.sdi to /var/lib/mysql//performance_schema/accounts_154.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.337769-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/accounts_154.sdi to /var/lib/mysql//performance_schema/accounts_154.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.337835-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/setup_threads_115.sdi to /var/lib/mysql//performance_schema/setup_threads_115.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.337923-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/setup_threads_115.sdi to /var/lib/mysql//performance_schema/setup_threads_115.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.337991-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/rwlock_instances_110.sdi to /var/lib/mysql//performance_schema/rwlock_instances_110.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.338079-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/rwlock_instances_110.sdi to /var/lib/mysql//performance_schema/rwlock_instances_110.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.338145-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/keyring_componen_202.sdi to /var/lib/mysql//performance_schema/keyring_componen_202.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.338234-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/keyring_componen_202.sdi to /var/lib/mysql//performance_schema/keyring_componen_202.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.338301-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/socket_summary_b_158.sdi to /var/lib/mysql//performance_schema/socket_summary_b_158.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.338390-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/socket_summary_b_158.sdi to /var/lib/mysql//performance_schema/socket_summary_b_158.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.338458-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_146.sdi to /var/lib/mysql//performance_schema/events_transacti_146.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.338547-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_146.sdi to /var/lib/mysql//performance_schema/events_transacti_146.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.338615-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/log_status_183.sdi to /var/lib/mysql//performance_schema/log_status_183.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.338704-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/log_status_183.sdi to /var/lib/mysql//performance_schema/log_status_183.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.338780-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_his_94.sdi to /var/lib/mysql//performance_schema/events_waits_his_94.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.338873-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_his_94.sdi to /var/lib/mysql//performance_schema/events_waits_his_94.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.338942-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_hi_122.sdi to /var/lib/mysql//performance_schema/events_stages_hi_122.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.339036-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_hi_122.sdi to /var/lib/mysql//performance_schema/events_stages_hi_122.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.339102-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/data_locks_169.sdi to /var/lib/mysql//performance_schema/data_locks_169.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.339192-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/data_locks_169.sdi to /var/lib/mysql//performance_schema/data_locks_169.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.339266-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/setup_objects_114.sdi to /var/lib/mysql//performance_schema/setup_objects_114.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.339358-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/setup_objects_114.sdi to /var/lib/mysql//performance_schema/setup_objects_114.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.339426-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/socket_instances_156.sdi to /var/lib/mysql//performance_schema/socket_instances_156.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.339518-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/socket_instances_156.sdi to /var/lib/mysql//performance_schema/socket_instances_156.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.339586-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/cond_instances_91.sdi to /var/lib/mysql//performance_schema/cond_instances_91.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.339676-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/cond_instances_91.sdi to /var/lib/mysql//performance_schema/cond_instances_91.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.339743-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/table_lock_waits_118.sdi to /var/lib/mysql//performance_schema/table_lock_waits_118.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.339834-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/table_lock_waits_118.sdi to /var/lib/mysql//performance_schema/table_lock_waits_118.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.339902-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_129.sdi to /var/lib/mysql//performance_schema/events_statement_129.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.339993-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_129.sdi to /var/lib/mysql//performance_schema/events_statement_129.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.340062-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_139.sdi to /var/lib/mysql//performance_schema/events_statement_139.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.340157-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_139.sdi to /var/lib/mysql//performance_schema/events_statement_139.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.340225-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_appl_176.sdi to /var/lib/mysql//performance_schema/replication_appl_176.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.340317-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_appl_176.sdi to /var/lib/mysql//performance_schema/replication_appl_176.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.340383-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/objects_summary__107.sdi to /var/lib/mysql//performance_schema/objects_summary__107.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.340474-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/objects_summary__107.sdi to /var/lib/mysql//performance_schema/objects_summary__107.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.340551-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/status_by_accoun_186.sdi to /var/lib/mysql//performance_schema/status_by_accoun_186.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.340644-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/status_by_accoun_186.sdi to /var/lib/mysql//performance_schema/status_by_accoun_186.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.340711-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_errors_su_151.sdi to /var/lib/mysql//performance_schema/events_errors_su_151.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.340804-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_errors_su_151.sdi to /var/lib/mysql//performance_schema/events_errors_su_151.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.340873-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_su_124.sdi to /var/lib/mysql//performance_schema/events_stages_su_124.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.341012-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_su_124.sdi to /var/lib/mysql//performance_schema/events_stages_su_124.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.341091-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/file_summary_by__103.sdi to /var/lib/mysql//performance_schema/file_summary_by__103.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.341209-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/file_summary_by__103.sdi to /var/lib/mysql//performance_schema/file_summary_by__103.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.341281-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_appl_175.sdi to /var/lib/mysql//performance_schema/replication_appl_175.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.341375-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_appl_175.sdi to /var/lib/mysql//performance_schema/replication_appl_175.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.341444-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_128.sdi to /var/lib/mysql//performance_schema/events_statement_128.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.341538-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_128.sdi to /var/lib/mysql//performance_schema/events_statement_128.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.341606-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/table_io_waits_s_116.sdi to /var/lib/mysql//performance_schema/table_io_waits_s_116.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.341700-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/table_io_waits_s_116.sdi to /var/lib/mysql//performance_schema/table_io_waits_s_116.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.341770-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_su_127.sdi to /var/lib/mysql//performance_schema/events_stages_su_127.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.341864-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_su_127.sdi to /var/lib/mysql//performance_schema/events_stages_su_127.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.341932-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/session_account__160.sdi to /var/lib/mysql//performance_schema/session_account__160.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.342025-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/session_account__160.sdi to /var/lib/mysql//performance_schema/session_account__160.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.342094-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_appl_174.sdi to /var/lib/mysql//performance_schema/replication_appl_174.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.342187-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_appl_174.sdi to /var/lib/mysql//performance_schema/replication_appl_174.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.342258-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/setup_actors_111.sdi to /var/lib/mysql//performance_schema/setup_actors_111.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.342350-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/setup_actors_111.sdi to /var/lib/mysql//performance_schema/setup_actors_111.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.342429-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_errors_su_150.sdi to /var/lib/mysql//performance_schema/events_errors_su_150.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.342526-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_errors_su_150.sdi to /var/lib/mysql//performance_schema/events_errors_su_150.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.342596-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_sum_100.sdi to /var/lib/mysql//performance_schema/events_waits_sum_100.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.342691-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_sum_100.sdi to /var/lib/mysql//performance_schema/events_waits_sum_100.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.342759-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/status_by_user_189.sdi to /var/lib/mysql//performance_schema/status_by_user_189.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.342853-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/status_by_user_189.sdi to /var/lib/mysql//performance_schema/status_by_user_189.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.342922-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_grou_178.sdi to /var/lib/mysql//performance_schema/replication_grou_178.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.343017-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_grou_178.sdi to /var/lib/mysql//performance_schema/replication_grou_178.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.343097-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/tls_channel_stat_199.sdi to /var/lib/mysql//performance_schema/tls_channel_stat_199.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.343195-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/tls_channel_stat_199.sdi to /var/lib/mysql//performance_schema/tls_channel_stat_199.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.343265-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_grou_172.sdi to /var/lib/mysql//performance_schema/replication_grou_172.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.343360-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_grou_172.sdi to /var/lib/mysql//performance_schema/replication_grou_172.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.343428-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/memory_summary_b_163.sdi to /var/lib/mysql//performance_schema/memory_summary_b_163.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.343523-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/memory_summary_b_163.sdi to /var/lib/mysql//performance_schema/memory_summary_b_163.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.343591-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/performance_time_108.sdi to /var/lib/mysql//performance_schema/performance_time_108.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.343685-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/performance_time_108.sdi to /var/lib/mysql//performance_schema/performance_time_108.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.343752-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/global_variables_193.sdi to /var/lib/mysql//performance_schema/global_variables_193.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.343847-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/global_variables_193.sdi to /var/lib/mysql//performance_schema/global_variables_193.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.343916-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_138.sdi to /var/lib/mysql//performance_schema/events_statement_138.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.344013-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_138.sdi to /var/lib/mysql//performance_schema/events_statement_138.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.344083-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/hosts_155.sdi to /var/lib/mysql//performance_schema/hosts_155.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.344178-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/hosts_155.sdi to /var/lib/mysql//performance_schema/hosts_155.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.344256-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/setup_consumers_112.sdi to /var/lib/mysql//performance_schema/setup_consumers_112.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.344352-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/setup_consumers_112.sdi to /var/lib/mysql//performance_schema/setup_consumers_112.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.344421-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_su_125.sdi to /var/lib/mysql//performance_schema/events_stages_su_125.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.344516-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_su_125.sdi to /var/lib/mysql//performance_schema/events_stages_su_125.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.344585-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/user_variables_b_185.sdi to /var/lib/mysql//performance_schema/user_variables_b_185.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.344680-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/user_variables_b_185.sdi to /var/lib/mysql//performance_schema/user_variables_b_185.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.344748-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_137.sdi to /var/lib/mysql//performance_schema/events_statement_137.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.344844-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_137.sdi to /var/lib/mysql//performance_schema/events_statement_137.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.344911-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_su_126.sdi to /var/lib/mysql//performance_schema/events_stages_su_126.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.345060-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_su_126.sdi to /var/lib/mysql//performance_schema/events_stages_su_126.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.345165-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/binary_log_trans_198.sdi to /var/lib/mysql//performance_schema/binary_log_trans_198.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.345266-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/binary_log_trans_198.sdi to /var/lib/mysql//performance_schema/binary_log_trans_198.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.345339-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/socket_summary_b_157.sdi to /var/lib/mysql//performance_schema/socket_summary_b_157.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.345438-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/socket_summary_b_157.sdi to /var/lib/mysql//performance_schema/socket_summary_b_157.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.345508-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_appl_180.sdi to /var/lib/mysql//performance_schema/replication_appl_180.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.345605-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_appl_180.sdi to /var/lib/mysql//performance_schema/replication_appl_180.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.345673-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_sum_99.sdi to /var/lib/mysql//performance_schema/events_waits_sum_99.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.345769-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_sum_99.sdi to /var/lib/mysql//performance_schema/events_waits_sum_99.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.345839-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/keyring_keys_161.sdi to /var/lib/mysql//performance_schema/keyring_keys_161.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.345934-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/keyring_keys_161.sdi to /var/lib/mysql//performance_schema/keyring_keys_161.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.346003-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/session_connect__159.sdi to /var/lib/mysql//performance_schema/session_connect__159.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.346101-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/session_connect__159.sdi to /var/lib/mysql//performance_schema/session_connect__159.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.346184-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/global_status_190.sdi to /var/lib/mysql//performance_schema/global_status_190.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.346282-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/global_status_190.sdi to /var/lib/mysql//performance_schema/global_status_190.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.346351-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/metadata_locks_168.sdi to /var/lib/mysql//performance_schema/metadata_locks_168.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.346449-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/metadata_locks_168.sdi to /var/lib/mysql//performance_schema/metadata_locks_168.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.346521-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/status_by_host_187.sdi to /var/lib/mysql//performance_schema/status_by_host_187.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.346618-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/status_by_host_187.sdi to /var/lib/mysql//performance_schema/status_by_host_187.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.346688-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/table_handles_167.sdi to /var/lib/mysql//performance_schema/table_handles_167.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.346786-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/table_handles_167.sdi to /var/lib/mysql//performance_schema/table_handles_167.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.346856-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/error_log_92.sdi to /var/lib/mysql//performance_schema/error_log_92.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.346954-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/error_log_92.sdi to /var/lib/mysql//performance_schema/error_log_92.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.347037-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_appl_177.sdi to /var/lib/mysql//performance_schema/replication_appl_177.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.347139-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_appl_177.sdi to /var/lib/mysql//performance_schema/replication_appl_177.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.347209-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_136.sdi to /var/lib/mysql//performance_schema/events_statement_136.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.347310-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_136.sdi to /var/lib/mysql//performance_schema/events_statement_136.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.347381-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_sum_101.sdi to /var/lib/mysql//performance_schema/events_waits_sum_101.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.347483-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_sum_101.sdi to /var/lib/mysql//performance_schema/events_waits_sum_101.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.347554-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_errors_su_149.sdi to /var/lib/mysql//performance_schema/events_errors_su_149.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.347656-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_errors_su_149.sdi to /var/lib/mysql//performance_schema/events_errors_su_149.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.347728-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/users_153.sdi to /var/lib/mysql//performance_schema/users_153.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.347827-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/users_153.sdi to /var/lib/mysql//performance_schema/users_153.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.347900-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_142.sdi to /var/lib/mysql//performance_schema/events_transacti_142.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.348010-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_142.sdi to /var/lib/mysql//performance_schema/events_transacti_142.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.348093-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_su_123.sdi to /var/lib/mysql//performance_schema/events_stages_su_123.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.348198-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_su_123.sdi to /var/lib/mysql//performance_schema/events_stages_su_123.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.348279-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_141.sdi to /var/lib/mysql//performance_schema/events_transacti_141.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.348387-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_141.sdi to /var/lib/mysql//performance_schema/events_transacti_141.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.348458-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/data_lock_waits_170.sdi to /var/lib/mysql//performance_schema/data_lock_waits_170.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.348559-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/data_lock_waits_170.sdi to /var/lib/mysql//performance_schema/data_lock_waits_170.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.348630-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_147.sdi to /var/lib/mysql//performance_schema/events_transacti_147.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.348736-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_147.sdi to /var/lib/mysql//performance_schema/events_transacti_147.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.348815-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_135.sdi to /var/lib/mysql//performance_schema/events_statement_135.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.348921-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_135.sdi to /var/lib/mysql//performance_schema/events_statement_135.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.349013-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_hi_121.sdi to /var/lib/mysql//performance_schema/events_stages_hi_121.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.349142-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_hi_121.sdi to /var/lib/mysql//performance_schema/events_stages_hi_121.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.349221-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/variables_info_195.sdi to /var/lib/mysql//performance_schema/variables_info_195.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.349325-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/variables_info_195.sdi to /var/lib/mysql//performance_schema/variables_info_195.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.349398-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/variables_by_thr_192.sdi to /var/lib/mysql//performance_schema/variables_by_thr_192.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.349506-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/variables_by_thr_192.sdi to /var/lib/mysql//performance_schema/variables_by_thr_192.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.349578-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_sum_96.sdi to /var/lib/mysql//performance_schema/events_waits_sum_96.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.349678-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_sum_96.sdi to /var/lib/mysql//performance_schema/events_waits_sum_96.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.349752-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_his_95.sdi to /var/lib/mysql//performance_schema/events_waits_his_95.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.349852-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_his_95.sdi to /var/lib/mysql//performance_schema/events_waits_his_95.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.349925-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_cur_93.sdi to /var/lib/mysql//performance_schema/events_waits_cur_93.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.350025-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_cur_93.sdi to /var/lib/mysql//performance_schema/events_waits_cur_93.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.350108-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_140.sdi to /var/lib/mysql//performance_schema/events_transacti_140.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.350212-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_140.sdi to /var/lib/mysql//performance_schema/events_transacti_140.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.350284-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/memory_summary_b_166.sdi to /var/lib/mysql//performance_schema/memory_summary_b_166.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.350387-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/memory_summary_b_166.sdi to /var/lib/mysql//performance_schema/memory_summary_b_166.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.350457-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/file_instances_102.sdi to /var/lib/mysql//performance_schema/file_instances_102.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.350558-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/file_instances_102.sdi to /var/lib/mysql//performance_schema/file_instances_102.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.350629-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_sum_98.sdi to /var/lib/mysql//performance_schema/events_waits_sum_98.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.350729-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_sum_98.sdi to /var/lib/mysql//performance_schema/events_waits_sum_98.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.350800-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_144.sdi to /var/lib/mysql//performance_schema/events_transacti_144.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.350903-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_144.sdi to /var/lib/mysql//performance_schema/events_transacti_144.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.350977-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_appl_179.sdi to /var/lib/mysql//performance_schema/replication_appl_179.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.351085-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_appl_179.sdi to /var/lib/mysql//performance_schema/replication_appl_179.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.351166-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/host_cache_105.sdi to /var/lib/mysql//performance_schema/host_cache_105.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.351268-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/host_cache_105.sdi to /var/lib/mysql//performance_schema/host_cache_105.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.351346-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_134.sdi to /var/lib/mysql//performance_schema/events_statement_134.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.351450-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_134.sdi to /var/lib/mysql//performance_schema/events_statement_134.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.351522-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/prepared_stateme_184.sdi to /var/lib/mysql//performance_schema/prepared_stateme_184.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.351624-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/prepared_stateme_184.sdi to /var/lib/mysql//performance_schema/prepared_stateme_184.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.351696-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/memory_summary_g_162.sdi to /var/lib/mysql//performance_schema/memory_summary_g_162.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.351799-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/memory_summary_g_162.sdi to /var/lib/mysql//performance_schema/memory_summary_g_162.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.351867-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./ib_buffer_pool to /var/lib/mysql//ib_buffer_pool\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.351956-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./ib_buffer_pool to /var/lib/mysql//ib_buffer_pool\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:57:19.430346-00:00 0 [Note] [MY-011825] [Xtrabackup] completed OK!\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"---- Starting the MySQL server used for post-processing ----\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:19.845747Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:19.845779Z 0 [Warning] [MY-011068] [Server] The syntax 'wsrep_slave_threads' is deprecated and will be removed in a future release. Please use wsrep_applier_threads instead.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:19.845808Z 0 [Warning] [MY-011068] [Server] The syntax 'skip_slave_start' is deprecated and will be removed in a future release. Please use skip_replica_start instead.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:19.847774Z 0 [Warning] [MY-010097] [Server] Insecure configuration for --secure-log-path: Current value does not restrict location of generated files. Consider setting it to a valid, non-empty path.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:19.847817Z 0 [Warning] [MY-000000] [WSREP] Node is not a cluster node. Disabling pxc_strict_mode\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:19.848464Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.32-24.2) starting as process 1052\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:19.852172Z 0 [Warning] [MY-010068] [Server] CA certificate /etc/mysql/ssl-internal/ca.crt is self signed.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:19.852202Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:19.869145Z 0 [Warning] [MY-010075] [Server] No existing UUID has been found, so we assume that this is the first time that this server has been started. Generating a new UUID: fee72d53-c739-11ee-a6aa-b226ed62daa0.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:19.880224Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:20.191077Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:20.413348Z 1 [Note] [MY-000000] [WSREP] wsrep_init_schema_and_SR (nil)\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:20.436896Z 1 [System] [MY-000000] [WSREP] PXC upgrade completed successfully\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:20.530424Z 0 [System] [MY-010229] [Server] Starting XA crash recovery...\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:20.553558Z 0 [System] [MY-010232] [Server] XA crash recovery finished.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:20.679458Z 0 [Warning] [MY-010068] [Server] CA certificate /etc/mysql/ssl-internal/ca.crt is self signed.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:20.679537Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:20.691527Z 0 [Warning] [MY-013595] [Server] Failed to initialize TLS for channel: mysql_admin. See below for the description of exact issue.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:20.691580Z 0 [Warning] [MY-010069] [Server] Failed to set up SSL because of the following SSL library error: SSL context is not usable without certificate and private key\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:20.691594Z 0 [System] [MY-013603] [Server] No TLS configuration was given for channel mysql_admin; re-using TLS configuration of channel mysql_main.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:20.760595Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/tmp' in the path is accessible to all OS users. Consider choosing a different directory.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:20.797732Z 0 [Note] [MY-000000] [WSREP] Initialized wsrep sidno 3\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:20.797796Z 0 [Note] [MY-000000] [Galera] Loading provider none initial position: 00000000-0000-0000-0000-000000000000:-1\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:20.797809Z 0 [Note] [MY-000000] [Galera] wsrep_load(): loading provider library 'none'\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:20.816555Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Socket: /var/lib/mysql/mysqlx.sock\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:20.816798Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.32-24.2'  socket: '/tmp/upgrd.zsNp/my.sock'  port: 0  Percona XtraDB Cluster (GPL), Release rel24, Revision 2119e75, WSREP version 26.1.4.3.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:21.628617Z 11 [System] [MY-013172] [Server] Received SHUTDOWN from user mysql.pxc.sst.user. Shutting down mysqld (Version: 8.0.32-24.2).\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:23.167889Z 0 [Note] [MY-000000] [WSREP-SST] ...........post-processing done\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:23.171382Z 0 [Note] [MY-000000] [WSREP-SST] Galera co-ords from recovery: 103be6ae-c738-11ee-95d1-526d43d08e41:42\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:23.195129Z 3 [Note] [MY-000000] [Galera] Processing SST received\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:23.195192Z 3 [Note] [MY-000000] [WSREP] Server status change joiner -> initializing\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:23.195228Z 3 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:23.206297Z 4 [System] [MY-013576] [InnoDB] InnoDB initialization has started.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:23.531080Z 4 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:23.749995Z 4 [Note] [MY-000000] [WSREP] wsrep_init_schema_and_SR (nil)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:23.779297Z 4 [System] [MY-000000] [WSREP] PXC upgrade completed successfully\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.090736Z 0 [Warning] [MY-010068] [Server] CA certificate /etc/mysql/ssl-internal/ca.crt is self signed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.090824Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.106051Z 0 [Warning] [MY-013595] [Server] Failed to initialize TLS for channel: mysql_admin. See below for the description of exact issue.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.106130Z 0 [Warning] [MY-010069] [Server] Failed to set up SSL because of the following SSL library error: SSL context is not usable without certificate and private key\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.106144Z 0 [System] [MY-013603] [Server] No TLS configuration was given for channel mysql_admin; re-using TLS configuration of channel mysql_main.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.113177Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/var/lib/mysql' in the path is accessible to all OS users. Consider choosing a different directory.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.141181Z 0 [Note] [MY-000000] [WSREP] Initialized wsrep sidno 2\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.141254Z 0 [Note] [MY-000000] [Galera] Server initialized\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.141277Z 0 [Note] [MY-000000] [WSREP] Server status change initializing -> initialized\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.141313Z 0 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.141411Z 3 [Note] [MY-000000] [Galera] Recovered position from storage: 103be6ae-c738-11ee-95d1-526d43d08e41:42\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.141460Z 3 [Note] [MY-000000] [WSREP] Server status change initialized -> joined\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.141478Z 3 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.141907Z 10 [Note] [MY-000000] [WSREP] Starting applier thread 10\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.143403Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Bind-address: '::' port: 33060, socket: /var/lib/mysql/mysqlx.sock\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.143582Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.32-24.2'  socket: '/tmp/mysql.sock'  port: 3306  Percona XtraDB Cluster (GPL), Release rel24, Revision 2119e75, WSREP version 26.1.4.3.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.143623Z 0 [System] [MY-013292] [Server] Admin interface ready for connections, address: '10.42.1.10'  port: 33062\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.146335Z 3 [Note] [MY-000000] [Galera] Recovered view from SST:\n  id: 103be6ae-c738-11ee-95d1-526d43d08e41:42\n  status: primary\n  protocol_version: 4\n  capabilities: MULTI-MASTER, CERTIFICATION, PARALLEL_APPLYING, REPLAY, ISOLATION, PAUSE, CAUSAL_READ, INCREMENTAL_WS, UNORDERED, PREORDERED, STREAMING, NBO\n  final: no\n  own_index: 2\n  members(3):\n\t0: 213e9b53-c738-11ee-8c4d-03cb16bd2d32, cluster1-pxc-0\n\t1: 486b248f-c738-11ee-8ac6-0a8a79d0dabd, cluster1-pxc-1\n\t2: f36a12ae-c739-11ee-9dca-f75ddd6c940f, cluster1-pxc-2\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.146400Z 3 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.146622Z 12 [Note] [MY-000000] [WSREP] Recovered cluster id 103be6ae-c738-11ee-95d1-526d43d08e41\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.149904Z 3 [Note] [MY-000000] [Galera] SST received: 103be6ae-c738-11ee-95d1-526d43d08e41:42\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.149948Z 3 [System] [MY-000000] [WSREP] SST completed\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.150062Z 2 [Note] [MY-000000] [Galera]  str_proto_ver_: 3 sst_seqno_: 42 cc_seqno: 42 req->ist_len(): 65\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.150134Z 2 [Note] [MY-000000] [Galera] Installed new state from SST: 103be6ae-c738-11ee-95d1-526d43d08e41:42\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.156759Z 2 [Note] [MY-000000] [Galera] Cert. index preload up to 42\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.156859Z 0 [Note] [MY-000000] [Galera] ####### IST applying starts with 43\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.157078Z 0 [Note] [MY-000000] [Galera] ####### IST current seqno initialized to 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.157206Z 0 [Note] [MY-000000] [Galera] Receiving IST...  0.0% ( 0/19 events) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.157231Z 0 [Note] [MY-000000] [Galera] IST preload starting at 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.157347Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.157473Z 0 [Note] [MY-000000] [Galera] ####### Assign initial position for certification: 00000000-0000-0000-0000-000000000000:23, protocol version: 5\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.157906Z 0 [Note] [MY-000000] [Galera] ####### Passing IST CC 35, must_apply: 0, preload: true\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.157981Z 0 [Note] [MY-000000] [Galera] REPL Protocols: 10 (5)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158007Z 0 [Note] [MY-000000] [Galera] ####### Adjusting cert position: 34 -> 35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158063Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158166Z 0 [Note] [MY-000000] [Galera] Recording CC from preload: 35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158205Z 0 [Note] [MY-000000] [Galera] Lowest cert index boundary for CC from preload: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158227Z 0 [Note] [MY-000000] [Galera] Min available from gcache for CC from preload: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158300Z 0 [Note] [MY-000000] [Galera] ####### Passing IST CC 36, must_apply: 0, preload: true\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158348Z 0 [Note] [MY-000000] [Galera] REPL Protocols: 10 (5)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158369Z 0 [Note] [MY-000000] [Galera] ####### Adjusting cert position: 35 -> 36\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158402Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158443Z 0 [Note] [MY-000000] [Galera] Recording CC from preload: 36\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158465Z 0 [Note] [MY-000000] [Galera] Lowest cert index boundary for CC from preload: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158482Z 0 [Note] [MY-000000] [Galera] Min available from gcache for CC from preload: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158598Z 0 [Note] [MY-000000] [Galera] ####### Passing IST CC 39, must_apply: 0, preload: true\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158637Z 0 [Note] [MY-000000] [Galera] REPL Protocols: 10 (5)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158656Z 0 [Note] [MY-000000] [Galera] ####### Adjusting cert position: 38 -> 39\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158686Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158776Z 0 [Note] [MY-000000] [Galera] Recording CC from preload: 39\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158815Z 0 [Note] [MY-000000] [Galera] Lowest cert index boundary for CC from preload: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158837Z 0 [Note] [MY-000000] [Galera] Min available from gcache for CC from preload: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158908Z 0 [Note] [MY-000000] [Galera] ####### Passing IST CC 40, must_apply: 0, preload: true\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158955Z 0 [Note] [MY-000000] [Galera] REPL Protocols: 10 (5)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.158976Z 0 [Note] [MY-000000] [Galera] ####### Adjusting cert position: 39 -> 40\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.159054Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.159116Z 0 [Note] [MY-000000] [Galera] Recording CC from preload: 40\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.159138Z 0 [Note] [MY-000000] [Galera] Lowest cert index boundary for CC from preload: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.159156Z 0 [Note] [MY-000000] [Galera] Min available from gcache for CC from preload: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.159210Z 0 [Note] [MY-000000] [Galera] ####### Passing IST CC 41, must_apply: 0, preload: true\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.159246Z 0 [Note] [MY-000000] [Galera] REPL Protocols: 10 (5)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.159265Z 0 [Note] [MY-000000] [Galera] ####### Adjusting cert position: 40 -> 41\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.159338Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.159391Z 0 [Note] [MY-000000] [Galera] Recording CC from preload: 41\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.159411Z 0 [Note] [MY-000000] [Galera] Lowest cert index boundary for CC from preload: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.159428Z 0 [Note] [MY-000000] [Galera] Min available from gcache for CC from preload: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.159478Z 0 [Note] [MY-000000] [Galera] ####### Passing IST CC 42, must_apply: 0, preload: true\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.159520Z 0 [Note] [MY-000000] [Galera] REPL Protocols: 10 (5)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.159540Z 0 [Note] [MY-000000] [Galera] ####### Adjusting cert position: 41 -> 42\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.159609Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.159712Z 0 [Note] [MY-000000] [Galera] Recording CC from preload: 42\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.159751Z 0 [Note] [MY-000000] [Galera] Lowest cert index boundary for CC from preload: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.159774Z 0 [Note] [MY-000000] [Galera] Min available from gcache for CC from preload: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.159839Z 0 [Note] [MY-000000] [Galera] Receiving IST...100.0% (19/19 events) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.160432Z 2 [Note] [MY-000000] [Galera] IST received: 103be6ae-c738-11ee-95d1-526d43d08e41:42\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.160530Z 2 [Note] [MY-000000] [Galera] Recording CC from sst: 42\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.160555Z 2 [Note] [MY-000000] [Galera] Lowest cert index boundary for CC from sst: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.160576Z 2 [Note] [MY-000000] [Galera] Min available from gcache for CC from sst: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.161506Z 0 [Note] [MY-000000] [Galera] 2.0 (cluster1-pxc-2): State transfer from 1.0 (cluster1-pxc-1) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.161553Z 0 [Note] [MY-000000] [Galera] SST leaving flow control\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.161564Z 0 [Note] [MY-000000] [Galera] Shifting JOINER -> JOINED (TO: 42)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.161629Z 0 [Note] [MY-000000] [Galera] Processing event queue:... -nan% (0/0 events) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.162281Z 0 [Note] [MY-000000] [Galera] Member 2.0 (cluster1-pxc-2) synced with group.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.162344Z 0 [Note] [MY-000000] [Galera] Processing event queue:...100.0% (1/1 events) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.162369Z 0 [Note] [MY-000000] [Galera] Shifting JOINED -> SYNCED (TO: 42)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.162455Z 2 [Note] [MY-000000] [Galera] Server cluster1-pxc-2 synced with group\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.162501Z 2 [Note] [MY-000000] [WSREP] Server status change joined -> synced\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:24.162519Z 2 [Note] [MY-000000] [WSREP] Synchronized with group, ready for connections\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:57:23.055898Z 0 [System] [MY-010910] [Server] /usr/sbin/mysqld: Shutdown complete (mysqld 8.0.32-24.2)  Percona XtraDB Cluster (GPL), Release rel24, Revision 2119e75, WSREP version 26.1.4.3.\n---- Stopped the MySQL server used for post-processing ----\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:57:24.162533Z 2 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
++ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/fluent-bit/bin
++ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/fluent-bit/bin
++ '[' logrotate = logrotate ']'
++ [[ 1001 != 1001 ]]
++ exec go-cron '0 0 * * *' sh -c 'logrotate -s /opt/percona/logrotate/logrotate.status /opt/percona/logrotate/logrotate-mysql.conf;/usr/bin/find /var/lib/mysql/ -name GRA_*.log -mtime +7 -delete'
+new cron: 0 0 * * *
++ trap exit SIGTERM
++ '[' m = - ']'
++ CFG=/etc/mysql/node.cnf
++ wantHelp=
++ for arg in "$@"
++ case "$arg" in
+++ mysqld -V
+++ awk '{print $3}'
+++ awk -F. '{print $1"."$2}'
++ MYSQL_VERSION=8.0
+++ mysqld -V
+++ awk '{print $3}'
+++ awk -F. '{print $3}'
+++ awk -F- '{print $1}'
++ MYSQL_PATCH_VERSION=32
++ vault_secret=/etc/mysql/vault-keyring-secret/keyring_vault.conf
++ '[' -f /etc/mysql/vault-keyring-secret/keyring_vault.conf ']'
++ '[' -f /usr/lib64/mysql/plugin/binlog_utils_udf.so ']'
++ sed -i '/\[mysqld\]/a plugin_load="binlog_utils_udf=binlog_utils_udf.so"' /etc/mysql/node.cnf
++ sed -i '/\[mysqld\]/a gtid-mode=ON' /etc/mysql/node.cnf
++ sed -i '/\[mysqld\]/a enforce-gtid-consistency' /etc/mysql/node.cnf
++ grep -q '^progress=' /etc/mysql/node.cnf
++ sed -i 's|^progress=.*|progress=1|' /etc/mysql/node.cnf
++ grep -q '^\[sst\]' /etc/mysql/node.cnf
++ grep -q '^cpat=' /etc/mysql/node.cnf
++ sed '/^\[sst\]/a cpat=.*\\.pem$\\|.*init\\.ok$\\|.*galera\\.cache$\\|.*wsrep_recovery_verbose\\.log$\\|.*readiness-check\\.sh$\\|.*liveness-check\\.sh$\\|.*get-pxc-state$\\|.*sst_in_progress$\\|.*pmm-prerun\\.sh$\\|.*sst-xb-tmpdir$\\|.*\\.sst$\\|.*gvwstate\\.dat$\\|.*grastate\\.dat$\\|.*\\.err$\\|.*\\.log$\\|.*RPM_UPGRADE_MARKER$\\|.*RPM_UPGRADE_HISTORY$\\|.*pxc-entrypoint\\.sh$\\|.*unsafe-bootstrap\\.sh$\\|.*pxc-configure-pxc\\.sh\\|.*peer-list$\\|.*auth_plugin$' /etc/mysql/node.cnf
++ [[ 8.0 == \8\.\0 ]]
++ [[ 32 -ge 26 ]]
++ grep -q '^skip_replica_start=ON' /etc/mysql/node.cnf
++ sed -i '/\[mysqld\]/a skip_replica_start=ON' /etc/mysql/node.cnf
++ auth_plugin=caching_sha2_password
++ [[ -f /var/lib/mysql/auth_plugin ]]
++ [[ -z caching_sha2_password ]]
++ [[ 8.0 == \5\.\7 ]]
++ echo caching_sha2_password
++ sed -i /default_authentication_plugin/d /etc/mysql/node.cnf
++ [[ 8.0 == \8\.\0 ]]
++ [[ 32 -ge 27 ]]
++ sed -i '/\[mysqld\]/a authentication_policy=caching_sha2_password,,' /etc/mysql/node.cnf
++ file_env XTRABACKUP_PASSWORD xtrabackup xtrabackup
+Percona XtraDB Cluster: Finding peers
+2024/02/09 10:56:47 Peer finder enter
+2024/02/09 10:56:47 Determined Domain to be pxc.svc.cluster.local
+2024/02/09 10:56:47 Peer list updated
+was []
+now [10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local 10-42-1-10.cluster1-pxc-unready.pxc.svc.cluster.local 10-42-2-8.cluster1-pxc-unready.pxc.svc.cluster.local]
+2024/02/09 10:56:47 execing: /var/lib/mysql/pxc-configure-pxc.sh with stdin: 10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local
+10-42-1-10.cluster1-pxc-unready.pxc.svc.cluster.local
+10-42-2-8.cluster1-pxc-unready.pxc.svc.cluster.local
+2024/02/09 10:56:47 ++ hostname -I
+++ awk ' { print $1 } '
++ NODE_IP=10.42.1.10
+++ hostname -f
+++ cut -d. -f2
++ CLUSTER_NAME=cluster1-pxc
++ SERVER_NUM=2
++ SERVER_ID=32109362
+++ hostname -f
++ NODE_NAME=cluster1-pxc-2.cluster1-pxc.pxc.svc.cluster.local
++ NODE_PORT=3306
++ read -ra LINE
++ echo 'read line 10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local'
+read line 10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local
+++ getent hosts 10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local
+++ awk '{ print $1 }'
++ LINE_IP=10.42.0.5
++ '[' 10.42.0.5 '!=' 10.42.1.10 ']'
+++ mysql_root_exec 10.42.0.5 'select @@hostname'
+++ local server=10.42.0.5
+++ local 'query=select @@hostname'
++ LINE_HOST=cluster1-pxc-0
++ '[' -n cluster1-pxc-0 ']'
++ PEERS=("${PEERS[@]}" $LINE_HOST)
++ PEERS_FULL=("${PEERS_FULL[@]}" "$LINE_HOST.$CLUSTER_NAME")
++ read -ra LINE
++ echo 'read line 10-42-1-10.cluster1-pxc-unready.pxc.svc.cluster.local'
+read line 10-42-1-10.cluster1-pxc-unready.pxc.svc.cluster.local
+++ getent hosts 10-42-1-10.cluster1-pxc-unready.pxc.svc.cluster.local
+++ awk '{ print $1 }'
++ LINE_IP=10.42.1.10
++ '[' 10.42.1.10 '!=' 10.42.1.10 ']'
++ read -ra LINE
++ echo 'read line 10-42-2-8.cluster1-pxc-unready.pxc.svc.cluster.local'
+read line 10-42-2-8.cluster1-pxc-unready.pxc.svc.cluster.local
+++ getent hosts 10-42-2-8.cluster1-pxc-unready.pxc.svc.cluster.local
+++ awk '{ print $1 }'
++ LINE_IP=10.42.2.8
++ '[' 10.42.2.8 '!=' 10.42.1.10 ']'
+++ mysql_root_exec 10.42.2.8 'select @@hostname'
+++ local server=10.42.2.8
+++ local 'query=select @@hostname'
++ LINE_HOST=cluster1-pxc-1
++ '[' -n cluster1-pxc-1 ']'
++ PEERS=("${PEERS[@]}" $LINE_HOST)
++ PEERS_FULL=("${PEERS_FULL[@]}" "$LINE_HOST.$CLUSTER_NAME")
++ read -ra LINE
++ '[' 2 '!=' 0 ']'
+++ printf '%s\n' cluster1-pxc-0 cluster1-pxc-1 cluster1-pxc-2
+++ sort --version-sort
+++ uniq
+++ grep -v -- '-0$'
+++ tr '\n' ,
+++ sed 's/^,$//'
+++ sed '$d'
++ DONOR_ADDRESS=cluster1-pxc-1,
++ '[' 2 '!=' 0 ']'
+++ sed 's/,$//'
+++ printf '%s\n' cluster1-pxc-0.cluster1-pxc cluster1-pxc-1.cluster1-pxc
+++ tr '\n' ,
+++ sort --version-sort
++ WSREP_CLUSTER_ADDRESS=cluster1-pxc-0.cluster1-pxc,cluster1-pxc-1.cluster1-pxc
++ CFG=/etc/mysql/node.cnf
+++ mysqld -V
+++ awk '{print $3}'
+++ awk -F. '{print $1"."$2}'
++ MYSQL_VERSION=8.0
++ '[' 8.0 == 8.0 ']'
++ grep -E -q '^[#]?admin-address' /etc/mysql/node.cnf
++ sed '/^\[mysqld\]/a admin-address=\n' /etc/mysql/node.cnf
++ grep -E -q '^[#]?log_error_suppression_list' /etc/mysql/node.cnf
++ sed '/^\[mysqld\]/a log_error_suppression_list="MY-010055"\n' /etc/mysql/node.cnf
++ '[' yes == yes ']'
++ grep -E -q '^[#]?log-error' /etc/mysql/node.cnf
++ sed '/^\[mysqld\]/a log-error=/var/lib/mysql/mysqld-error.log\n' /etc/mysql/node.cnf
++ grep -E -q '^[#]?wsrep_sst_donor' /etc/mysql/node.cnf
++ sed '/^\[mysqld\]/a wsrep_sst_donor=\n' /etc/mysql/node.cnf
++ grep -E -q '^[#]?wsrep_node_incoming_address' /etc/mysql/node.cnf
++ grep -E -q '^[#]?wsrep_provider_options' /etc/mysql/node.cnf
++ sed '/^\[mysqld\]/a wsrep_provider_options="pc.weight=10"\n' /etc/mysql/node.cnf
++ sed -r 's|^[#]?server_id=.*$|server_id=32109362|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?coredumper$|coredumper|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?wsrep_node_address=.*$|wsrep_node_address=10.42.1.10|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?wsrep_cluster_name=.*$|wsrep_cluster_name=cluster1-pxc|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?wsrep_sst_donor=.*$|wsrep_sst_donor=cluster1-pxc-1,|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?wsrep_cluster_address=.*$|wsrep_cluster_address=gcomm://cluster1-pxc-0.cluster1-pxc,cluster1-pxc-1.cluster1-pxc|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?wsrep_node_incoming_address=.*$|wsrep_node_incoming_address=cluster1-pxc-2.cluster1-pxc.pxc.svc.cluster.local:3306|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?admin-address=.*$|admin-address=10.42.1.10|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?extra_max_connections=.*$|extra_max_connections=100|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?extra_port=.*$|extra_port=33062|' /etc/mysql/node.cnf
++ CA=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
++ '[' -f /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt ']'
++ SSL_DIR=/etc/mysql/ssl
++ '[' -f /etc/mysql/ssl/ca.crt ']'
++ CA=/etc/mysql/ssl/ca.crt
++ SSL_INTERNAL_DIR=/etc/mysql/ssl-internal
++ '[' -f /etc/mysql/ssl-internal/ca.crt ']'
++ CA=/etc/mysql/ssl-internal/ca.crt
++ KEY=/etc/mysql/ssl/tls.key
++ CERT=/etc/mysql/ssl/tls.crt
++ '[' -f /etc/mysql/ssl-internal/tls.key -a -f /etc/mysql/ssl-internal/tls.crt ']'
++ KEY=/etc/mysql/ssl-internal/tls.key
++ CERT=/etc/mysql/ssl-internal/tls.crt
++ '[' -f /etc/mysql/ssl-internal/ca.crt -a -f /etc/mysql/ssl-internal/tls.key -a -f /etc/mysql/ssl-internal/tls.crt ']'
++ sed '/^\[mysqld\]/a pxc-encrypt-cluster-traffic=ON\nssl-ca=/etc/mysql/ssl-internal/ca.crt\nssl-key=/etc/mysql/ssl-internal/tls.key\nssl-cert=/etc/mysql/ssl-internal/tls.crt' /etc/mysql/node.cnf
+2024/02/09 10:56:48 Peer finder exiting
+Cluster address set to: cluster1-pxc-0.cluster1-pxc,cluster1-pxc-1.cluster1-pxc
+/usr/sbin/mysqld  Ver 8.0.32-24.2 for Linux on x86_64 (Percona XtraDB Cluster (GPL), Release rel24, Revision 2119e75, WSREP version 26.1.4.3)
+[mysqld]
+pxc-encrypt-cluster-traffic=ON
+ssl-ca=/etc/mysql/ssl-internal/ca.crt
+ssl-key=/etc/mysql/ssl-internal/tls.key
+ssl-cert=/etc/mysql/ssl-internal/tls.crt
+wsrep_provider_options="pc.weight=10"
+
+wsrep_sst_donor=cluster1-pxc-1,
+
+log-error=/var/lib/mysql/mysqld-error.log
+
+log_error_suppression_list="MY-010055"
+
+admin-address=10.42.1.10
+
+authentication_policy=caching_sha2_password,,
+skip_replica_start=ON
+enforce-gtid-consistency
+gtid-mode=ON
+plugin_load="binlog_utils_udf=binlog_utils_udf.so"
+
+datadir=/var/lib/mysql
+socket=/tmp/mysql.sock
+skip-host-cache
+
+coredumper
+server_id=32109362
+binlog_format=ROW
+default_storage_engine=InnoDB
+
+innodb_flush_log_at_trx_commit  = 0
+innodb_flush_method             = O_DIRECT
+innodb_file_per_table           = 1
+innodb_autoinc_lock_mode=2
+
+bind_address = 0.0.0.0
+
+wsrep_slave_threads=2
+wsrep_cluster_address=gcomm://cluster1-pxc-0.cluster1-pxc,cluster1-pxc-1.cluster1-pxc
+wsrep_provider=/usr/lib64/galera4/libgalera_smm.so
+
+wsrep_cluster_name=cluster1-pxc
+wsrep_node_address=10.42.1.10
+wsrep_node_incoming_address=cluster1-pxc-2.cluster1-pxc.pxc.svc.cluster.local:3306
+
+wsrep_sst_method=xtrabackup-v2
+
+[client]
+socket=/tmp/mysql.sock
+
+[sst]
+cpat=.*\.pem$\|.*init\.ok$\|.*galera\.cache$\|.*wsrep_recovery_verbose\.log$\|.*readiness-check\.sh$\|.*liveness-check\.sh$\|.*get-pxc-state$\|.*sst_in_progress$\|.*pmm-prerun\.sh$\|.*sst-xb-tmpdir$\|.*\.sst$\|.*gvwstate\.dat$\|.*grastate\.dat$\|.*\.err$\|.*\.log$\|.*RPM_UPGRADE_MARKER$\|.*RPM_UPGRADE_HISTORY$\|.*pxc-entrypoint\.sh$\|.*unsafe-bootstrap\.sh$\|.*pxc-configure-pxc\.sh\|.*peer-list$\|.*auth_plugin$
+progress=1
+
++ [[ -z node:10-42-2-8.cluster1-pxc-unready.pxc.svc.cluster.local:wsrep_ready:ON:wsrep_connected:ON:wsrep_local_state_comment:Synced:wsrep_cluster_status:Primary ]]
++ [[ -z node:10-42-2-8.cluster1-pxc-unready.pxc.svc.cluster.local:wsrep_ready:ON:wsrep_connected:ON:wsrep_local_state_comment:Synced:wsrep_cluster_status:Primary ]]
++ [[ -z node:10-42-2-8.cluster1-pxc-unready.pxc.svc.cluster.local:wsrep_ready:ON:wsrep_connected:ON:wsrep_local_state_comment:Synced:wsrep_cluster_status:Primary ]]
++ test -e /opt/percona/hookscript/hook.sh
++ exec mysqld

--- a/src/go/pt-galera-log-explainer/tests/logs/operator_split/node2.log
+++ b/src/go/pt-galera-log-explainer/tests/logs/operator_split/node2.log
@@ -1,0 +1,802 @@
++ trap exit SIGTERM
++ '[' m = - ']'
++ CFG=/etc/mysql/node.cnf
++ wantHelp=
++ for arg in "$@"
++ case "$arg" in
+++ mysqld -V
+++ awk '{print $3}'
+++ awk -F. '{print $1"."$2}'
++ MYSQL_VERSION=8.0
+++ mysqld -V
+++ awk '{print $3}'
+++ awk -F. '{print $3}'
+++ awk -F- '{print $1}'
++ MYSQL_PATCH_VERSION=32
++ vault_secret=/etc/mysql/vault-keyring-secret/keyring_vault.conf
++ '[' -f /etc/mysql/vault-keyring-secret/keyring_vault.conf ']'
++ '[' -f /usr/lib64/mysql/plugin/binlog_utils_udf.so ']'
++ sed -i '/\[mysqld\]/a plugin_load="binlog_utils_udf=binlog_utils_udf.so"' /etc/mysql/node.cnf
++ sed -i '/\[mysqld\]/a gtid-mode=ON' /etc/mysql/node.cnf
++ sed -i '/\[mysqld\]/a enforce-gtid-consistency' /etc/mysql/node.cnf
++ grep -q '^progress=' /etc/mysql/node.cnf
++ sed -i 's|^progress=.*|progress=1|' /etc/mysql/node.cnf
++ grep -q '^\[sst\]' /etc/mysql/node.cnf
++ grep -q '^cpat=' /etc/mysql/node.cnf
++ sed '/^\[sst\]/a cpat=.*\\.pem$\\|.*init\\.ok$\\|.*galera\\.cache$\\|.*wsrep_recovery_verbose\\.log$\\|.*readiness-check\\.sh$\\|.*liveness-check\\.sh$\\|.*get-pxc-state$\\|.*sst_in_progress$\\|.*pmm-prerun\\.sh$\\|.*sst-xb-tmpdir$\\|.*\\.sst$\\|.*gvwstate\\.dat$\\|.*grastate\\.dat$\\|.*\\.err$\\|.*\\.log$\\|.*RPM_UPGRADE_MARKER$\\|.*RPM_UPGRADE_HISTORY$\\|.*pxc-entrypoint\\.sh$\\|.*unsafe-bootstrap\\.sh$\\|.*pxc-configure-pxc\\.sh\\|.*peer-list$\\|.*auth_plugin$' /etc/mysql/node.cnf
++ [[ 8.0 == \8\.\0 ]]
++ [[ 32 -ge 26 ]]
++ grep -q '^skip_replica_start=ON' /etc/mysql/node.cnf
++ sed -i '/\[mysqld\]/a skip_replica_start=ON' /etc/mysql/node.cnf
++ auth_plugin=caching_sha2_password
++ [[ -f /var/lib/mysql/auth_plugin ]]
++ [[ -z caching_sha2_password ]]
++ [[ 8.0 == \5\.\7 ]]
++ echo caching_sha2_password
++ sed -i /default_authentication_plugin/d /etc/mysql/node.cnf
++ [[ 8.0 == \8\.\0 ]]
++ [[ 32 -ge 27 ]]
++ sed -i '/\[mysqld\]/a authentication_policy=caching_sha2_password,,' /etc/mysql/node.cnf
++ file_env XTRABACKUP_PASSWORD xtrabackup xtrabackup
+Percona XtraDB Cluster: Finding peers
+2024/02/09 10:46:22 Peer finder enter
+2024/02/09 10:46:22 Determined Domain to be pxc.svc.cluster.local
+2024/02/09 10:46:22 Peer list updated
+was []
+now [10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local 10-42-1-6.cluster1-pxc-unready.pxc.svc.cluster.local 10-42-2-8.cluster1-pxc-unready.pxc.svc.cluster.local]
+2024/02/09 10:46:22 execing: /var/lib/mysql/pxc-configure-pxc.sh with stdin: 10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local
+10-42-1-6.cluster1-pxc-unready.pxc.svc.cluster.local
+10-42-2-8.cluster1-pxc-unready.pxc.svc.cluster.local
+2024/02/09 10:46:22 ++ hostname -I
+++ awk ' { print $1 } '
++ NODE_IP=10.42.1.6
+++ hostname -f
+++ cut -d. -f2
++ CLUSTER_NAME=cluster1-pxc
++ SERVER_NUM=2
++ SERVER_ID=32109362
+++ hostname -f
++ NODE_NAME=cluster1-pxc-2.cluster1-pxc.pxc.svc.cluster.local
++ NODE_PORT=3306
++ read -ra LINE
++ echo 'read line 10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local'
+read line 10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local
+++ getent hosts 10-42-0-5.cluster1-pxc-unready.pxc.svc.cluster.local
+++ awk '{ print $1 }'
++ LINE_IP=10.42.0.5
++ '[' 10.42.0.5 '!=' 10.42.1.6 ']'
+++ mysql_root_exec 10.42.0.5 'select @@hostname'
+++ local server=10.42.0.5
+++ local 'query=select @@hostname'
++ LINE_HOST=cluster1-pxc-0
++ '[' -n cluster1-pxc-0 ']'
++ PEERS=("${PEERS[@]}" $LINE_HOST)
++ PEERS_FULL=("${PEERS_FULL[@]}" "$LINE_HOST.$CLUSTER_NAME")
++ read -ra LINE
++ echo 'read line 10-42-1-6.cluster1-pxc-unready.pxc.svc.cluster.local'
+read line 10-42-1-6.cluster1-pxc-unready.pxc.svc.cluster.local
+++ getent hosts 10-42-1-6.cluster1-pxc-unready.pxc.svc.cluster.local
+++ awk '{ print $1 }'
++ LINE_IP=10.42.1.6
++ '[' 10.42.1.6 '!=' 10.42.1.6 ']'
++ read -ra LINE
++ echo 'read line 10-42-2-8.cluster1-pxc-unready.pxc.svc.cluster.local'
+read line 10-42-2-8.cluster1-pxc-unready.pxc.svc.cluster.local
+++ awk '{ print $1 }'
+++ getent hosts 10-42-2-8.cluster1-pxc-unready.pxc.svc.cluster.local
++ LINE_IP=10.42.2.8
++ '[' 10.42.2.8 '!=' 10.42.1.6 ']'
+++ mysql_root_exec 10.42.2.8 'select @@hostname'
+++ local server=10.42.2.8
+++ local 'query=select @@hostname'
++ LINE_HOST=cluster1-pxc-1
++ '[' -n cluster1-pxc-1 ']'
++ PEERS=("${PEERS[@]}" $LINE_HOST)
++ PEERS_FULL=("${PEERS_FULL[@]}" "$LINE_HOST.$CLUSTER_NAME")
++ read -ra LINE
++ '[' 2 '!=' 0 ']'
+++ printf '%s\n' cluster1-pxc-0 cluster1-pxc-1 cluster1-pxc-2
+++ sort --version-sort
+++ uniq
+++ grep -v -- '-0$'
+++ sed '$d'
+++ tr '\n' ,
+++ sed 's/^,$//'
++ DONOR_ADDRESS=cluster1-pxc-1,
++ '[' 2 '!=' 0 ']'
+++ printf '%s\n' cluster1-pxc-0.cluster1-pxc cluster1-pxc-1.cluster1-pxc
+++ sort --version-sort
+++ tr '\n' ,
+++ sed 's/,$//'
++ WSREP_CLUSTER_ADDRESS=cluster1-pxc-0.cluster1-pxc,cluster1-pxc-1.cluster1-pxc
++ CFG=/etc/mysql/node.cnf
+++ mysqld -V
+++ awk '{print $3}'
+++ awk -F. '{print $1"."$2}'
++ MYSQL_VERSION=8.0
++ '[' 8.0 == 8.0 ']'
++ grep -E -q '^[#]?admin-address' /etc/mysql/node.cnf
++ sed '/^\[mysqld\]/a admin-address=\n' /etc/mysql/node.cnf
++ grep -E -q '^[#]?log_error_suppression_list' /etc/mysql/node.cnf
++ sed '/^\[mysqld\]/a log_error_suppression_list="MY-010055"\n' /etc/mysql/node.cnf
++ '[' yes == yes ']'
++ grep -E -q '^[#]?log-error' /etc/mysql/node.cnf
++ sed '/^\[mysqld\]/a log-error=/var/lib/mysql/mysqld-error.log\n' /etc/mysql/node.cnf
++ grep -E -q '^[#]?wsrep_sst_donor' /etc/mysql/node.cnf
++ sed '/^\[mysqld\]/a wsrep_sst_donor=\n' /etc/mysql/node.cnf
++ grep -E -q '^[#]?wsrep_node_incoming_address' /etc/mysql/node.cnf
++ grep -E -q '^[#]?wsrep_provider_options' /etc/mysql/node.cnf
++ sed '/^\[mysqld\]/a wsrep_provider_options="pc.weight=10"\n' /etc/mysql/node.cnf
++ sed -r 's|^[#]?server_id=.*$|server_id=32109362|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?coredumper$|coredumper|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?wsrep_node_address=.*$|wsrep_node_address=10.42.1.6|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?wsrep_cluster_name=.*$|wsrep_cluster_name=cluster1-pxc|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?wsrep_sst_donor=.*$|wsrep_sst_donor=cluster1-pxc-1,|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?wsrep_cluster_address=.*$|wsrep_cluster_address=gcomm://cluster1-pxc-0.cluster1-pxc,cluster1-pxc-1.cluster1-pxc|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?wsrep_node_incoming_address=.*$|wsrep_node_incoming_address=cluster1-pxc-2.cluster1-pxc.pxc.svc.cluster.local:3306|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?admin-address=.*$|admin-address=10.42.1.6|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?extra_max_connections=.*$|extra_max_connections=100|' /etc/mysql/node.cnf
++ sed -r 's|^[#]?extra_port=.*$|extra_port=33062|' /etc/mysql/node.cnf
++ CA=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
++ '[' -f /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt ']'
++ SSL_DIR=/etc/mysql/ssl
++ '[' -f /etc/mysql/ssl/ca.crt ']'
++ CA=/etc/mysql/ssl/ca.crt
++ SSL_INTERNAL_DIR=/etc/mysql/ssl-internal
++ '[' -f /etc/mysql/ssl-internal/ca.crt ']'
++ CA=/etc/mysql/ssl-internal/ca.crt
++ KEY=/etc/mysql/ssl/tls.key
++ CERT=/etc/mysql/ssl/tls.crt
++ '[' -f /etc/mysql/ssl-internal/tls.key -a -f /etc/mysql/ssl-internal/tls.crt ']'
++ KEY=/etc/mysql/ssl-internal/tls.key
++ CERT=/etc/mysql/ssl-internal/tls.crt
++ '[' -f /etc/mysql/ssl-internal/ca.crt -a -f /etc/mysql/ssl-internal/tls.key -a -f /etc/mysql/ssl-internal/tls.crt ']'
++ sed '/^\[mysqld\]/a pxc-encrypt-cluster-traffic=ON\nssl-ca=/etc/mysql/ssl-internal/ca.crt\nssl-key=/etc/mysql/ssl-internal/tls.key\nssl-cert=/etc/mysql/ssl-internal/tls.crt' /etc/mysql/node.cnf
+2024/02/09 10:46:23 Peer finder exiting
+Cluster address set to: cluster1-pxc-0.cluster1-pxc,cluster1-pxc-1.cluster1-pxc
+/usr/sbin/mysqld  Ver 8.0.32-24.2 for Linux on x86_64 (Percona XtraDB Cluster (GPL), Release rel24, Revision 2119e75, WSREP version 26.1.4.3)
+[mysqld]
+pxc-encrypt-cluster-traffic=ON
+ssl-ca=/etc/mysql/ssl-internal/ca.crt
+ssl-key=/etc/mysql/ssl-internal/tls.key
+ssl-cert=/etc/mysql/ssl-internal/tls.crt
+wsrep_provider_options="pc.weight=10"
+
+wsrep_sst_donor=cluster1-pxc-1,
+
+log-error=/var/lib/mysql/mysqld-error.log
+
+log_error_suppression_list="MY-010055"
+
+admin-address=10.42.1.6
+
+authentication_policy=caching_sha2_password,,
+skip_replica_start=ON
+enforce-gtid-consistency
+gtid-mode=ON
+plugin_load="binlog_utils_udf=binlog_utils_udf.so"
+
+datadir=/var/lib/mysql
+socket=/tmp/mysql.sock
+skip-host-cache
+
+coredumper
+server_id=32109362
+binlog_format=ROW
+default_storage_engine=InnoDB
+
+innodb_flush_log_at_trx_commit  = 0
+innodb_flush_method             = O_DIRECT
+innodb_file_per_table           = 1
+innodb_autoinc_lock_mode=2
+
+bind_address = 0.0.0.0
+
+wsrep_slave_threads=2
+wsrep_cluster_address=gcomm://cluster1-pxc-0.cluster1-pxc,cluster1-pxc-1.cluster1-pxc
+wsrep_provider=/usr/lib64/galera4/libgalera_smm.so
+
+wsrep_cluster_name=cluster1-pxc
+wsrep_node_address=10.42.1.6
+wsrep_node_incoming_address=cluster1-pxc-2.cluster1-pxc.pxc.svc.cluster.local:3306
+
+wsrep_sst_method=xtrabackup-v2
+
+[client]
+socket=/tmp/mysql.sock
+
+[sst]
+cpat=.*\.pem$\|.*init\.ok$\|.*galera\.cache$\|.*wsrep_recovery_verbose\.log$\|.*readiness-check\.sh$\|.*liveness-check\.sh$\|.*get-pxc-state$\|.*sst_in_progress$\|.*pmm-prerun\.sh$\|.*sst-xb-tmpdir$\|.*\.sst$\|.*gvwstate\.dat$\|.*grastate\.dat$\|.*\.err$\|.*\.log$\|.*RPM_UPGRADE_MARKER$\|.*RPM_UPGRADE_HISTORY$\|.*pxc-entrypoint\.sh$\|.*unsafe-bootstrap\.sh$\|.*pxc-configure-pxc\.sh\|.*peer-list$\|.*auth_plugin$
+progress=1
+
++ [[ -z node:10-42-2-8.cluster1-pxc-unready.pxc.svc.cluster.local:wsrep_ready:ON:wsrep_connected:ON:wsrep_local_state_comment:Synced:wsrep_cluster_status:Primary ]]
++ [[ -z node:10-42-2-8.cluster1-pxc-unready.pxc.svc.cluster.local:wsrep_ready:ON:wsrep_connected:ON:wsrep_local_state_comment:Synced:wsrep_cluster_status:Primary ]]
++ [[ -z node:10-42-2-8.cluster1-pxc-unready.pxc.svc.cluster.local:wsrep_ready:ON:wsrep_connected:ON:wsrep_local_state_comment:Synced:wsrep_cluster_status:Primary ]]
++ test -e /opt/percona/hookscript/hook.sh
++ exec mysqld
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /pxc-entrypoint.sh /var/lib/mysql/pxc-entrypoint.sh
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /unsafe-bootstrap.sh /var/lib/mysql/unsafe-bootstrap.sh
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /pxc-configure-pxc.sh /var/lib/mysql/pxc-configure-pxc.sh
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /liveness-check.sh /var/lib/mysql/liveness-check.sh
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /readiness-check.sh /var/lib/mysql/readiness-check.sh
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /peer-list /var/lib/mysql/peer-list
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /get-pxc-state /var/lib/mysql/get-pxc-state
+++ id -u
+++ id -g
++ install -o 2 -g 2 -m 0755 -D /pmm-prerun.sh /var/lib/mysql/pmm-prerun.sh
++ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/fluent-bit/bin
++ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/fluent-bit/bin
++ '[' fluent-bit = logrotate ']'
++ '[' fluent-bit = fluent-bit ']'
++ fluentbit_opt+='-c /etc/fluentbit/fluentbit.conf'
++ test -e /opt/percona/hookscript/hook.sh
++ exec fluent-bit -c /etc/fluentbit/fluentbit.conf
+Fluent Bit v2.1.5
+* Copyright (C) 2015-2022 The Fluent Bit Authors
+* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
+* https://fluentbit.io
+
+{"log":"2024-02-09T10:46:35.630765Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.630799Z 0 [Warning] [MY-011068] [Server] The syntax 'wsrep_slave_threads' is deprecated and will be removed in a future release. Please use wsrep_applier_threads instead.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.632875Z 0 [Warning] [MY-010097] [Server] Insecure configuration for --secure-log-path: Current value does not restrict location of generated files. Consider setting it to a valid, non-empty path.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.633632Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.32-24.2) starting as process 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.638017Z 0 [Warning] [MY-010068] [Server] CA certificate /etc/mysql/ssl-internal/ca.crt is self signed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.638056Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.638066Z 0 [Note] [MY-000000] [WSREP] New joining cluster node configured to use specified SSL artifacts\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.638104Z 0 [Note] [MY-000000] [Galera] Loading provider /usr/lib64/galera4/libgalera_smm.so initial position: 00000000-0000-0000-0000-000000000000:-1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.638118Z 0 [Note] [MY-000000] [Galera] wsrep_load(): loading provider library '/usr/lib64/galera4/libgalera_smm.so'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.638915Z 0 [Note] [MY-000000] [Galera] wsrep_load(): Galera 4.14(779b689) by Codership Oy <info@codership.com> (modified by Percona <https://percona.com/>) loaded successfully.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.638945Z 0 [Note] [MY-000000] [Galera] CRC-32C: using 64-bit x86 acceleration.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.639195Z 0 [Warning] [MY-000000] [Galera] SSL compression is not effective. The option socket.ssl_compression is deprecated and will be removed in future releases.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.639204Z 0 [Warning] [MY-000000] [Galera] Parameter 'socket.ssl_compression' is deprecated and will be removed in future versions\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.639792Z 0 [Warning] [MY-000000] [Galera] Could not open state file for reading: '/var/lib/mysql//grastate.dat'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.639806Z 0 [Warning] [MY-000000] [Galera] No persistent state found. Bootstraping with default state\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.639870Z 0 [Note] [MY-000000] [Galera] Found saved state: 00000000-0000-0000-0000-000000000000:-1, safe_to_bootstrap: 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.640259Z 0 [Note] [MY-000000] [Galera] Generated new GCache ID: 7ee9a7d0-c738-11ee-9f9b-cf2bf4f91491\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.640278Z 0 [Note] [MY-000000] [Galera] GCache DEBUG: opened preamble:\nVersion: 0\nUUID: 00000000-0000-0000-0000-000000000000\nSeqno: -1 - -1\nOffset: -1\nSynced: 0\nEncVersion: 0\nEncrypted: 0\nMasterKeyConst UUID: 7ee9a7d0-c738-11ee-9f9b-cf2bf4f91491\nMasterKey UUID: 00000000-0000-0000-0000-000000000000\nMasterKey ID: 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.640285Z 0 [Note] [MY-000000] [Galera] Skipped GCache ring buffer recovery: could not determine history UUID.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.656782Z 0 [Note] [MY-000000] [Galera] Passing config to GCS: allocator.disk_pages_encryption = no; allocator.encryption_cache_page_size = 32K; allocator.encryption_cache_size = 16777216; base_dir = /var/lib/mysql/; base_host = 10.42.1.6; base_port = 4567; cert.log_conflicts = no; cert.optimistic_pa = no; debug = no; evs.auto_evict = 0; evs.delay_margin = PT1S; evs.delayed_keep_period = PT30S; evs.inactive_check_period = PT0.5S; evs.inactive_timeout = PT15S; evs.join_retrans_period = PT1S; evs.max_install_timeouts = 3; evs.send_window = 10; evs.stats_report_period = PT1M; evs.suspect_timeout = PT5S; evs.user_send_window = 4; evs.view_forget_timeout = PT24H; gcache.dir = /var/lib/mysql/; gcache.encryption = no; gcache.encryption_cache_page_size = 32K; gcache.encryption_cache_size = 16777216; gcache.freeze_purge_at_seqno = -1; gcache.keep_pages_count = 0; gcache.keep_pages_size = 0; gcache.mem_size = 0; gcache.name = galera.cache; gcache.page_size = 128M; gcache.recover = yes; gcache.size = 128M; gcomm.thread_prio = ; gcs.fc_debug = 0; gcs.fc_factor = 1.0; gcs.fc_limit = 100; gcs.fc_master_slave = no; gcs.fc_single_primary = no; gcs.max_packet_size = 64500; gcs.max_throttle = 0.25; gcs.recv_q_hard_limit = 9223372036854775807; gcs.recv_q_soft_limit = 0.25; gcs.sync_donor = no; gmcast.segment = 0; gmcast.version = 0; pc.announce_timeout = PT3S; pc.checksum = false; pc.ignore_quorum = false; pc.ignore_sb = false; pc.npvo = false; pc.recovery = true; pc.version = 0; pc.wait_prim = true; pc.wait_prim_timeout = PT30S; pc.weight = 10; protonet.backend = asio; protonet.version = 0; repl.causal_read_timeout = PT30S; repl.commit_order = 3; repl.key_format = FLAT8; repl.max_ws_size = 2147483647; repl.proto_max = 10; socket.checksum = 2; socket.recv_buf_size = auto; socket.send_buf_size = auto; socket.ssl = YES; socket.ssl_ca = /etc/mysql/ssl-internal/ca.crt; socket.ssl_cert = /etc/mysql/ssl-internal/tls.crt; socket.ssl_cipher = ; socket.ssl_compression = YES; socket.ssl_key = /etc/mysql/ssl-internal/tls.key; socket.ssl_reload = 1; \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.671460Z 0 [Note] [MY-000000] [WSREP] Starting replication\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.671507Z 0 [Note] [MY-000000] [Galera] Connecting with bootstrap option: 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.671523Z 0 [Note] [MY-000000] [Galera] Setting GCS initial position to 00000000-0000-0000-0000-000000000000:-1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.671582Z 0 [Note] [MY-000000] [Galera] protonet asio version 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.672239Z 0 [Note] [MY-000000] [Galera] Using CRC-32C for message checksums.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.672255Z 0 [Note] [MY-000000] [Galera] backend: asio\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.672337Z 0 [Note] [MY-000000] [Galera] gcomm thread scheduling priority set to other:0 \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.672454Z 0 [Note] [MY-000000] [Galera] Fail to access the file (/var/lib/mysql//gvwstate.dat) error (No such file or directory). It is possible if node is booting for first time or re-booting after a graceful shutdown\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.672463Z 0 [Note] [MY-000000] [Galera] Restoring primary-component from disk failed. Either node is booting for first time or re-booting after a graceful shutdown\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.672648Z 0 [Note] [MY-000000] [Galera] GMCast version 0\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.674931Z 0 [Note] [MY-000000] [Galera] (7eee9476-83f9, 'ssl://0.0.0.0:4567') listening at ssl://0.0.0.0:4567\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.674966Z 0 [Note] [MY-000000] [Galera] (7eee9476-83f9, 'ssl://0.0.0.0:4567') multicast: , ttl: 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.675306Z 0 [Note] [MY-000000] [Galera] EVS version 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.675382Z 0 [Note] [MY-000000] [Galera] gcomm: connecting to group 'cluster1-pxc', peer 'cluster1-pxc-0.cluster1-pxc:,cluster1-pxc-1.cluster1-pxc:'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.683925Z 0 [Note] [MY-000000] [Galera] (7eee9476-83f9, 'ssl://0.0.0.0:4567') connection established to 486b248f-8ac6 ssl://10.42.2.8:4567\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.684070Z 0 [Note] [MY-000000] [Galera] (7eee9476-83f9, 'ssl://0.0.0.0:4567') turning message relay requesting on, nonlive peers: \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:35.686005Z 0 [Note] [MY-000000] [Galera] (7eee9476-83f9, 'ssl://0.0.0.0:4567') connection established to 213e9b53-8c4d ssl://10.42.0.5:4567\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:36.177961Z 0 [Note] [MY-000000] [Galera] EVS version upgrade 0 -> 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:36.178025Z 0 [Note] [MY-000000] [Galera] declaring 213e9b53-8c4d at ssl://10.42.0.5:4567 stable\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:36.178042Z 0 [Note] [MY-000000] [Galera] declaring 486b248f-8ac6 at ssl://10.42.2.8:4567 stable\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:36.178065Z 0 [Note] [MY-000000] [Galera] PC protocol upgrade 0 -> 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.178686Z 0 [Note] [MY-000000] [Galera] Node 213e9b53-8c4d state primary\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.179784Z 0 [Note] [MY-000000] [Galera] Current view of cluster as seen by this node\nview (view_id(PRIM,213e9b53-8c4d,3)\nmemb {\n\t213e9b53-8c4d,0\n\t486b248f-8ac6,0\n\t7eee9476-83f9,0\n\t}\njoined {\n\t}\nleft {\n\t}\npartitioned {\n\t}\n)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.179822Z 0 [Note] [MY-000000] [Galera] Save the discovered primary-component to disk\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.676475Z 0 [Note] [MY-000000] [Galera] gcomm: connected\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.676687Z 0 [Note] [MY-000000] [Galera] Changing maximum packet size to 64500, resulting msg size: 32636\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.676991Z 0 [Note] [MY-000000] [Galera] Shifting CLOSED -> OPEN (TO: 0)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.677018Z 0 [Note] [MY-000000] [Galera] Opened channel 'cluster1-pxc'\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.677354Z 0 [Note] [MY-000000] [Galera] New COMPONENT: primary = yes, bootstrap = no, my_idx = 2, memb_num = 3\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.677446Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: Waiting for state UUID.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.677515Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: sent state msg: 7fd70a41-c738-11ee-8cb8-0a31c2c73e26\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.677578Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: got state msg: 7fd70a41-c738-11ee-8cb8-0a31c2c73e26 from 0 (cluster1-pxc-0)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.677636Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: got state msg: 7fd70a41-c738-11ee-8cb8-0a31c2c73e26 from 1 (cluster1-pxc-1)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.677685Z 2 [Note] [MY-000000] [WSREP] Starting rollbacker thread 2\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.677794Z 1 [Note] [MY-000000] [WSREP] Starting applier thread 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679068Z 0 [Note] [MY-000000] [Galera] STATE EXCHANGE: got state msg: 7fd70a41-c738-11ee-8cb8-0a31c2c73e26 from 2 (cluster1-pxc-2)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679172Z 0 [Note] [MY-000000] [Galera] Quorum results:\n\tversion    = 6,\n\tcomponent  = PRIMARY,\n\tconf_id    = 2,\n\tmembers    = 2/3 (primary/total),\n\tact_id     = 35,\n\tlast_appl. = 22,\n\tprotocols  = 2/10/4 (gcs/repl/appl),\n\tvote policy= 0,\n\tgroup UUID = 103be6ae-c738-11ee-95d1-526d43d08e41\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679305Z 0 [Note] [MY-000000] [Galera] Flow-control interval: [173, 173]\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679340Z 0 [Note] [MY-000000] [Galera] Shifting OPEN -> PRIMARY (TO: 36)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679557Z 1 [Note] [MY-000000] [Galera] ####### processing CC 36, local, ordered\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679614Z 1 [Note] [MY-000000] [Galera] Maybe drain monitors from -1 upto current CC event 36 upto:-1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679633Z 1 [Note] [MY-000000] [Galera] Drain monitors from -1 up to -1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679660Z 1 [Note] [MY-000000] [Galera] Process first view: 103be6ae-c738-11ee-95d1-526d43d08e41 my uuid: 7eee9476-c738-11ee-83f9-e3e1dce47b60\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679726Z 1 [Note] [MY-000000] [Galera] Server cluster1-pxc-2 connected to cluster at position 103be6ae-c738-11ee-95d1-526d43d08e41:36 with ID 7eee9476-c738-11ee-83f9-e3e1dce47b60\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679744Z 1 [Note] [MY-000000] [WSREP] Server status change disconnected -> connected\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679805Z 1 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679861Z 1 [Note] [MY-000000] [Galera] ####### My UUID: 7eee9476-c738-11ee-83f9-e3e1dce47b60\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.679884Z 1 [Note] [MY-000000] [Galera] Cert index reset to 00000000-0000-0000-0000-000000000000:-1 (proto: 10), state transfer needed: yes\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.680068Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.680212Z 1 [Note] [MY-000000] [Galera] ####### Assign initial position for certification: 00000000-0000-0000-0000-000000000000:-1, protocol version: -1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.680244Z 1 [Note] [MY-000000] [Galera] State transfer required: \n\tGroup state: 103be6ae-c738-11ee-95d1-526d43d08e41:36\n\tLocal state: 00000000-0000-0000-0000-000000000000:-1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.680257Z 1 [Note] [MY-000000] [WSREP] Server status change connected -> joiner\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.680268Z 1 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:37.680557Z 0 [Note] [MY-000000] [WSREP] Initiating SST/IST transfer on JOINER side (wsrep_sst_xtrabackup-v2 --role 'joiner' --address '10.42.1.6' --datadir '/var/lib/mysql/' --basedir '/usr/' --plugindir '/usr/lib64/mysql/plugin/' --defaults-file '/etc/my.cnf' --defaults-group-suffix '' --parent '1' --mysqld-version '8.0.32-24.2'  --binlog 'binlog' )\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.762504Z 1 [Note] [MY-000000] [WSREP] Prepared SST request: xtrabackup-v2|10.42.1.6:4444/xtrabackup_sst//1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.762590Z 1 [Note] [MY-000000] [Galera] Check if state gap can be serviced using IST\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.762623Z 1 [Note] [MY-000000] [Galera] Local UUID: 00000000-0000-0000-0000-000000000000 != Group UUID: 103be6ae-c738-11ee-95d1-526d43d08e41\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.762636Z 1 [Note] [MY-000000] [Galera] ####### IST uuid:00000000-0000-0000-0000-000000000000 f: 0, l: 36, STRv: 3\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.762719Z 1 [Note] [MY-000000] [Galera] IST receiver addr using ssl://10.42.1.6:4568\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.762762Z 1 [Note] [MY-000000] [Galera] IST receiver using ssl\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.762965Z 1 [Note] [MY-000000] [Galera] Prepared IST receiver for 0-36, listening at: ssl://10.42.1.6:4568\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.764075Z 0 [Note] [MY-000000] [Galera] Member 2.0 (cluster1-pxc-2) requested state transfer from 'cluster1-pxc-1,'. Selected 1.0 (cluster1-pxc-1)(SYNCED) as donor.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.764092Z 0 [Note] [MY-000000] [Galera] Shifting PRIMARY -> JOINER (TO: 36)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.764134Z 1 [Note] [MY-000000] [Galera] Requesting state transfer: success, donor: 1\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.764183Z 1 [Note] [MY-000000] [Galera] Resetting GCache seqno map due to different histories.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:38.764205Z 1 [Note] [MY-000000] [Galera] GCache history reset: 00000000-0000-0000-0000-000000000000:0 -> 103be6ae-c738-11ee-95d1-526d43d08e41:36\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:39.176772Z 0 [Note] [MY-000000] [Galera] (7eee9476-83f9, 'ssl://0.0.0.0:4567') turning message relay requesting off\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:39.630279Z 0 [Note] [MY-000000] [WSREP-SST]    joiner: => Rate:[ 145 B/s] Avg:[ 145 B/s] Elapsed:0:00:01  Bytes:  167 B \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:40.617441Z 0 [Note] [MY-000000] [WSREP-SST] Proceeding with SST.........\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:40.644135Z 0 [Note] [MY-000000] [WSREP-SST] ............Waiting for SST streaming to complete!\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:53.702890Z 0 [Note] [MY-000000] [WSREP-SST]    joiner: => Rate:[0.00 B/s] Avg:[0.00 B/s] Elapsed:0:00:10  Bytes: 0.00 B \r   joiner: => Rate:[5.80MiB/s] Avg:[5.80MiB/s] Elapsed:0:00:13  Bytes: 75.9MiB \n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:53.708455Z 0 [Note] [MY-000000] [Galera] 1.0 (cluster1-pxc-1): State transfer to 2.0 (cluster1-pxc-2) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:53.709300Z 0 [Note] [MY-000000] [Galera] Member 1.0 (cluster1-pxc-1) synced with group.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:53.715924Z 0 [Note] [MY-000000] [WSREP-SST] Preparing the backup at /var/lib/mysql//sst-xb-tmpdir\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:55.404692Z 0 [Note] [MY-000000] [WSREP-SST] Moving the backup to /var/lib/mysql/\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:55.538871Z 0 [Note] [MY-000000] [WSREP-SST] Running post-processing...........\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:55.551497Z 0 [Note] [MY-000000] [WSREP-SST] Skipping mysql_upgrade (sst): local version (8.0.32) == donor version (8.0.32)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:55.647840Z 0 [Note] [MY-000000] [WSREP-SST] Waiting for server instance to start.....  This may take some time\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:53.734125-00:00 0 [Note] [MY-011825] [Xtrabackup] recognized server arguments: --innodb_checksum_algorithm=crc32 --innodb_log_checksums=1 --innodb_data_file_path=ibdata1:12M:autoextend --innodb_log_file_size=50331648 --innodb_page_size=16384 --innodb_undo_directory=./ --innodb_undo_tablespaces=2 --server-id=32109361 --innodb_log_checksums=ON --innodb_redo_log_encrypt=0 --innodb_undo_log_encrypt=0 \n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.734276-00:00 0 [Note] [MY-011825] [Xtrabackup] recognized client arguments: --no-version-check=1 --prepare=1 --rollback-prepared-trx=1 --xtrabackup-plugin-dir=/usr/bin/pxc_extra/pxb-8.0/lib/plugin --target-dir=/var/lib/mysql//sst-xb-tmpdir \n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"/usr/bin/pxc_extra/pxb-8.0/bin/xtrabackup version 8.0.32-26 based on MySQL server 8.0.32 Linux (x86_64) (revision id: 34cf2908)\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.734309-00:00 0 [Note] [MY-011825] [Xtrabackup] cd to /var/lib/mysql/sst-xb-tmpdir/\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.734366-00:00 0 [Note] [MY-011825] [Xtrabackup] This target seems to be not prepared yet.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.745163-00:00 0 [Note] [MY-011825] [Xtrabackup] xtrabackup_logfile detected: size=8388608, start_lsn=(32368935)\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.746135-00:00 0 [Note] [MY-011825] [Xtrabackup] using the following InnoDB configuration for recovery:\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.746156-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_data_home_dir = .\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.746163-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_data_file_path = ibdata1:12M:autoextend\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.746205-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_group_home_dir = .\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.746211-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_files_in_group = 1\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.746220-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_file_size = 8388608\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.746493-00:00 0 [Note] [MY-011825] [Xtrabackup] inititialize_service_handles suceeded\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.746702-00:00 0 [Note] [MY-011825] [Xtrabackup] using the following InnoDB configuration for recovery:\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.746711-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_data_home_dir = .\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.746717-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_data_file_path = ibdata1:12M:autoextend\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.746728-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_group_home_dir = .\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.746734-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_files_in_group = 1\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.746740-00:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_file_size = 8388608\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.746748-00:00 0 [Note] [MY-011825] [Xtrabackup] Starting InnoDB instance for recovery.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.746755-00:00 0 [Note] [MY-011825] [Xtrabackup] Using 104857600 bytes for buffer pool (set by --use-memory parameter)\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.746800-00:00 0 [Note] [MY-012932] [InnoDB] PUNCH HOLE support available\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.746818-00:00 0 [Note] [MY-012944] [InnoDB] Uses event mutexes\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.746824-00:00 0 [Note] [MY-012945] [InnoDB] GCC builtin __atomic_thread_fence() is used for memory barrier\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.746835-00:00 0 [Note] [MY-012948] [InnoDB] Compressed tables use zlib 1.2.13\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.747059-00:00 0 [Note] [MY-012951] [InnoDB] Using hardware accelerated crc32 and polynomial multiplication.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.747395-00:00 0 [Note] [MY-012203] [InnoDB] Directories to scan './'\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.747491-00:00 0 [Note] [MY-012204] [InnoDB] Scanning './'\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.749385-00:00 0 [Note] [MY-012208] [InnoDB] Completed space ID check of 7 files.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.750329-00:00 0 [Note] [MY-012955] [InnoDB] Initializing buffer pool, total size = 128.000000M, instances = 1, chunk size =128.000000M \n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.761566-00:00 0 [Note] [MY-012957] [InnoDB] Completed initialization of buffer pool\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.765801-00:00 0 [Note] [MY-011952] [InnoDB] If the mysqld execution user is authorized, page cleaner thread priority can be changed. See the man page of setpriority().\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.888769-00:00 0 [Note] [MY-013883] [InnoDB] The latest found checkpoint is at lsn = 32368935 in redo log file ./#innodb_redo/#ib_redo0.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.888880-00:00 0 [Note] [MY-012560] [InnoDB] The log sequence number 32265428 in the system tablespace does not match the log sequence number 32368935 in the redo log files!\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.888892-00:00 0 [Note] [MY-012551] [InnoDB] Database was not shutdown normally!\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.888902-00:00 0 [Note] [MY-012552] [InnoDB] Starting crash recovery.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.889081-00:00 0 [Note] [MY-013086] [InnoDB] Starting to parse redo log at lsn = 32368663, whereas checkpoint_lsn = 32368935 and start_lsn = 32368640\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.889099-00:00 0 [Note] [MY-012550] [InnoDB] Doing recovery: scanned up to log sequence number 32368945\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.903573-00:00 0 [Note] [MY-013083] [InnoDB] Log background threads are being started...\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.904083-00:00 0 [Note] [MY-012532] [InnoDB] Applying a batch of 1 redo log records ...\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.904164-00:00 0 [Note] [MY-012533] [InnoDB] 100%\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:53.904177-00:00 0 [Note] [MY-012535] [InnoDB] Apply batch completed!\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.013050-00:00 0 [Note] [MY-013084] [InnoDB] Log background threads are being closed...\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.014525-00:00 0 [Note] [MY-013041] [InnoDB] Resizing redo log from 8M to 1024M (LSN=32368945) synchronously. If this takes too long, consider starting the server with large --innodb_redo_log_capacity, and resizing the redo log online using SET.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.021427-00:00 0 [Note] [MY-012968] [InnoDB] Starting to delete and rewrite redo log files.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.021647-00:00 0 [Note] [MY-011825] [InnoDB] Removing redo log file: ./#innodb_redo/#ib_redo0\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.147942-00:00 0 [Note] [MY-011825] [InnoDB] Creating redo log file at ./#innodb_redo/#ib_redo0_tmp with file_id 0 with size 33554432 bytes\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.160549-00:00 0 [Note] [MY-011825] [InnoDB] Renaming redo log file from ./#innodb_redo/#ib_redo0_tmp to ./#innodb_redo/#ib_redo0\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.175257-00:00 0 [Note] [MY-012893] [InnoDB] New redo log files created, LSN=32369164\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.175460-00:00 0 [Note] [MY-013083] [InnoDB] Log background threads are being started...\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.176242-00:00 0 [Note] [MY-013252] [InnoDB] Using undo tablespace './undo_001'.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.177060-00:00 0 [Note] [MY-013252] [InnoDB] Using undo tablespace './undo_002'.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.178519-00:00 0 [Note] [MY-012910] [InnoDB] Opened 2 existing undo tablespaces.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.178655-00:00 0 [Note] [MY-011980] [InnoDB] GTID recovery trx_no: 3628\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.206984-00:00 0 [Note] [MY-013776] [InnoDB] Parallel initialization of rseg complete\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.207045-00:00 0 [Note] [MY-013777] [InnoDB] Time taken to initialize rseg using 4 thread: 28403 ms.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.207131-00:00 0 [Note] [MY-012923] [InnoDB] Creating shared tablespace for temporary tables\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.207229-00:00 0 [Note] [MY-012265] [InnoDB] Setting file './ibtmp1' size to 12 MB. Physically writing the file full; Please wait ...\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.230265-00:00 0 [Note] [MY-012266] [InnoDB] File './ibtmp1' size is now 12 MB.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.230570-00:00 0 [Note] [MY-013627] [InnoDB] Scanning temp tablespace dir:'./#innodb_temp/'\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.303817-00:00 0 [Note] [MY-013018] [InnoDB] Created 128 and tracked 128 new rollback segment(s) in the temporary tablespace. 128 are now active.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.304331-00:00 0 [Note] [MY-012976] [InnoDB] 8.0.32 started; log sequence number 32369174\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.304688-00:00 0 [Warning] [MY-012091] [InnoDB] Allocated tablespace ID 3 for mysql/wsrep_cluster_members, old maximum was 0\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.329630-00:00 0 [Note] [MY-011825] [Xtrabackup] Recovered WSREP position: 103be6ae-c738-11ee-95d1-526d43d08e41:36\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.329702-00:00 0 [Note] [MY-011825] [Xtrabackup] starting shutdown with innodb_fast_shutdown = 1\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:54.329902-00:00 0 [Note] [MY-012330] [InnoDB] FTS optimize thread exiting.\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:55.329590-00:00 0 [Note] [MY-013072] [InnoDB] Starting shutdown...\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:55.358017-00:00 0 [Note] [MY-013084] [InnoDB] Log background threads are being closed...\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:55.378894-00:00 0 [Note] [MY-012980] [InnoDB] Shutdown completed; log sequence number 32369174\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:55.382823-00:00 0 [Note] [MY-011825] [Xtrabackup] completed OK!\n","file":"/var/lib/mysql/innobackup.prepare.log"}
+{"log":"2024-02-09T10:46:55.424979-00:00 0 [Note] [MY-011825] [Xtrabackup] recognized server arguments: --datadir=/var/lib/mysql --server-id=32109362 --innodb_flush_log_at_trx_commit=0 --innodb_flush_method=O_DIRECT --innodb_file_per_table=1 --defaults_group=mysqld --datadir=/var/lib/mysql/ \n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.425496-00:00 0 [Note] [MY-011825] [Xtrabackup] recognized client arguments: --socket=/tmp/mysql.sock --no-version-check=1 --move-back=1 --force-non-empty-directories=1 --xtrabackup-plugin-dir=/usr/bin/pxc_extra/pxb-8.0/lib/plugin --target-dir=/var/lib/mysql//sst-xb-tmpdir \n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"/usr/bin/pxc_extra/pxb-8.0/bin/xtrabackup version 8.0.32-26 based on MySQL server 8.0.32 Linux (x86_64) (revision id: 34cf2908)\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.425577-00:00 0 [Note] [MY-011825] [Xtrabackup] cd to /var/lib/mysql/sst-xb-tmpdir/\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.427079-00:00 0 [Note] [MY-011825] [Xtrabackup] Moving undo_001 to /var/lib/mysql//undo_001\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.427215-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Moving file undo_001 to /var/lib/mysql//undo_001\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.427289-00:00 0 [Note] [MY-011825] [Xtrabackup] Moving undo_002 to /var/lib/mysql//undo_002\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.427379-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Moving file undo_002 to /var/lib/mysql//undo_002\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.427772-00:00 0 [Note] [MY-011825] [Xtrabackup] Moving ibdata1 to /var/lib/mysql//ibdata1\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.427869-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Moving file ibdata1 to /var/lib/mysql//ibdata1\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.428409-00:00 0 [Note] [MY-011825] [Xtrabackup] Moving binlog.000006 to /var/lib/mysql//binlog.000006\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.428512-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Moving file binlog.000006 to /var/lib/mysql//binlog.000006\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.428719-00:00 0 [Note] [MY-011825] [Xtrabackup] Moving binlog.index to /var/lib/mysql//binlog.index\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.428811-00:00 0 [Note] [MY-011825] [Xtrabackup] Done: Moving file binlog.index to /var/lib/mysql//binlog.index\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.429736-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/slow_log_226.sdi to /var/lib/mysql//mysql/slow_log_226.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.429916-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/slow_log_226.sdi to /var/lib/mysql//mysql/slow_log_226.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.430022-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/wsrep_streaming_log.ibd to /var/lib/mysql//mysql/wsrep_streaming_log.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.430124-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/wsrep_streaming_log.ibd to /var/lib/mysql//mysql/wsrep_streaming_log.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.430212-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/slow_log.CSM to /var/lib/mysql//mysql/slow_log.CSM\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.430307-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/slow_log.CSM to /var/lib/mysql//mysql/slow_log.CSM\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.430384-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/general_log.CSM to /var/lib/mysql//mysql/general_log.CSM\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.430478-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/general_log.CSM to /var/lib/mysql//mysql/general_log.CSM\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.430545-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/general_log.CSV to /var/lib/mysql//mysql/general_log.CSV\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.430633-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/general_log.CSV to /var/lib/mysql//mysql/general_log.CSV\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.430699-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/slow_log.CSV to /var/lib/mysql//mysql/slow_log.CSV\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.430787-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/slow_log.CSV to /var/lib/mysql//mysql/slow_log.CSV\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.430856-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/wsrep_cluster_members.ibd to /var/lib/mysql//mysql/wsrep_cluster_members.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.430944-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/wsrep_cluster_members.ibd to /var/lib/mysql//mysql/wsrep_cluster_members.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.431015-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/general_log_225.sdi to /var/lib/mysql//mysql/general_log_225.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.431129-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/general_log_225.sdi to /var/lib/mysql//mysql/general_log_225.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.431200-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql/wsrep_cluster.ibd to /var/lib/mysql//mysql/wsrep_cluster.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.431300-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql/wsrep_cluster.ibd to /var/lib/mysql//mysql/wsrep_cluster.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.431322-00:00 1 [Note] [MY-011825] [Xtrabackup] Creating directory ./#innodb_redo\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.431347-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: creating directory ./#innodb_redo\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.431415-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./ibtmp1 to /var/lib/mysql//ibtmp1\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.431511-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./ibtmp1 to /var/lib/mysql//ibtmp1\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.431679-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./sys/sys_config.ibd to /var/lib/mysql//sys/sys_config.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.431785-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./sys/sys_config.ibd to /var/lib/mysql//sys/sys_config.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.431860-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./mysql.ibd to /var/lib/mysql//mysql.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.431951-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./mysql.ibd to /var/lib/mysql//mysql.ibd\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.432028-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./xtrabackup_info to /var/lib/mysql//xtrabackup_info\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.432180-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./xtrabackup_info to /var/lib/mysql//xtrabackup_info\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.432286-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./innobackup.prepare.log to /var/lib/mysql//innobackup.prepare.log\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.432354-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./innobackup.prepare.log to /var/lib/mysql//innobackup.prepare.log\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.432383-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./innobackup.move.log to /var/lib/mysql//innobackup.move.log\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.432428-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./innobackup.move.log to /var/lib/mysql//innobackup.move.log\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.432454-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./xtrabackup_galera_info to /var/lib/mysql//xtrabackup_galera_info\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.432497-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./xtrabackup_galera_info to /var/lib/mysql//xtrabackup_galera_info\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.432580-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_asyn_182.sdi to /var/lib/mysql//performance_schema/replication_asyn_182.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.432628-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_asyn_182.sdi to /var/lib/mysql//performance_schema/replication_asyn_182.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.432659-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/malloc_stats_tot_200.sdi to /var/lib/mysql//performance_schema/malloc_stats_tot_200.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.432701-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/malloc_stats_tot_200.sdi to /var/lib/mysql//performance_schema/malloc_stats_tot_200.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.432728-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/malloc_stats_201.sdi to /var/lib/mysql//performance_schema/malloc_stats_201.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.432770-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/malloc_stats_201.sdi to /var/lib/mysql//performance_schema/malloc_stats_201.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.432796-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/memory_summary_b_164.sdi to /var/lib/mysql//performance_schema/memory_summary_b_164.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.432838-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/memory_summary_b_164.sdi to /var/lib/mysql//performance_schema/memory_summary_b_164.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.432874-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_131.sdi to /var/lib/mysql//performance_schema/events_statement_131.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.432917-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_131.sdi to /var/lib/mysql//performance_schema/events_statement_131.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.432942-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/file_summary_by__104.sdi to /var/lib/mysql//performance_schema/file_summary_by__104.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433041-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/file_summary_by__104.sdi to /var/lib/mysql//performance_schema/file_summary_by__104.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433070-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/setup_instrument_113.sdi to /var/lib/mysql//performance_schema/setup_instrument_113.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433112-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/setup_instrument_113.sdi to /var/lib/mysql//performance_schema/setup_instrument_113.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433138-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/session_variable_194.sdi to /var/lib/mysql//performance_schema/session_variable_194.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433181-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/session_variable_194.sdi to /var/lib/mysql//performance_schema/session_variable_194.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433207-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_conn_171.sdi to /var/lib/mysql//performance_schema/replication_conn_171.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433249-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_conn_171.sdi to /var/lib/mysql//performance_schema/replication_conn_171.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433274-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_143.sdi to /var/lib/mysql//performance_schema/events_transacti_143.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433316-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_143.sdi to /var/lib/mysql//performance_schema/events_transacti_143.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433342-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_sum_97.sdi to /var/lib/mysql//performance_schema/events_waits_sum_97.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433384-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_sum_97.sdi to /var/lib/mysql//performance_schema/events_waits_sum_97.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433410-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/pxc_cluster_view_203.sdi to /var/lib/mysql//performance_schema/pxc_cluster_view_203.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433452-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/pxc_cluster_view_203.sdi to /var/lib/mysql//performance_schema/pxc_cluster_view_203.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433477-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/table_io_waits_s_117.sdi to /var/lib/mysql//performance_schema/table_io_waits_s_117.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433520-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/table_io_waits_s_117.sdi to /var/lib/mysql//performance_schema/table_io_waits_s_117.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433546-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/mutex_instances_106.sdi to /var/lib/mysql//performance_schema/mutex_instances_106.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433589-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/mutex_instances_106.sdi to /var/lib/mysql//performance_schema/mutex_instances_106.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433616-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/threads_119.sdi to /var/lib/mysql//performance_schema/threads_119.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433658-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/threads_119.sdi to /var/lib/mysql//performance_schema/threads_119.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433692-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_132.sdi to /var/lib/mysql//performance_schema/events_statement_132.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433735-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_132.sdi to /var/lib/mysql//performance_schema/events_statement_132.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433761-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/status_by_thread_188.sdi to /var/lib/mysql//performance_schema/status_by_thread_188.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433806-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/status_by_thread_188.sdi to /var/lib/mysql//performance_schema/status_by_thread_188.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433835-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_conn_173.sdi to /var/lib/mysql//performance_schema/replication_conn_173.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433877-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_conn_173.sdi to /var/lib/mysql//performance_schema/replication_conn_173.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433903-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_cu_120.sdi to /var/lib/mysql//performance_schema/events_stages_cu_120.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433946-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_cu_120.sdi to /var/lib/mysql//performance_schema/events_stages_cu_120.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.433972-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_130.sdi to /var/lib/mysql//performance_schema/events_statement_130.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434015-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_130.sdi to /var/lib/mysql//performance_schema/events_statement_130.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434041-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/processlist_109.sdi to /var/lib/mysql//performance_schema/processlist_109.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434083-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/processlist_109.sdi to /var/lib/mysql//performance_schema/processlist_109.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434109-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/memory_summary_b_165.sdi to /var/lib/mysql//performance_schema/memory_summary_b_165.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434152-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/memory_summary_b_165.sdi to /var/lib/mysql//performance_schema/memory_summary_b_165.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434178-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/user_defined_fun_197.sdi to /var/lib/mysql//performance_schema/user_defined_fun_197.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434220-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/user_defined_fun_197.sdi to /var/lib/mysql//performance_schema/user_defined_fun_197.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434249-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_145.sdi to /var/lib/mysql//performance_schema/events_transacti_145.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434292-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_145.sdi to /var/lib/mysql//performance_schema/events_transacti_145.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434318-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_asyn_181.sdi to /var/lib/mysql//performance_schema/replication_asyn_181.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434361-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_asyn_181.sdi to /var/lib/mysql//performance_schema/replication_asyn_181.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434387-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_errors_su_152.sdi to /var/lib/mysql//performance_schema/events_errors_su_152.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434430-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_errors_su_152.sdi to /var/lib/mysql//performance_schema/events_errors_su_152.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434459-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/session_status_191.sdi to /var/lib/mysql//performance_schema/session_status_191.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434502-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/session_status_191.sdi to /var/lib/mysql//performance_schema/session_status_191.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434528-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_133.sdi to /var/lib/mysql//performance_schema/events_statement_133.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434572-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_133.sdi to /var/lib/mysql//performance_schema/events_statement_133.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434598-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/persisted_variab_196.sdi to /var/lib/mysql//performance_schema/persisted_variab_196.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434645-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/persisted_variab_196.sdi to /var/lib/mysql//performance_schema/persisted_variab_196.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434671-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_errors_su_148.sdi to /var/lib/mysql//performance_schema/events_errors_su_148.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434715-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_errors_su_148.sdi to /var/lib/mysql//performance_schema/events_errors_su_148.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434741-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/accounts_154.sdi to /var/lib/mysql//performance_schema/accounts_154.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434786-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/accounts_154.sdi to /var/lib/mysql//performance_schema/accounts_154.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434812-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/setup_threads_115.sdi to /var/lib/mysql//performance_schema/setup_threads_115.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434855-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/setup_threads_115.sdi to /var/lib/mysql//performance_schema/setup_threads_115.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434881-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/rwlock_instances_110.sdi to /var/lib/mysql//performance_schema/rwlock_instances_110.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434927-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/rwlock_instances_110.sdi to /var/lib/mysql//performance_schema/rwlock_instances_110.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434954-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/keyring_componen_202.sdi to /var/lib/mysql//performance_schema/keyring_componen_202.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.434997-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/keyring_componen_202.sdi to /var/lib/mysql//performance_schema/keyring_componen_202.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435024-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/socket_summary_b_158.sdi to /var/lib/mysql//performance_schema/socket_summary_b_158.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435069-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/socket_summary_b_158.sdi to /var/lib/mysql//performance_schema/socket_summary_b_158.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435095-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_146.sdi to /var/lib/mysql//performance_schema/events_transacti_146.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435139-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_146.sdi to /var/lib/mysql//performance_schema/events_transacti_146.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435165-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/log_status_183.sdi to /var/lib/mysql//performance_schema/log_status_183.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435209-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/log_status_183.sdi to /var/lib/mysql//performance_schema/log_status_183.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435237-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_his_94.sdi to /var/lib/mysql//performance_schema/events_waits_his_94.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435281-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_his_94.sdi to /var/lib/mysql//performance_schema/events_waits_his_94.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435309-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_hi_122.sdi to /var/lib/mysql//performance_schema/events_stages_hi_122.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435353-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_hi_122.sdi to /var/lib/mysql//performance_schema/events_stages_hi_122.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435380-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/data_locks_169.sdi to /var/lib/mysql//performance_schema/data_locks_169.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435425-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/data_locks_169.sdi to /var/lib/mysql//performance_schema/data_locks_169.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435454-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/setup_objects_114.sdi to /var/lib/mysql//performance_schema/setup_objects_114.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435499-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/setup_objects_114.sdi to /var/lib/mysql//performance_schema/setup_objects_114.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435526-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/socket_instances_156.sdi to /var/lib/mysql//performance_schema/socket_instances_156.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435571-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/socket_instances_156.sdi to /var/lib/mysql//performance_schema/socket_instances_156.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435597-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/cond_instances_91.sdi to /var/lib/mysql//performance_schema/cond_instances_91.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435641-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/cond_instances_91.sdi to /var/lib/mysql//performance_schema/cond_instances_91.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435668-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/table_lock_waits_118.sdi to /var/lib/mysql//performance_schema/table_lock_waits_118.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435712-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/table_lock_waits_118.sdi to /var/lib/mysql//performance_schema/table_lock_waits_118.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435739-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_129.sdi to /var/lib/mysql//performance_schema/events_statement_129.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435785-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_129.sdi to /var/lib/mysql//performance_schema/events_statement_129.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435811-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_139.sdi to /var/lib/mysql//performance_schema/events_statement_139.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435856-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_139.sdi to /var/lib/mysql//performance_schema/events_statement_139.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435883-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_appl_176.sdi to /var/lib/mysql//performance_schema/replication_appl_176.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435930-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_appl_176.sdi to /var/lib/mysql//performance_schema/replication_appl_176.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.435956-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/objects_summary__107.sdi to /var/lib/mysql//performance_schema/objects_summary__107.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436001-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/objects_summary__107.sdi to /var/lib/mysql//performance_schema/objects_summary__107.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436030-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/status_by_accoun_186.sdi to /var/lib/mysql//performance_schema/status_by_accoun_186.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436075-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/status_by_accoun_186.sdi to /var/lib/mysql//performance_schema/status_by_accoun_186.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436103-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_errors_su_151.sdi to /var/lib/mysql//performance_schema/events_errors_su_151.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436148-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_errors_su_151.sdi to /var/lib/mysql//performance_schema/events_errors_su_151.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436175-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_su_124.sdi to /var/lib/mysql//performance_schema/events_stages_su_124.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436221-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_su_124.sdi to /var/lib/mysql//performance_schema/events_stages_su_124.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436247-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/file_summary_by__103.sdi to /var/lib/mysql//performance_schema/file_summary_by__103.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436295-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/file_summary_by__103.sdi to /var/lib/mysql//performance_schema/file_summary_by__103.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436321-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_appl_175.sdi to /var/lib/mysql//performance_schema/replication_appl_175.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436367-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_appl_175.sdi to /var/lib/mysql//performance_schema/replication_appl_175.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436394-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_128.sdi to /var/lib/mysql//performance_schema/events_statement_128.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436440-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_128.sdi to /var/lib/mysql//performance_schema/events_statement_128.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436467-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/table_io_waits_s_116.sdi to /var/lib/mysql//performance_schema/table_io_waits_s_116.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436513-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/table_io_waits_s_116.sdi to /var/lib/mysql//performance_schema/table_io_waits_s_116.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436539-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_su_127.sdi to /var/lib/mysql//performance_schema/events_stages_su_127.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436584-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_su_127.sdi to /var/lib/mysql//performance_schema/events_stages_su_127.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436612-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/session_account__160.sdi to /var/lib/mysql//performance_schema/session_account__160.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436658-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/session_account__160.sdi to /var/lib/mysql//performance_schema/session_account__160.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436685-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_appl_174.sdi to /var/lib/mysql//performance_schema/replication_appl_174.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436731-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_appl_174.sdi to /var/lib/mysql//performance_schema/replication_appl_174.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436758-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/setup_actors_111.sdi to /var/lib/mysql//performance_schema/setup_actors_111.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436803-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/setup_actors_111.sdi to /var/lib/mysql//performance_schema/setup_actors_111.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436833-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_errors_su_150.sdi to /var/lib/mysql//performance_schema/events_errors_su_150.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436879-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_errors_su_150.sdi to /var/lib/mysql//performance_schema/events_errors_su_150.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436907-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_sum_100.sdi to /var/lib/mysql//performance_schema/events_waits_sum_100.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436965-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_sum_100.sdi to /var/lib/mysql//performance_schema/events_waits_sum_100.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.436997-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/status_by_user_189.sdi to /var/lib/mysql//performance_schema/status_by_user_189.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437044-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/status_by_user_189.sdi to /var/lib/mysql//performance_schema/status_by_user_189.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437072-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_grou_178.sdi to /var/lib/mysql//performance_schema/replication_grou_178.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437118-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_grou_178.sdi to /var/lib/mysql//performance_schema/replication_grou_178.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437148-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/tls_channel_stat_199.sdi to /var/lib/mysql//performance_schema/tls_channel_stat_199.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437194-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/tls_channel_stat_199.sdi to /var/lib/mysql//performance_schema/tls_channel_stat_199.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437222-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_grou_172.sdi to /var/lib/mysql//performance_schema/replication_grou_172.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437270-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_grou_172.sdi to /var/lib/mysql//performance_schema/replication_grou_172.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437298-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/memory_summary_b_163.sdi to /var/lib/mysql//performance_schema/memory_summary_b_163.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437345-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/memory_summary_b_163.sdi to /var/lib/mysql//performance_schema/memory_summary_b_163.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437373-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/performance_time_108.sdi to /var/lib/mysql//performance_schema/performance_time_108.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437419-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/performance_time_108.sdi to /var/lib/mysql//performance_schema/performance_time_108.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437446-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/global_variables_193.sdi to /var/lib/mysql//performance_schema/global_variables_193.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437492-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/global_variables_193.sdi to /var/lib/mysql//performance_schema/global_variables_193.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437520-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_138.sdi to /var/lib/mysql//performance_schema/events_statement_138.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437567-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_138.sdi to /var/lib/mysql//performance_schema/events_statement_138.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437594-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/hosts_155.sdi to /var/lib/mysql//performance_schema/hosts_155.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437640-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/hosts_155.sdi to /var/lib/mysql//performance_schema/hosts_155.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437670-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/setup_consumers_112.sdi to /var/lib/mysql//performance_schema/setup_consumers_112.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437716-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/setup_consumers_112.sdi to /var/lib/mysql//performance_schema/setup_consumers_112.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437744-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_su_125.sdi to /var/lib/mysql//performance_schema/events_stages_su_125.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437792-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_su_125.sdi to /var/lib/mysql//performance_schema/events_stages_su_125.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437819-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/user_variables_b_185.sdi to /var/lib/mysql//performance_schema/user_variables_b_185.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437867-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/user_variables_b_185.sdi to /var/lib/mysql//performance_schema/user_variables_b_185.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437894-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_137.sdi to /var/lib/mysql//performance_schema/events_statement_137.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437941-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_137.sdi to /var/lib/mysql//performance_schema/events_statement_137.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.437969-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_su_126.sdi to /var/lib/mysql//performance_schema/events_stages_su_126.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438018-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_su_126.sdi to /var/lib/mysql//performance_schema/events_stages_su_126.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438046-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/binary_log_trans_198.sdi to /var/lib/mysql//performance_schema/binary_log_trans_198.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438092-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/binary_log_trans_198.sdi to /var/lib/mysql//performance_schema/binary_log_trans_198.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438121-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/socket_summary_b_157.sdi to /var/lib/mysql//performance_schema/socket_summary_b_157.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438168-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/socket_summary_b_157.sdi to /var/lib/mysql//performance_schema/socket_summary_b_157.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438196-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_appl_180.sdi to /var/lib/mysql//performance_schema/replication_appl_180.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438244-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_appl_180.sdi to /var/lib/mysql//performance_schema/replication_appl_180.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438271-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_sum_99.sdi to /var/lib/mysql//performance_schema/events_waits_sum_99.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438320-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_sum_99.sdi to /var/lib/mysql//performance_schema/events_waits_sum_99.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438348-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/keyring_keys_161.sdi to /var/lib/mysql//performance_schema/keyring_keys_161.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438395-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/keyring_keys_161.sdi to /var/lib/mysql//performance_schema/keyring_keys_161.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438423-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/session_connect__159.sdi to /var/lib/mysql//performance_schema/session_connect__159.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438471-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/session_connect__159.sdi to /var/lib/mysql//performance_schema/session_connect__159.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438502-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/global_status_190.sdi to /var/lib/mysql//performance_schema/global_status_190.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438549-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/global_status_190.sdi to /var/lib/mysql//performance_schema/global_status_190.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438578-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/metadata_locks_168.sdi to /var/lib/mysql//performance_schema/metadata_locks_168.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438625-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/metadata_locks_168.sdi to /var/lib/mysql//performance_schema/metadata_locks_168.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438653-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/status_by_host_187.sdi to /var/lib/mysql//performance_schema/status_by_host_187.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438700-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/status_by_host_187.sdi to /var/lib/mysql//performance_schema/status_by_host_187.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438728-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/table_handles_167.sdi to /var/lib/mysql//performance_schema/table_handles_167.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438775-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/table_handles_167.sdi to /var/lib/mysql//performance_schema/table_handles_167.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438803-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/error_log_92.sdi to /var/lib/mysql//performance_schema/error_log_92.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438850-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/error_log_92.sdi to /var/lib/mysql//performance_schema/error_log_92.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438881-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_appl_177.sdi to /var/lib/mysql//performance_schema/replication_appl_177.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438930-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_appl_177.sdi to /var/lib/mysql//performance_schema/replication_appl_177.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.438958-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_136.sdi to /var/lib/mysql//performance_schema/events_statement_136.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439007-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_136.sdi to /var/lib/mysql//performance_schema/events_statement_136.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439036-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_sum_101.sdi to /var/lib/mysql//performance_schema/events_waits_sum_101.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439085-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_sum_101.sdi to /var/lib/mysql//performance_schema/events_waits_sum_101.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439114-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_errors_su_149.sdi to /var/lib/mysql//performance_schema/events_errors_su_149.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439163-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_errors_su_149.sdi to /var/lib/mysql//performance_schema/events_errors_su_149.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439191-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/users_153.sdi to /var/lib/mysql//performance_schema/users_153.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439239-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/users_153.sdi to /var/lib/mysql//performance_schema/users_153.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439267-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_142.sdi to /var/lib/mysql//performance_schema/events_transacti_142.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439317-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_142.sdi to /var/lib/mysql//performance_schema/events_transacti_142.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439348-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_su_123.sdi to /var/lib/mysql//performance_schema/events_stages_su_123.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439398-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_su_123.sdi to /var/lib/mysql//performance_schema/events_stages_su_123.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439427-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_141.sdi to /var/lib/mysql//performance_schema/events_transacti_141.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439475-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_141.sdi to /var/lib/mysql//performance_schema/events_transacti_141.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439503-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/data_lock_waits_170.sdi to /var/lib/mysql//performance_schema/data_lock_waits_170.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439552-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/data_lock_waits_170.sdi to /var/lib/mysql//performance_schema/data_lock_waits_170.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439580-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_147.sdi to /var/lib/mysql//performance_schema/events_transacti_147.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439629-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_147.sdi to /var/lib/mysql//performance_schema/events_transacti_147.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439657-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_135.sdi to /var/lib/mysql//performance_schema/events_statement_135.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439706-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_135.sdi to /var/lib/mysql//performance_schema/events_statement_135.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439735-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_stages_hi_121.sdi to /var/lib/mysql//performance_schema/events_stages_hi_121.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439790-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_stages_hi_121.sdi to /var/lib/mysql//performance_schema/events_stages_hi_121.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439818-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/variables_info_195.sdi to /var/lib/mysql//performance_schema/variables_info_195.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439866-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/variables_info_195.sdi to /var/lib/mysql//performance_schema/variables_info_195.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439894-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/variables_by_thr_192.sdi to /var/lib/mysql//performance_schema/variables_by_thr_192.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439943-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/variables_by_thr_192.sdi to /var/lib/mysql//performance_schema/variables_by_thr_192.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.439973-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_sum_96.sdi to /var/lib/mysql//performance_schema/events_waits_sum_96.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440022-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_sum_96.sdi to /var/lib/mysql//performance_schema/events_waits_sum_96.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440050-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_his_95.sdi to /var/lib/mysql//performance_schema/events_waits_his_95.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440099-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_his_95.sdi to /var/lib/mysql//performance_schema/events_waits_his_95.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440127-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_cur_93.sdi to /var/lib/mysql//performance_schema/events_waits_cur_93.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440175-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_cur_93.sdi to /var/lib/mysql//performance_schema/events_waits_cur_93.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440207-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_140.sdi to /var/lib/mysql//performance_schema/events_transacti_140.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440258-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_140.sdi to /var/lib/mysql//performance_schema/events_transacti_140.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440287-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/memory_summary_b_166.sdi to /var/lib/mysql//performance_schema/memory_summary_b_166.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440337-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/memory_summary_b_166.sdi to /var/lib/mysql//performance_schema/memory_summary_b_166.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440366-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/file_instances_102.sdi to /var/lib/mysql//performance_schema/file_instances_102.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440417-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/file_instances_102.sdi to /var/lib/mysql//performance_schema/file_instances_102.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440447-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_waits_sum_98.sdi to /var/lib/mysql//performance_schema/events_waits_sum_98.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440497-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_waits_sum_98.sdi to /var/lib/mysql//performance_schema/events_waits_sum_98.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440527-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_transacti_144.sdi to /var/lib/mysql//performance_schema/events_transacti_144.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440580-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_transacti_144.sdi to /var/lib/mysql//performance_schema/events_transacti_144.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440610-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/replication_appl_179.sdi to /var/lib/mysql//performance_schema/replication_appl_179.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440660-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/replication_appl_179.sdi to /var/lib/mysql//performance_schema/replication_appl_179.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440691-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/host_cache_105.sdi to /var/lib/mysql//performance_schema/host_cache_105.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440740-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/host_cache_105.sdi to /var/lib/mysql//performance_schema/host_cache_105.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440769-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/events_statement_134.sdi to /var/lib/mysql//performance_schema/events_statement_134.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440820-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/events_statement_134.sdi to /var/lib/mysql//performance_schema/events_statement_134.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440848-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/prepared_stateme_184.sdi to /var/lib/mysql//performance_schema/prepared_stateme_184.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440899-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/prepared_stateme_184.sdi to /var/lib/mysql//performance_schema/prepared_stateme_184.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.440928-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./performance_schema/memory_summary_g_162.sdi to /var/lib/mysql//performance_schema/memory_summary_g_162.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.441058-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./performance_schema/memory_summary_g_162.sdi to /var/lib/mysql//performance_schema/memory_summary_g_162.sdi\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.441093-00:00 1 [Note] [MY-011825] [Xtrabackup] Moving ./ib_buffer_pool to /var/lib/mysql//ib_buffer_pool\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.441141-00:00 1 [Note] [MY-011825] [Xtrabackup] Done: Moving file ./ib_buffer_pool to /var/lib/mysql//ib_buffer_pool\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"2024-02-09T10:46:55.530940-00:00 0 [Note] [MY-011825] [Xtrabackup] completed OK!\n","file":"/var/lib/mysql/innobackup.move.log"}
+{"log":"---- Starting the MySQL server used for post-processing ----\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:55.944932Z 0 [Warning] [MY-011068] [Server] The syntax '--skip-host-cache' is deprecated and will be removed in a future release. Please use SET GLOBAL host_cache_size=0 instead.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:55.944990Z 0 [Warning] [MY-011068] [Server] The syntax 'wsrep_slave_threads' is deprecated and will be removed in a future release. Please use wsrep_applier_threads instead.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:55.945023Z 0 [Warning] [MY-011068] [Server] The syntax 'skip_slave_start' is deprecated and will be removed in a future release. Please use skip_replica_start instead.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:55.947170Z 0 [Warning] [MY-010097] [Server] Insecure configuration for --secure-log-path: Current value does not restrict location of generated files. Consider setting it to a valid, non-empty path.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:55.947233Z 0 [Warning] [MY-000000] [WSREP] Node is not a cluster node. Disabling pxc_strict_mode\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:55.948110Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.32-24.2) starting as process 1050\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:55.952119Z 0 [Warning] [MY-010068] [Server] CA certificate /etc/mysql/ssl-internal/ca.crt is self signed.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:55.952155Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:55.954474Z 0 [Warning] [MY-010075] [Server] No existing UUID has been found, so we assume that this is the first time that this server has been started. Generating a new UUID: 8b055a8d-c738-11ee-a519-ca8c5cddcae6.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:55.965523Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:56.308105Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:56.562206Z 1 [Note] [MY-000000] [WSREP] wsrep_init_schema_and_SR (nil)\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:56.587857Z 1 [System] [MY-000000] [WSREP] PXC upgrade completed successfully\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:56.684256Z 0 [System] [MY-010229] [Server] Starting XA crash recovery...\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:56.698615Z 0 [System] [MY-010232] [Server] XA crash recovery finished.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:56.819537Z 0 [Warning] [MY-010068] [Server] CA certificate /etc/mysql/ssl-internal/ca.crt is self signed.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:56.819585Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:56.830851Z 0 [Warning] [MY-013595] [Server] Failed to initialize TLS for channel: mysql_admin. See below for the description of exact issue.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:56.830907Z 0 [Warning] [MY-010069] [Server] Failed to set up SSL because of the following SSL library error: SSL context is not usable without certificate and private key\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:56.830923Z 0 [System] [MY-013603] [Server] No TLS configuration was given for channel mysql_admin; re-using TLS configuration of channel mysql_main.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:56.932071Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/tmp' in the path is accessible to all OS users. Consider choosing a different directory.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:56.967263Z 0 [Note] [MY-000000] [WSREP] Initialized wsrep sidno 3\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:56.967327Z 0 [Note] [MY-000000] [Galera] Loading provider none initial position: 00000000-0000-0000-0000-000000000000:-1\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:56.967340Z 0 [Note] [MY-000000] [Galera] wsrep_load(): loading provider library 'none'\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:56.983871Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.32-24.2'  socket: '/tmp/upgrd.RE5x/my.sock'  port: 0  Percona XtraDB Cluster (GPL), Release rel24, Revision 2119e75, WSREP version 26.1.4.3.\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:56.983902Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Socket: /var/lib/mysql/mysqlx.sock\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:57.719464Z 11 [System] [MY-013172] [Server] Received SHUTDOWN from user mysql.pxc.sst.user. Shutting down mysqld (Version: 8.0.32-24.2).\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:46:59.767105Z 0 [Note] [MY-000000] [WSREP-SST] ...........post-processing done\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:59.771412Z 0 [Note] [MY-000000] [WSREP-SST] Galera co-ords from recovery: 103be6ae-c738-11ee-95d1-526d43d08e41:36\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:59.795621Z 3 [Note] [MY-000000] [Galera] Processing SST received\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:59.795682Z 3 [Note] [MY-000000] [WSREP] Server status change joiner -> initializing\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:59.795721Z 3 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:59.815955Z 4 [System] [MY-013576] [InnoDB] InnoDB initialization has started.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:46:59.255089Z 0 [System] [MY-010910] [Server] /usr/sbin/mysqld: Shutdown complete (mysqld 8.0.32-24.2)  Percona XtraDB Cluster (GPL), Release rel24, Revision 2119e75, WSREP version 26.1.4.3.\n---- Stopped the MySQL server used for post-processing ----\n","file":"/var/lib/mysql/mysqld.post.processing.log"}
+{"log":"2024-02-09T10:47:00.107070Z 4 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.286757Z 4 [Note] [MY-000000] [WSREP] wsrep_init_schema_and_SR (nil)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.311705Z 4 [System] [MY-000000] [WSREP] PXC upgrade completed successfully\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.552077Z 0 [Warning] [MY-010068] [Server] CA certificate /etc/mysql/ssl-internal/ca.crt is self signed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.552134Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.563222Z 0 [Warning] [MY-013595] [Server] Failed to initialize TLS for channel: mysql_admin. See below for the description of exact issue.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.563308Z 0 [Warning] [MY-010069] [Server] Failed to set up SSL because of the following SSL library error: SSL context is not usable without certificate and private key\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.563322Z 0 [System] [MY-013603] [Server] No TLS configuration was given for channel mysql_admin; re-using TLS configuration of channel mysql_main.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.570525Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/var/lib/mysql' in the path is accessible to all OS users. Consider choosing a different directory.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.605362Z 0 [Note] [MY-000000] [WSREP] Initialized wsrep sidno 2\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.605441Z 0 [Note] [MY-000000] [Galera] Server initialized\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.605471Z 0 [Note] [MY-000000] [WSREP] Server status change initializing -> initialized\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.605522Z 0 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.605623Z 3 [Note] [MY-000000] [Galera] Recovered position from storage: 103be6ae-c738-11ee-95d1-526d43d08e41:36\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.605664Z 3 [Note] [MY-000000] [WSREP] Server status change initialized -> joined\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.605674Z 3 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.606074Z 10 [Note] [MY-000000] [WSREP] Starting applier thread 10\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.607578Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Bind-address: '::' port: 33060, socket: /var/lib/mysql/mysqlx.sock\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.607819Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.32-24.2'  socket: '/tmp/mysql.sock'  port: 3306  Percona XtraDB Cluster (GPL), Release rel24, Revision 2119e75, WSREP version 26.1.4.3.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.607861Z 0 [System] [MY-013292] [Server] Admin interface ready for connections, address: '10.42.1.6'  port: 33062\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.609963Z 3 [Note] [MY-000000] [Galera] Recovered view from SST:\n  id: 103be6ae-c738-11ee-95d1-526d43d08e41:36\n  status: primary\n  protocol_version: 4\n  capabilities: MULTI-MASTER, CERTIFICATION, PARALLEL_APPLYING, REPLAY, ISOLATION, PAUSE, CAUSAL_READ, INCREMENTAL_WS, UNORDERED, PREORDERED, STREAMING, NBO\n  final: no\n  own_index: 2\n  members(3):\n\t0: 213e9b53-c738-11ee-8c4d-03cb16bd2d32, cluster1-pxc-0\n\t1: 486b248f-c738-11ee-8ac6-0a8a79d0dabd, cluster1-pxc-1\n\t2: 7eee9476-c738-11ee-83f9-e3e1dce47b60, cluster1-pxc-2\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.610027Z 3 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.610261Z 12 [Note] [MY-000000] [WSREP] Recovered cluster id 103be6ae-c738-11ee-95d1-526d43d08e41\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.613694Z 3 [Note] [MY-000000] [Galera] SST received: 103be6ae-c738-11ee-95d1-526d43d08e41:36\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.613759Z 3 [System] [MY-000000] [WSREP] SST completed\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.613811Z 1 [Note] [MY-000000] [Galera]  str_proto_ver_: 3 sst_seqno_: 36 cc_seqno: 36 req->ist_len(): 64\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.613861Z 1 [Note] [MY-000000] [Galera] Installed new state from SST: 103be6ae-c738-11ee-95d1-526d43d08e41:36\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.620488Z 1 [Note] [MY-000000] [Galera] Cert. index preload up to 36\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.620547Z 0 [Note] [MY-000000] [Galera] ####### IST applying starts with 37\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.620689Z 0 [Note] [MY-000000] [Galera] ####### IST current seqno initialized to 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.620776Z 0 [Note] [MY-000000] [Galera] Receiving IST...  0.0% ( 0/13 events) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.620789Z 0 [Note] [MY-000000] [Galera] IST preload starting at 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.620840Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.620903Z 0 [Note] [MY-000000] [Galera] ####### Assign initial position for certification: 00000000-0000-0000-0000-000000000000:23, protocol version: 5\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.621094Z 0 [Note] [MY-000000] [Galera] ####### Passing IST CC 35, must_apply: 0, preload: true\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.621131Z 0 [Note] [MY-000000] [Galera] REPL Protocols: 10 (5)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.621140Z 0 [Note] [MY-000000] [Galera] ####### Adjusting cert position: 34 -> 35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.621221Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.621320Z 0 [Note] [MY-000000] [Galera] Recording CC from preload: 35\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.621360Z 0 [Note] [MY-000000] [Galera] Lowest cert index boundary for CC from preload: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.621371Z 0 [Note] [MY-000000] [Galera] Min available from gcache for CC from preload: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.621419Z 0 [Note] [MY-000000] [Galera] ####### Passing IST CC 36, must_apply: 0, preload: true\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.621445Z 0 [Note] [MY-000000] [Galera] REPL Protocols: 10 (5)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.621454Z 0 [Note] [MY-000000] [Galera] ####### Adjusting cert position: 35 -> 36\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.621535Z 0 [Note] [MY-000000] [Galera] Service thread queue flushed.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.621647Z 0 [Note] [MY-000000] [Galera] Recording CC from preload: 36\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.621680Z 0 [Note] [MY-000000] [Galera] Lowest cert index boundary for CC from preload: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.621689Z 0 [Note] [MY-000000] [Galera] Min available from gcache for CC from preload: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.621725Z 0 [Note] [MY-000000] [Galera] Receiving IST...100.0% (13/13 events) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.622122Z 1 [Note] [MY-000000] [Galera] IST received: 103be6ae-c738-11ee-95d1-526d43d08e41:36\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.622167Z 1 [Note] [MY-000000] [Galera] Recording CC from sst: 36\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.622176Z 1 [Note] [MY-000000] [Galera] Lowest cert index boundary for CC from sst: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.622183Z 1 [Note] [MY-000000] [Galera] Min available from gcache for CC from sst: 24\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.622832Z 0 [Note] [MY-000000] [Galera] 2.0 (cluster1-pxc-2): State transfer from 1.0 (cluster1-pxc-1) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.622887Z 0 [Note] [MY-000000] [Galera] SST leaving flow control\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.622913Z 0 [Note] [MY-000000] [Galera] Shifting JOINER -> JOINED (TO: 36)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.623002Z 0 [Note] [MY-000000] [Galera] Processing event queue:... -nan% (0/0 events) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.623576Z 0 [Note] [MY-000000] [Galera] Member 2.0 (cluster1-pxc-2) synced with group.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.623615Z 0 [Note] [MY-000000] [Galera] Processing event queue:...100.0% (1/1 events) complete.\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.623634Z 0 [Note] [MY-000000] [Galera] Shifting JOINED -> SYNCED (TO: 36)\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.623684Z 1 [Note] [MY-000000] [Galera] Server cluster1-pxc-2 synced with group\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.623729Z 1 [Note] [MY-000000] [WSREP] Server status change joined -> synced\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.623747Z 1 [Note] [MY-000000] [WSREP] Synchronized with group, ready for connections\n","file":"/var/lib/mysql/mysqld-error.log"}
+{"log":"2024-02-09T10:47:00.623761Z 1 [Note] [MY-000000] [WSREP] wsrep_notify_cmd is not defined, skipping notification.\n","file":"/var/lib/mysql/mysqld-error.log"}
++ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/fluent-bit/bin
++ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/fluent-bit/bin
++ '[' logrotate = logrotate ']'
++ [[ 1001 != 1001 ]]
++ exec go-cron '0 0 * * *' sh -c 'logrotate -s /opt/percona/logrotate/logrotate.status /opt/percona/logrotate/logrotate-mysql.conf;/usr/bin/find /var/lib/mysql/ -name GRA_*.log -mtime +7 -delete'
+new cron: 0 0 * * *

--- a/src/go/pt-galera-log-explainer/types/logctx.go
+++ b/src/go/pt-galera-log-explainer/types/logctx.go
@@ -24,6 +24,7 @@ type LogCtx struct {
 	statePostProcessingLog string
 	stateBackupLog         string
 	Version                string
+	OperatorMetadata       *OperatorMetadata
 
 	// SSTs where key is donor name, as it will always be known.
 	// is meant to be shared with a deep copy, there's no sense to share the pointer

--- a/src/go/pt-galera-log-explainer/types/operator.go
+++ b/src/go/pt-galera-log-explainer/types/operator.go
@@ -1,0 +1,7 @@
+package types
+
+type OperatorMetadata struct {
+	PodName    string
+	Deployment string
+	Namespace  string
+}

--- a/src/go/pt-galera-log-explainer/types/operator.go
+++ b/src/go/pt-galera-log-explainer/types/operator.go
@@ -1,5 +1,9 @@
 package types
 
+const (
+	OperatorLogPrefix = `{"log":"`
+)
+
 type OperatorMetadata struct {
 	PodName    string
 	Deployment string

--- a/src/go/pt-galera-log-explainer/types/timeline.go
+++ b/src/go/pt-galera-log-explainer/types/timeline.go
@@ -40,11 +40,10 @@ func (timeline Timeline) MergeByIdentifier(lt LocalTimeline) {
 
 func (timeline Timeline) MergeByDirectory(path string, lt LocalTimeline) {
 	node := filepath.Base(filepath.Dir(path))
-MERGE:
 	for _, lt2 := range timeline {
 		if len(lt2) > 0 && node == filepath.Base(filepath.Dir(lt2[0].LogCtx.FilePath)) {
 			lt = MergeTimeline(lt2, lt)
-			break MERGE
+			break
 		}
 	}
 	timeline[node] = lt
@@ -59,7 +58,6 @@ func (timeline Timeline) MergeByPodnameElsePath(path string, lt LocalTimeline) {
 		timeline[path] = lt
 		return
 	}
-MERGE:
 	for _, lt2 := range timeline {
 		if len(lt2) == 0 {
 			continue
@@ -70,7 +68,7 @@ MERGE:
 			metadata.Namespace == metadata2.Namespace {
 
 			lt = MergeTimeline(lt2, lt)
-			break MERGE
+			break
 		}
 	}
 	timeline[metadata.PodName] = lt


### PR DESCRIPTION
Don't get scared by +6482 lines, most of it is from adding a regression test (locally generated)
To me commits are short enough, let me know if that's too much. 

summary of various changes:

- "grep -a": because some logs are sent in a binary format, even though it's actually readable.
- --skip-merge: useful for cases with identical wsrep node names (got one in actual customer case)
- small refactor of "extractor" sub-logger. It was not using the same params as the general one, it was giving 2 formats of log when using -vv

operators log improvements: 
- auto detection because many people missed --pxc-operator
- setting pod name as identifier because it make more sense than using filenames
- enabling a merge mechanism because many customer cases ends up having many pt-k8s-debug-collector with completely different log files when pvc is destroyed. (merge uses podname+deployment+namespace)

**Important**:
- logs have been added in b15cdf2, but they were generated using a local k3d setup.
- make sure to review 3a5bde7, this is a debatable change. (https://github.com/alecthomas/kong/issues/408)

If this format of PR is not ideal let me know. 

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] Documentation updated
- [x] Test suite update
