### PR TITLE
PT-2295 - fix tests on distributions

### DIFF
--- a/bin/pt-archiver
+++ b/bin/pt-archiver
@@ -4076,8 +4076,14 @@ sub get_master_status {
       return;
    }
 
-   my $sth = $self->{sths}->{$dbh}->{MASTER_STATUS}
+   my $sth;
+   if ( $self->{sths}->{$dbh} && $dbh && $self->{sths}->{$dbh} == $dbh ) {
+      $sth = $self->{sths}->{$dbh}->{MASTER_STATUS}
          ||= $dbh->prepare('SHOW MASTER STATUS');
+   }
+   else {
+      $sth = $dbh->prepare('SHOW MASTER STATUS');
+   }
    PTDEBUG && _d($dbh, 'SHOW MASTER STATUS');
    $sth->execute();
    my ($ms) = @{$sth->fetchall_arrayref({})};

--- a/bin/pt-archiver
+++ b/bin/pt-archiver
@@ -4728,7 +4728,9 @@ sub lost_connection {
    my ($self, $e) = @_;
    return 0 unless $e;
    return $e =~ m/MySQL server has gone away/
+       || $e =~ m/Server has gone away/
        || $e =~ m/Lost connection to MySQL server/
+       || $e =~ m/Lost connection to server/
        || $e =~ m/Server shutdown in progress/;
 }
 

--- a/bin/pt-config-diff
+++ b/bin/pt-config-diff
@@ -2433,7 +2433,9 @@ sub lost_connection {
    my ($self, $e) = @_;
    return 0 unless $e;
    return $e =~ m/MySQL server has gone away/
+       || $e =~ m/Server has gone away/
        || $e =~ m/Lost connection to MySQL server/
+       || $e =~ m/Lost connection to server/
        || $e =~ m/Server shutdown in progress/;
 }
 

--- a/bin/pt-deadlock-logger
+++ b/bin/pt-deadlock-logger
@@ -2777,7 +2777,9 @@ sub lost_connection {
    my ($self, $e) = @_;
    return 0 unless $e;
    return $e =~ m/MySQL server has gone away/
+       || $e =~ m/Server has gone away/
        || $e =~ m/Lost connection to MySQL server/
+       || $e =~ m/Lost connection to server/
        || $e =~ m/Server shutdown in progress/;
 }
 

--- a/bin/pt-fk-error-logger
+++ b/bin/pt-fk-error-logger
@@ -1931,7 +1931,9 @@ sub lost_connection {
    my ($self, $e) = @_;
    return 0 unless $e;
    return $e =~ m/MySQL server has gone away/
+       || $e =~ m/Server has gone away/
        || $e =~ m/Lost connection to MySQL server/
+       || $e =~ m/Lost connection to server/
        || $e =~ m/Server shutdown in progress/;
 }
 

--- a/bin/pt-heartbeat
+++ b/bin/pt-heartbeat
@@ -553,8 +553,14 @@ sub get_master_status {
       return;
    }
 
-   my $sth = $self->{sths}->{$dbh}->{MASTER_STATUS}
+   my $sth;
+   if ( $self->{sths}->{$dbh} && $dbh && $self->{sths}->{$dbh} == $dbh ) {
+      $sth = $self->{sths}->{$dbh}->{MASTER_STATUS}
          ||= $dbh->prepare('SHOW MASTER STATUS');
+   }
+   else {
+      $sth = $dbh->prepare('SHOW MASTER STATUS');
+   }
    PTDEBUG && _d($dbh, 'SHOW MASTER STATUS');
    $sth->execute();
    my ($ms) = @{$sth->fetchall_arrayref({})};

--- a/bin/pt-kill
+++ b/bin/pt-kill
@@ -4353,8 +4353,14 @@ sub get_master_status {
       return;
    }
 
-   my $sth = $self->{sths}->{$dbh}->{MASTER_STATUS}
+   my $sth;
+   if ( $self->{sths}->{$dbh} && $dbh && $self->{sths}->{$dbh} == $dbh ) {
+      $sth = $self->{sths}->{$dbh}->{MASTER_STATUS}
          ||= $dbh->prepare('SHOW MASTER STATUS');
+   }
+   else {
+      $sth = $dbh->prepare('SHOW MASTER STATUS');
+   }
    PTDEBUG && _d($dbh, 'SHOW MASTER STATUS');
    $sth->execute();
    my ($ms) = @{$sth->fetchall_arrayref({})};

--- a/bin/pt-kill
+++ b/bin/pt-kill
@@ -5543,7 +5543,9 @@ sub lost_connection {
    my ($self, $e) = @_;
    return 0 unless $e;
    return $e =~ m/MySQL server has gone away/
+       || $e =~ m/Server has gone away/
        || $e =~ m/Lost connection to MySQL server/
+       || $e =~ m/Lost connection to server/
        || $e =~ m/Server shutdown in progress/;
 }
 
@@ -7177,7 +7179,11 @@ sub main {
                # The 1st pattern means that MySQL itself died or was stopped.
                # The 2nd pattern means that our cxn was killed (KILL <id>).
                if (    $error =~ m/MySQL server has gone away/
+                    || $error =~ m/Server has gone away/
+                    || $error =~ m/Lost connection to server/
                     || $error =~ m/Lost connection to MySQL server/ ) {
+                  eval {
+                  eval {
                   eval {
                      $dbh      = $cxn->connect();
                      $proc_sth = $dbh->prepare('SHOW FULL PROCESSLIST');
@@ -7210,6 +7216,8 @@ sub main {
                # The 1st pattern means that MySQL itself died or was stopped.
                # The 2nd pattern means that our cxn was killed (KILL <id>).
                if (    $error =~ m/MySQL server has gone away/
+                    || $error =~ m/Server has gone away/
+                    || $error =~ m/Lost connection to server/
                     || $error =~ m/Lost connection to MySQL server/ ) {
                   eval {
                      $dbh      = $cxn->connect();
@@ -7299,6 +7307,8 @@ sub main {
                # The 1st pattern means that MySQL itself died or was stopped.
                # The 2nd pattern means that our cxn was killed (KILL <id>).
                if (    $error =~ m/MySQL server has gone away/
+                    || $error =~ m/Server has gone away/
+                    || $error =~ m/Lost connection to server/
                     || $error =~ m/Lost connection to MySQL server/ ) {
                   eval {
                      $log_dbh = $log_cxn->connect();

--- a/bin/pt-kill
+++ b/bin/pt-kill
@@ -7183,8 +7183,6 @@ sub main {
                     || $error =~ m/Lost connection to server/
                     || $error =~ m/Lost connection to MySQL server/ ) {
                   eval {
-                  eval {
-                  eval {
                      $dbh      = $cxn->connect();
                      $proc_sth = $dbh->prepare('SHOW FULL PROCESSLIST');
                      msg('Reconnected to ' . $cxn->name());

--- a/bin/pt-mysql-summary
+++ b/bin/pt-mysql-summary
@@ -2571,7 +2571,7 @@ report_mysql_summary () {
       fi
    fi
 
-   local has_rocksdb=$(cat $dir/mysql-plugins | grep -i 'rocksdb.*active.*storage engine')
+   local has_rocksdb="$(cat $dir/mysql-plugins | grep -i 'rocksdb.*active.*storage engine')"
    if [ ! -z "$has_rocksdb" ]; then
        section "RocksDB"
        section_rocksdb "$dir/mysql-variables" "$dir/mysql-status"

--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -9352,6 +9352,7 @@ sub main {
          # and the mentioned test error doesn't arise
 
          my $original_error = $EVAL_ERROR;
+         my $original_error_code = $?;
 
          foreach my $task ( reverse @cleanup_tasks ) {
             eval {
@@ -9361,7 +9362,14 @@ sub main {
                warn "Error cleaning up: $EVAL_ERROR\n";
             }
          }
-         die $original_error if $original_error;  # rethrow original error
+         
+         # rethrow original error
+         # we do not call _die here, because it prints messages to STDOUT
+         if ($original_error) {
+            print STDERR $original_error;
+            exit $original_error_code;
+         }
+         
          return;
       }
    );

--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -4039,7 +4039,9 @@ sub lost_connection {
    my ($self, $e) = @_;
    return 0 unless $e;
    return $e =~ m/MySQL server has gone away/
+       || $e =~ m/Server has gone away/
        || $e =~ m/Lost connection to MySQL server/
+       || $e =~ m/Lost connection to server/
        || $e =~ m/Server shutdown in progress/;
 }
 

--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -4641,8 +4641,14 @@ sub get_master_status {
       return;
    }
 
-   my $sth = $self->{sths}->{$dbh}->{MASTER_STATUS}
+   my $sth;
+   if ( $self->{sths}->{$dbh} && $dbh && $self->{sths}->{$dbh} == $dbh ) {
+      $sth = $self->{sths}->{$dbh}->{MASTER_STATUS}
          ||= $dbh->prepare('SHOW MASTER STATUS');
+   }
+   else {
+      $sth = $dbh->prepare('SHOW MASTER STATUS');
+   }
    PTDEBUG && _d($dbh, 'SHOW MASTER STATUS');
    $sth->execute();
    my ($ms) = @{$sth->fetchall_arrayref({})};

--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -10947,8 +10947,14 @@ sub get_master_status {
       return;
    }
 
-   my $sth = $self->{sths}->{$dbh}->{MASTER_STATUS}
+   my $sth;
+   if ( $self->{sths}->{$dbh} && $dbh && $self->{sths}->{$dbh} == $dbh ) {
+      $sth = $self->{sths}->{$dbh}->{MASTER_STATUS}
          ||= $dbh->prepare('SHOW MASTER STATUS');
+   }
+   else {
+      $sth = $dbh->prepare('SHOW MASTER STATUS');
+   }
    PTDEBUG && _d($dbh, 'SHOW MASTER STATUS');
    $sth->execute();
    my ($ms) = @{$sth->fetchall_arrayref({})};

--- a/bin/pt-slave-find
+++ b/bin/pt-slave-find
@@ -2689,8 +2689,14 @@ sub get_master_status {
       return;
    }
 
-   my $sth = $self->{sths}->{$dbh}->{MASTER_STATUS}
+   my $sth;
+   if ( $self->{sths}->{$dbh} && $dbh && $self->{sths}->{$dbh} == $dbh ) {
+      $sth = $self->{sths}->{$dbh}->{MASTER_STATUS}
          ||= $dbh->prepare('SHOW MASTER STATUS');
+   }
+   else {
+      $sth = $dbh->prepare('SHOW MASTER STATUS');
+   }
    PTDEBUG && _d($dbh, 'SHOW MASTER STATUS');
    $sth->execute();
    my ($ms) = @{$sth->fetchall_arrayref({})};

--- a/bin/pt-slave-restart
+++ b/bin/pt-slave-restart
@@ -3100,8 +3100,14 @@ sub get_master_status {
       return;
    }
 
-   my $sth = $self->{sths}->{$dbh}->{MASTER_STATUS}
+   my $sth;
+   if ( $self->{sths}->{$dbh} && $dbh && $self->{sths}->{$dbh} == $dbh ) {
+      $sth = $self->{sths}->{$dbh}->{MASTER_STATUS}
          ||= $dbh->prepare('SHOW MASTER STATUS');
+   }
+   else {
+      $sth = $dbh->prepare('SHOW MASTER STATUS');
+   }
    PTDEBUG && _d($dbh, 'SHOW MASTER STATUS');
    $sth->execute();
    my ($ms) = @{$sth->fetchall_arrayref({})};

--- a/bin/pt-table-checksum
+++ b/bin/pt-table-checksum
@@ -5604,8 +5604,14 @@ sub get_master_status {
       return;
    }
 
-   my $sth = $self->{sths}->{$dbh}->{MASTER_STATUS}
+   my $sth;
+   if ( $self->{sths}->{$dbh} && $dbh && $self->{sths}->{$dbh} == $dbh ) {
+      $sth = $self->{sths}->{$dbh}->{MASTER_STATUS}
          ||= $dbh->prepare('SHOW MASTER STATUS');
+   }
+   else {
+      $sth = $dbh->prepare('SHOW MASTER STATUS');
+   }
    PTDEBUG && _d($dbh, 'SHOW MASTER STATUS');
    $sth->execute();
    my ($ms) = @{$sth->fetchall_arrayref({})};

--- a/bin/pt-table-checksum
+++ b/bin/pt-table-checksum
@@ -3738,7 +3738,9 @@ sub lost_connection {
    my ($self, $e) = @_;
    return 0 unless $e;
    return $e =~ m/MySQL server has gone away/
+       || $e =~ m/Server has gone away/
        || $e =~ m/Lost connection to MySQL server/
+       || $e =~ m/Lost connection to server/
        || $e =~ m/Server shutdown in progress/;
 }
 

--- a/bin/pt-table-sync
+++ b/bin/pt-table-sync
@@ -7118,8 +7118,14 @@ sub get_master_status {
       return;
    }
 
-   my $sth = $self->{sths}->{$dbh}->{MASTER_STATUS}
+   my $sth;
+   if ( $self->{sths}->{$dbh} && $dbh && $self->{sths}->{$dbh} == $dbh ) {
+      $sth = $self->{sths}->{$dbh}->{MASTER_STATUS}
          ||= $dbh->prepare('SHOW MASTER STATUS');
+   }
+   else {
+      $sth = $dbh->prepare('SHOW MASTER STATUS');
+   }
    PTDEBUG && _d($dbh, 'SHOW MASTER STATUS');
    $sth->execute();
    my ($ms) = @{$sth->fetchall_arrayref({})};

--- a/bin/pt-upgrade
+++ b/bin/pt-upgrade
@@ -2604,7 +2604,9 @@ sub lost_connection {
    my ($self, $e) = @_;
    return 0 unless $e;
    return $e =~ m/MySQL server has gone away/
+       || $e =~ m/Server has gone away/
        || $e =~ m/Lost connection to MySQL server/
+       || $e =~ m/Lost connection to server/
        || $e =~ m/Server shutdown in progress/;
 }
 

--- a/lib/Cxn.pm
+++ b/lib/Cxn.pm
@@ -204,7 +204,9 @@ sub lost_connection {
    my ($self, $e) = @_;
    return 0 unless $e;
    return $e =~ m/MySQL server has gone away/
+       || $e =~ m/Server has gone away/
        || $e =~ m/Lost connection to MySQL server/
+       || $e =~ m/Lost connection to server/
        || $e =~ m/Server shutdown in progress/;
       # The 1st pattern means that MySQL itself died or was stopped.
       # The 2nd pattern means that our cxn was killed (KILL <id>).

--- a/lib/MasterSlave.pm
+++ b/lib/MasterSlave.pm
@@ -538,8 +538,14 @@ sub get_master_status {
       return;
    }
 
-   my $sth = $self->{sths}->{$dbh}->{MASTER_STATUS}
+   my $sth;
+   if ( $self->{sths}->{$dbh} && $dbh && $self->{sths}->{$dbh} == $dbh ) {
+      $sth = $self->{sths}->{$dbh}->{MASTER_STATUS}
          ||= $dbh->prepare('SHOW MASTER STATUS');
+   }
+   else {
+      $sth = $dbh->prepare('SHOW MASTER STATUS');
+   }
    PTDEBUG && _d($dbh, 'SHOW MASTER STATUS');
    $sth->execute();
    my ($ms) = @{$sth->fetchall_arrayref({})};

--- a/lib/bash/collect.sh
+++ b/lib/bash/collect.sh
@@ -317,6 +317,8 @@ collect_system_data_loop() {
    # Sleep between collect cycles.
    # Synchronize ourselves onto the clock tick, so the sleeps are 1-second
    sleep $(date +'%s.%N' | awk "{print $OPT_SLEEP_COLLECT - (\$1 % $OPT_SLEEP_COLLECT)}")
+   log "In collect_system_data_loop"
+   log  $(date +'%s.%N' | awk "{print $OPT_SLEEP_COLLECT - (\$1 % $OPT_SLEEP_COLLECT)}")
    ts="$(date +"TS %s.%N %F %T")"
 
    # #####################################################################

--- a/lib/bash/collect.sh
+++ b/lib/bash/collect.sh
@@ -317,8 +317,6 @@ collect_system_data_loop() {
    # Sleep between collect cycles.
    # Synchronize ourselves onto the clock tick, so the sleeps are 1-second
    sleep $(date +'%s.%N' | awk "{print $OPT_SLEEP_COLLECT - (\$1 % $OPT_SLEEP_COLLECT)}")
-   log "In collect_system_data_loop"
-   log  $(date +'%s.%N' | awk "{print $OPT_SLEEP_COLLECT - (\$1 % $OPT_SLEEP_COLLECT)}")
    ts="$(date +"TS %s.%N %F %T")"
 
    # #####################################################################

--- a/lib/bash/report_mysql_info.sh
+++ b/lib/bash/report_mysql_info.sh
@@ -1547,7 +1547,7 @@ report_mysql_summary () {
       fi
    fi
 
-   local has_rocksdb=$(cat $dir/mysql-plugins | grep -i 'rocksdb.*active.*storage engine')
+   local has_rocksdb="$(cat $dir/mysql-plugins | grep -i 'rocksdb.*active.*storage engine')"
    if [ ! -z "$has_rocksdb" ]; then
        section "RocksDB"
        section_rocksdb "$dir/mysql-variables" "$dir/mysql-status"

--- a/t/lib/TableParser.t
+++ b/t/lib/TableParser.t
@@ -753,7 +753,7 @@ SKIP: {
 
    # msandbox user does not have GRANT privs.
    my $root_dbh = DBI->connect(
-      "DBI:mysql:host=127.0.0.1;port=12345;mysql_ssl=1", 'root', 'msandbox',
+      "DBI:mysql:host=127.0.0.1;port=12345", 'root', 'msandbox',
       { PrintError => 0, RaiseError => 1 });
 
    $root_dbh->do(q[CREATE USER 'user'@'%' IDENTIFIED BY '';] ) || die($root_dbh->errstr);

--- a/t/lib/bash/collect.sh
+++ b/t/lib/bash/collect.sh
@@ -173,6 +173,25 @@ parse_options "$BIN_DIR/pt-stalk" --run-time 2 -- --defaults-file=/tmp/12345/my.
 
 rm $PT_TMPDIR/collect/*
 
+collect "$PT_TMPDIR/collect" "2011_12_05" > $p-output 2>&1
+
+cat $p-output
+
+iters=$(cat $p-df | grep -c '^TS ')
+is "$iters" "2" "2 iteration/2s run time"
+
+if [ -f "$p-vmstat" ]; then
+   n=$(awk '/[ ]*[0-9]/ { n += 1 } END { print n }' "$p-vmstat")
+   is \
+      "$n" \
+      "2" \
+      "vmstat runs for --run-time seconds (bug 955860)"
+else
+   is "1" "1" "SKIP vmstat not installed"
+fi
+
+rm $PT_TMPDIR/collect/*
+
 fake_opcontrol="$PT_TMPDIR/collect/fake_opcontrol"
 fake_out="$PT_TMPDIR/collect/pt-faked-opcontrol-out"
 cat <<FAKE_EXEC > "$fake_opcontrol"
@@ -192,25 +211,13 @@ collect "$PT_TMPDIR/collect" "2011_12_05" > $p-output 2>&1
 CMD_OPCONTROL=""
 OPT_COLLECT_OPROFILE=""
 
-cat $p-df | grep -c '^TS '
-iters=$(cat $p-df | grep -c '^TS ')
-is "$iters" "2" "2 iteration/2s run time"
-
 is \
    "$(cat "$fake_out")" \
    "Faked opcontrol: --init" \
    "Bug 986847: Can manually set which commands pt-stalk uses"
 
-if [ -f "$p-vmstat" ]; then
-   n=$(awk '/[ ]*[0-9]/ { n += 1 } END { print n }' "$p-vmstat")
-   is \
-      "$n" \
-      "2" \
-      "vmstat runs for --run-time seconds (bug 955860)"
-else
-   is "1" "1" "SKIP vmstat not installed"
-fi
-
 # ############################################################################
 # Done
 # ############################################################################
+
+rm $PT_TMPDIR/collect/*

--- a/t/lib/bash/collect.sh
+++ b/t/lib/bash/collect.sh
@@ -192,6 +192,7 @@ collect "$PT_TMPDIR/collect" "2011_12_05" > $p-output 2>&1
 CMD_OPCONTROL=""
 OPT_COLLECT_OPROFILE=""
 
+cat $p-df | grep -c '^TS '
 iters=$(cat $p-df | grep -c '^TS ')
 is "$iters" "2" "2 iteration/2s run time"
 

--- a/t/pt-archiver/pt-2064.t
+++ b/t/pt-archiver/pt-2064.t
@@ -37,6 +37,9 @@ $sb->create_dbs($master_dbh, ['test']);
 $sb->load_file('master', 't/pt-archiver/samples/table1.sql');
 $sb->wait_for_slaves();
 
+my $old_innodb_lock_wait_timeout = `/tmp/12345/use -ss -e 'select \@\@global.innodb_lock_wait_timeout'`;
+chomp $old_innodb_lock_wait_timeout;
+
 $master_dbh->do('set global innodb_lock_wait_timeout=1');
 
 $master_dbh->do('begin');
@@ -59,7 +62,7 @@ unlike(
 # #############################################################################
 # Done.
 # #############################################################################
-$master_dbh->do('set global innodb_lock_wait_timeout=DEFAULT');
+$master_dbh->do("set global innodb_lock_wait_timeout=$old_innodb_lock_wait_timeout");
 
 $sb->wipe_clean($master_dbh);
 ok($sb->ok(), "Sandbox servers") or BAIL_OUT(__FILE__ . " broke the sandbox");

--- a/t/pt-online-schema-change/pt-169.t
+++ b/t/pt-online-schema-change/pt-169.t
@@ -63,7 +63,7 @@ is(
       $exit_status,
       $ERROR_UPDATING_FKS,
       "--alter rename columns with uppercase names -> exit status 0",
-);
+) or diag($output);
 
 # 2
 # Since drop_swap has failed, the clueanup process should be skipped and the new table
@@ -73,7 +73,7 @@ is (
     $row->{how_many},
     1,
     "Correct number of rows",
-);
+) or diag($row);
 
 $master_dbh->do("DROP DATABASE IF EXISTS test");
 

--- a/t/pt-query-digest/explain.t
+++ b/t/pt-query-digest/explain.t
@@ -145,9 +145,11 @@ ok(
        : $sandbox_version ge '5.6' ? "t/pt-query-digest/samples/issue_1196-output-5.6.txt"
        : $sandbox_version ge '5.1' ? "t/pt-query-digest/samples/issue_1196-output.txt"
        :                             "t/pt-query-digest/samples/issue_1196-output-5.0.txt"),
+      keep_output => 1,
    ),
    "--explain sparkline uses event db and doesn't crash ea (issue 1196)"
-);
+) or diag(`cat /tmp/percona-toolkit-test-output.txt`);
+diag(`rm /tmp/percona-toolkit-test-output.txt`);
 
 # #############################################################################
 # Done.

--- a/t/pt-stalk/plugin.t
+++ b/t/pt-stalk/plugin.t
@@ -70,5 +70,6 @@ foreach my $hook (qw(
 diag(`rm $pid_file 2>/dev/null`);
 diag(`rm $log_file 2>/dev/null`);
 diag(`rm -rf $dest 2>/dev/null`);
+$sb->wipe_clean($dbh);
 ok($sb->ok(), "Sandbox servers") or BAIL_OUT(__FILE__ . " broke the sandbox");
 done_testing;

--- a/t/pt-stalk/pt-stalk-replication.t
+++ b/t/pt-stalk/pt-stalk-replication.t
@@ -78,5 +78,6 @@ is(
 
 
 cleanup();
+$sb->wipe_clean($dbh);
 ok($sb->ok(), "Sandbox servers") or BAIL_OUT(__FILE__ . " broke the sandbox");
 done_testing;

--- a/t/pt-stalk/pt-stalk.t
+++ b/t/pt-stalk/pt-stalk.t
@@ -507,7 +507,7 @@ is(
    $output,
    0,
    "Retention test 3: tests, matched auto-generated patern, are removed"
-);
+) or diag(`ls -l $dest`);
 
 # ###########################################################################
 # Test if retention by size works as expected

--- a/t/pt-stalk/pt-stalk.t
+++ b/t/pt-stalk/pt-stalk.t
@@ -993,8 +993,8 @@ SKIP: {
 # Done.
 # #############################################################################
 
-
 cleanup();
 diag(`rm -rf $dest 2>/dev/null`);
+$sb->wipe_clean($dbh);
 ok($sb->ok(), "Sandbox servers") or BAIL_OUT(__FILE__ . " broke the sandbox");
 done_testing;

--- a/t/pt-table-checksum/basics.t
+++ b/t/pt-table-checksum/basics.t
@@ -23,6 +23,10 @@ use Sandbox;
 
 require "$trunk/bin/pt-table-checksum";
 
+# We need to restart, so environment is clean for the 
+# "Default checksum" test
+diag(`$trunk/sandbox/test-env restart`);
+
 my $dp = new DSNParser(opts=>$dsn_opts);
 my $sb = new Sandbox(basedir => '/tmp', DSNParser => $dp);
 my $master_dbh = $sb->get_dbh_for('master');

--- a/t/pt-table-checksum/basics.t
+++ b/t/pt-table-checksum/basics.t
@@ -23,10 +23,6 @@ use Sandbox;
 
 require "$trunk/bin/pt-table-checksum";
 
-# We need to restart, so environment is clean for the 
-# "Default checksum" test
-diag(`$trunk/sandbox/test-env restart`);
-
 my $dp = new DSNParser(opts=>$dsn_opts);
 my $sb = new Sandbox(basedir => '/tmp', DSNParser => $dp);
 my $master_dbh = $sb->get_dbh_for('master');
@@ -81,16 +77,17 @@ sub reset_repl_db {
 # from this table after they have been added, so we cannot remove them when wipe cleaning
 # sandbox. See https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#static-dynamic-privileges
 
-# This test often fails if run after other tests, we need to see what is wrong
-# So we will re-run failed code if test does not pass.
+# This test randomly reports diffs for tables with TIMESTAMP columns
+# that have ON UPDATE action.
+# Therefore we are filtering such tables from the diff
 my $cmd = sub { pt_table_checksum::main(@args) };
 
 ok(
    no_diff(
       $cmd,
       "$sample/default-results-$sandbox_version.txt",
-      sed_out => '\'/mysql.plugin$/d; /percona_test.checksums$/d; /mysql.help_category$/d; /mysql.help_keyword$/d; /mysql.help_relation$/d; /mysql.help_topic$/d\'',
-      post_pipe => 'sed \'/mysql.plugin$/d; /percona_test.checksums$/d; /mysql.help_category$/d; /mysql.help_keyword$/d; /mysql.help_relation$/d; /mysql.help_topic$/d; /mysql.ndb_binlog_index$/d; /mysql.global_grants$/d\' | ' .
+      sed_out => '\'/mysql.plugin$/d; /percona_test.checksums$/d; /mysql.help_category$/d; /mysql.help_keyword$/d; /mysql.help_relation$/d; /mysql.help_topic$/d; /mysql.columns_priv$/d; /mysql.engine_cost$/d; /mysql.general_log$/d; /mysql.innodb_index_stats$/d; /mysql.innodb_table_stats$/d; /mysql.password_history$/d; /mysql.procs_priv$/d; /mysql.proxies_priv$/d; /mysql.server_cost$/d; /mysql.slow_log$/d; /mysql.tables_priv$/d\'',
+      post_pipe => 'sed \'/mysql.plugin$/d; /percona_test.checksums$/d; /mysql.help_category$/d; /mysql.help_keyword$/d; /mysql.help_relation$/d; /mysql.help_topic$/d; /mysql.ndb_binlog_index$/d; /mysql.global_grants$/d; /mysql.columns_priv$/d; /mysql.engine_cost$/d; /mysql.general_log$/d; /mysql.innodb_index_stats$/d; /mysql.innodb_table_stats$/d; /mysql.password_history$/d; /mysql.procs_priv$/d; /mysql.proxies_priv$/d; /mysql.server_cost$/d; /mysql.slow_log$/d; /mysql.tables_priv$/d\' | ' .
                    'awk \'{print $2 " " $3 " " $4 " " $7 " " $9}\'',
       keep_ouput => 1,
    ),

--- a/t/pt-table-checksum/basics.t
+++ b/t/pt-table-checksum/basics.t
@@ -85,7 +85,6 @@ sub reset_repl_db {
 # So we will re-run failed code if test does not pass.
 my $cmd = sub { pt_table_checksum::main(@args) };
 
-#diag(output($cmd)) 
 ok(
    no_diff(
       $cmd,

--- a/t/pt-table-checksum/basics.t
+++ b/t/pt-table-checksum/basics.t
@@ -85,16 +85,18 @@ sub reset_repl_db {
 # So we will re-run failed code if test does not pass.
 my $cmd = sub { pt_table_checksum::main(@args) };
 
-diag(output($cmd)) if not ok(
+#diag(output($cmd)) 
+ok(
    no_diff(
       $cmd,
       "$sample/default-results-$sandbox_version.txt",
       sed_out => '\'/mysql.plugin$/d; /percona_test.checksums$/d; /mysql.help_category$/d; /mysql.help_keyword$/d; /mysql.help_relation$/d; /mysql.help_topic$/d\'',
       post_pipe => 'sed \'/mysql.plugin$/d; /percona_test.checksums$/d; /mysql.help_category$/d; /mysql.help_keyword$/d; /mysql.help_relation$/d; /mysql.help_topic$/d; /mysql.ndb_binlog_index$/d; /mysql.global_grants$/d\' | ' .
                    'awk \'{print $2 " " $3 " " $4 " " $7 " " $9}\'',
+      keep_ouput => 1,
    ),
    "Default checksum"
-);
+) or diag($test_diff);
 
 # On fast machines, the chunk size will probably be be auto-adjusted so
 # large that all tables will be done in a single chunk without an index.

--- a/t/pt-table-checksum/progress.t
+++ b/t/pt-table-checksum/progress.t
@@ -48,7 +48,7 @@ else {
 # worse. This is a random stab in the dark. There is a problem either way.)
 my $master_dsn = 'h=127.1,P=12345,u=msandbox,p=msandbox';
 my @args       = ($master_dsn, qw(--set-vars innodb_lock_wait_timeout=3),
-                   '--chunk-size', '200'); 
+                   '--chunk-size', '50'); 
 my $output;
 my $row;
 my $scripts = "$trunk/t/pt-table-checksum/scripts/";
@@ -83,7 +83,7 @@ like(
    $output,
    qr/Replica h=127.0.0.1,P=12347 is stopped/,
    "--progress for slave lag"
-);
+) or diag($output);
 
 like(
    $output,

--- a/t/pt-table-sync/specify_column_or_index.t
+++ b/t/pt-table-sync/specify_column_or_index.t
@@ -35,21 +35,23 @@ $sb->wipe_clean($master_dbh);
 $sb->wipe_clean($slave_dbh);
 
 # #############################################################################
-# Issue 376: Permit specifying an index for mk-table-sync
+# Issue 376: Permit specifying an index for pt-table-sync
 # #############################################################################
 diag(`/tmp/12345/use < $trunk/t/pt-table-sync/samples/issue_375.sql`);
 sleep 1;
 $output = `$trunk/bin/pt-table-sync --sync-to-master h=127.1,P=12346,u=msandbox,p=msandbox -d issue_375 --print -v -v  --chunk-size 50 --chunk-index updated_at`;
+# We cannot rely on the exact time here, because pt-osc uses EXPLAIN to calculate rows range
+# and EXPLAIN does not guarantee accuracy of results.
 like(
    $output,
-   qr/FROM `issue_375`.`t` FORCE INDEX \(`updated_at`\) WHERE \(`updated_at` > 0 AND `updated_at` < '2009-09-05 02:38:12'/,
+   qr/FROM `issue_375`.`t` FORCE INDEX \(`updated_at`\) WHERE \(`updated_at` > 0 AND `updated_at` < '2009-09-05 02:\d\d:\d\d'/,
    '--chunk-index',
 );
 
 $output = `$trunk/bin/pt-table-sync --sync-to-master h=127.1,P=12346,u=msandbox,p=msandbox -d issue_375 --print -v -v  --chunk-size 50 --chunk-column updated_at`;
 like(
    $output,
-   qr/FROM `issue_375`.`t` FORCE INDEX \(`updated_at`\) WHERE \(`updated_at` > 0 AND `updated_at` < '2009-09-05 02:38:12'/,
+   qr/FROM `issue_375`.`t` FORCE INDEX \(`updated_at`\) WHERE \(`updated_at` > 0 AND `updated_at` < '2009-09-05 02:\d\d:\d\d'/,
    '--chunk-column',
 );
 


### PR DESCRIPTION
Fixed test failures for PS MYSQL 8.0. Test results are now green.

All distributions: pt-unit-tests-all, build 24
Re-run test for buster: pt-unit-tests, build 179

- [ ] The contributed code is licensed under GPL v2.0
- [ ] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documentation updated
- [ ] Test suite update
