### PR TITLE
PT-2119 - pt-osc aborts in 8.0.15 even if no FK exists

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -9266,13 +9266,6 @@ sub main {
    my $child_tables;
 
    my $vp = VersionParser->new($cxn->dbh());
-   if (($vp->cmp('8.0.14') >= 0 && $vp->cmp('8.0.17') <= 0) && $vp->flavor() !~ m/maria/i) {
-       my $msg = "There is an error in MySQL that makes the server to die when trying to ".
-                 "rename a table with FKs. See https://bugs.mysql.com/bug.php?id=96145\n".
-                 "Since pt-online-schema change needs to rename the old <-> new tables as the final " .
-                 "step, and the requested table has FKs, it cannot be executed under the current MySQL version";
-       _die($msg, NO_MINIMUM_REQUIREMENTS);
-   }
 
    if ( ($alter_fk_method || '') eq 'none' ) {
       print "Not updating foreign keys because "
@@ -9306,6 +9299,13 @@ sub main {
          # so nothing to do.
       }
       else {
+         if (($vp->cmp('8.0.14') >= 0 && $vp->cmp('8.0.17') <= 0) && $vp->flavor() !~ m/maria/i) {
+            my $msg = "There is an error in MySQL that makes the server to die when trying to ".
+                      "rename a table with FKs. See https://bugs.mysql.com/bug.php?id=96145\n".
+                      "Since pt-online-schema change needs to rename the old <-> new tables as the final " .
+                      "step, and the requested table has FKs, it cannot be executed under the current MySQL version";
+            _die($msg, NO_MINIMUM_REQUIREMENTS);
+         }
          print "Child tables:\n";
          foreach my $child_table ( @$child_tables ) {
             printf "  %s (approx. %s rows)\n",

--- a/t/pt-online-schema-change/pt-2119.t
+++ b/t/pt-online-schema-change/pt-2119.t
@@ -1,0 +1,107 @@
+#!/usr/bin/env perl
+
+BEGIN {
+   die "The PERCONA_TOOLKIT_BRANCH environment variable is not set.\n"
+      unless $ENV{PERCONA_TOOLKIT_BRANCH} && -d $ENV{PERCONA_TOOLKIT_BRANCH};
+   unshift @INC, "$ENV{PERCONA_TOOLKIT_BRANCH}/lib";
+};
+
+use strict;
+use warnings FATAL => 'all';
+use English qw(-no_match_vars);
+use Test::More;
+
+use Data::Dumper;
+use PerconaTest;
+use Sandbox;
+
+require "$trunk/bin/pt-online-schema-change";
+
+my $dp = new DSNParser(opts=>$dsn_opts);
+my $sb = new Sandbox(basedir => '/tmp', DSNParser => $dp);
+my $master_dbh = $sb->get_dbh_for('master');
+
+if ( !$master_dbh ) {
+   plan skip_all => 'Cannot connect to sandbox master';
+}
+
+my $vp = VersionParser->new($master_dbh);
+
+if ( $vp->cmp('8.0') > -1 && ($vp->cmp('8.0.14') < 0 || $vp->cmp('8.0.17') >= 0 || $vp->flavor() =~ m/maria/i) ) {
+   plan skip_all => 'Test requires versions between 8.0.14 and 8.0.17';
+}
+
+# The sandbox servers run with lock_wait_timeout=3 and it's not dynamic
+# so we need to specify --set-vars innodb_lock_wait_timeout=3 else the
+# tool will die.
+my $master_dsn = 'h=127.1,P=12345,u=msandbox,p=msandbox';
+my @args       = (qw(--set-vars innodb_lock_wait_timeout=3));
+my $sample     = "t/pt-online-schema-change/samples/";
+my $plugin     = "$trunk/$sample/plugins";
+my $output;
+my $exit_status;
+
+$sb->load_file('master', "$sample/pt-2119.sql");
+
+($output, $exit_status) = full_output(
+   sub { pt_online_schema_change::main(@args,
+      "$master_dsn,D=pt_osc,t=t",
+      "--alter", "ENGINE=InnoDB",
+      '--execute') },
+);
+
+is(
+   $exit_status,
+   0,
+   "No error for table without FK reference"
+);
+
+like(
+   $output,
+   qr/Successfully altered `pt_osc`.`t`/s,
+   'Table successfully altered'
+);
+
+($output, $exit_status) = full_output(
+   sub { pt_online_schema_change::main(@args,
+      "$master_dsn,D=pt_osc,t=person",
+      "--alter", "ENGINE=InnoDB",
+      '--execute') },
+);
+
+is(
+   $exit_status,
+   3,
+   "Error for the parent table"
+);
+
+like(
+   $output,
+   qr/There is an error in MySQL that makes the server to die when trying to rename a table with FKs./s,
+   'Parent table was not altered'
+);
+
+($output, $exit_status) = full_output(
+   sub { pt_online_schema_change::main(@args,
+      "$master_dsn,D=pt_osc,t=test_table",
+      "--alter", "ENGINE=InnoDB",
+      '--execute') },
+);
+
+is(
+   $exit_status,
+   3,
+   "Error for the child table"
+);
+
+like(
+   $output,
+   qr/There is an error in MySQL that makes the server to die when trying to rename a table with FKs./s,
+   'Child table was not altered'
+);
+# #############################################################################
+# Done.
+# #############################################################################
+$sb->wipe_clean($master_dbh);
+ok($sb->ok(), "Sandbox servers") or BAIL_OUT(__FILE__ . " broke the sandbox");
+done_testing;

--- a/t/pt-online-schema-change/samples/pt-2119.sql
+++ b/t/pt-online-schema-change/samples/pt-2119.sql
@@ -1,0 +1,26 @@
+DROP DATABASE IF EXISTS pt_osc;
+CREATE DATABASE pt_osc;
+USE pt_osc;
+
+CREATE TABLE t(
+    id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    f1 INT
+) ENGINE=InnoDB;
+
+CREATE TABLE `person` (
+ `id` bigint(20) NOT NULL AUTO_INCREMENT,
+ `name` varchar(20) NOT NULL,
+ `testId` bigint(20) DEFAULT NULL,
+ PRIMARY KEY (`id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `test_table` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `refId` bigint(20) DEFAULT NULL,
+  `person` bigint(20) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_person` (`person`),
+  KEY `fk_refId` (`refId`),
+  CONSTRAINT `fk_person` FOREIGN KEY (`person`) REFERENCES `person`(`id`),
+  CONSTRAINT `fk_refId` FOREIGN KEY (`refId`) REFERENCES `test_table`(`id`)
+) ENGINE=InnoDB;


### PR DESCRIPTION
- Moved check after we identified child tables
- Added test case

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documentation updated
- [ ] Test suite update
