### PR TITLE
Pt 2302 pt k8s debug collector cannot pass properly to pt mysql summary pxc root password with special characters

### DIFF
--- a/src/go/pt-k8s-debug-collector/dumper/dumper.go
+++ b/src/go/pt-k8s-debug-collector/dumper/dumper.go
@@ -421,15 +421,15 @@ func (d *Dumper) getPodSummary(resource, podName, crName string, namespace strin
 		}
 		ports = port + ":3306"
 		summCmdName = "pt-mysql-summary"
-		summCmdArgs = []string{"--host=127.0.0.1", "--port=" + port, "--user=root", "--password='" + string(pass) + "'"}
-	case "pg","pgv2":
-		var kubeconfig string=""
-		if d.kubeconfig != "" { 
-			kubeconfig=" --kubeconfig=" + d.kubeconfig 
+		summCmdArgs = []string{"--host=127.0.0.1", "--port=" + port, "--user=root", "--password=" + string(pass)}
+	case "pg", "pgv2":
+		var kubeconfig string = ""
+		if d.kubeconfig != "" {
+			kubeconfig = " --kubeconfig=" + d.kubeconfig
 		}
 		summCmdName = "sh"
 		summCmdArgs = []string{"-c", "curl https://raw.githubusercontent.com/percona/support-snippets/master/postgresql/pg_gather/gather.sql 2>/dev/null | " +
-			d.cmd + kubeconfig + " -n "+ namespace + " exec -i "+ podName +" -- psql -X -f - "}
+			d.cmd + kubeconfig + " -n " + namespace + " exec -i " + podName + " -- psql -X -f - "}
 	case "psmdb":
 		var port string
 		if d.forwardport != "" {
@@ -451,7 +451,7 @@ func (d *Dumper) getPodSummary(resource, podName, crName string, namespace strin
 		}
 		ports = port + ":27017"
 		summCmdName = "pt-mongodb-summary"
-		summCmdArgs = []string{"--username='" + user + "'", "--password='" + pass + "'", "--authenticationDatabase=admin", "127.0.0.1:" + port}
+		summCmdArgs = []string{"--username='" + user + "'", "--password=" + pass, "--authenticationDatabase=admin", "127.0.0.1:" + port}
 	}
 
 	cmdPortFwd := exec.Command(d.cmd, "port-forward", "pod/"+podName, ports, "-n", namespace, "--kubeconfig", d.kubeconfig)

--- a/src/go/pt-k8s-debug-collector/dumper/dumper.go
+++ b/src/go/pt-k8s-debug-collector/dumper/dumper.go
@@ -443,7 +443,7 @@ func (d *Dumper) getPodSummary(resource, podName, crName string, namespace strin
 		}
 		user, err := d.getDataFromSecret(cr.Spec.Secrets.Users, "MONGODB_DATABASE_ADMIN_USER", namespace)
 		if err != nil {
-			return nil, errors.Wrap(err, "get password from psmdb users secret")
+			return nil, errors.Wrap(err, "get user name from psmdb users secret")
 		}
 		pass, err := d.getDataFromSecret(cr.Spec.Secrets.Users, "MONGODB_DATABASE_ADMIN_PASSWORD", namespace)
 		if err != nil {

--- a/src/go/pt-k8s-debug-collector/dumper/dumper.go
+++ b/src/go/pt-k8s-debug-collector/dumper/dumper.go
@@ -423,7 +423,7 @@ func (d *Dumper) getPodSummary(resource, podName, crName string, namespace strin
 		summCmdName = "pt-mysql-summary"
 		summCmdArgs = []string{"--host=127.0.0.1", "--port=" + port, "--user=root", "--password=" + string(pass)}
 	case "pg", "pgv2":
-		var kubeconfig string = ""
+		var kubeconfig string
 		if d.kubeconfig != "" {
 			kubeconfig = " --kubeconfig=" + d.kubeconfig
 		}


### PR DESCRIPTION
Tested by adding a password with special characters (e.g., "8^ye<*2*cLsQ%f]d<K") to my test PXC, MySQL, and MongoDB clusters.

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documentation updated
- [ ] Test suite update
