### PR TITLE
Fix sphinx error that crashes the docs build (3.5.7)

### DIFF
--- a/requirements-docbuild.txt
+++ b/requirements-docbuild.txt
@@ -1,4 +1,4 @@
-Sphinx==4.2.0
+Sphinx==5.0
 sphinx-copybutton
 sphinx-gitstamp
 sphinx-material


### PR DESCRIPTION
modified:   requirements-docbuild.txt

- [ ] The contributed code is licensed under GPL v2.0
- [ ] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [x] Documentation updated
- [ ] Test suite update
