### PR TITLE
PT-1911 - pt-online-schema-change can't use options port

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -13498,7 +13498,7 @@ If password contains commas they must be escaped with a backslash: "exam\,ple"
 
 =item * P
 
-dsn: port; copy: no
+dsn: port; copy: yes
 
 Port number to use for connection.
 


### PR DESCRIPTION
- Reverted typo introduced by 4fc3d9fd1f49e97c11d5ee5d0e83771285dee4e3

- [ ] The contributed code is licensed under GPL v2.0
- [ ] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documentation updated
- [ ] Test suite update
