### PR TITLE
PT-2190 - pt-show-grants should use print_identified_with_as_hex

### DIFF
--- a/bin/pt-show-grants
+++ b/bin/pt-show-grants
@@ -2006,11 +2006,18 @@ sub main {
    # Roles can be identified because the user password is expired, the authentication
    # string is empty and the account is locked
    my $mysql8_where = '';
-   if ($version !~ "-MariaDB" && VersionCompare::cmp($version, '8.0.0') >= 0) {
+   if ( $version !~ "-MariaDB" && VersionCompare::cmp($version, '8.0.0') >= 0 ) {
        $mysql8_where = ' WHERE NOT ( `account_locked`="Y" AND ' .
                                       ' `password_expired`="Y" AND ' .
                                       ' `authentication_string`="" ) ';
    }
+
+   # PT-2190. Starting from 8.0.17 we will set print_identified_with_as_hex
+   # before getting users
+   if ( $version !~ "-MariaDB" && VersionCompare::cmp($version, '8.0.17') >= 0 ) {
+      $dbh->do('SET print_identified_with_as_hex = 1');
+   }
+
    my $users = $o->get('only') || $dbh->selectall_arrayref(
       "SELECT DISTINCT User, Host FROM mysql.user $mysql8_where ORDER BY User, Host",
       { Slice => {} });

--- a/t/pt-show-grants/pt-2190.t
+++ b/t/pt-show-grants/pt-2190.t
@@ -1,0 +1,71 @@
+#!/usr/bin/env perl
+
+BEGIN {
+   die "The PERCONA_TOOLKIT_BRANCH environment variable is not set.\n"
+      unless $ENV{PERCONA_TOOLKIT_BRANCH} && -d $ENV{PERCONA_TOOLKIT_BRANCH};
+   unshift @INC, "$ENV{PERCONA_TOOLKIT_BRANCH}/lib";
+};
+
+use strict;
+use warnings FATAL => 'all';
+use English qw(-no_match_vars);
+use Test::More;
+
+use PerconaTest;
+use Sandbox;
+use SqlModes;
+use VersionParser;
+require "$trunk/bin/pt-show-grants";
+
+my $dp = new DSNParser(opts=>$dsn_opts);
+my $sb = new Sandbox(basedir => '/tmp', DSNParser => $dp);
+my $dbh = $sb->get_dbh_for('master');
+
+if ( !$dbh ) {
+   plan skip_all => 'Cannot connect to sandbox master';
+}
+
+if ( VersionParser->new($dbh) lt '8.0.17') {
+   plan skip_all => "This test requires MySQL 8.0.17 or higher";
+}
+
+$sb->wipe_clean($dbh);
+
+my $output;
+my $cnf = '/tmp/12345/my.sandbox.cnf';
+
+diag(`/tmp/12345/use -u root -e "CREATE USER 'sally'\@'%' IDENTIFIED WITH 'caching_sha2_password' BY 'A005?>6LZe1'"`);
+
+ok(
+   `/tmp/12345/use -s -u sally -p'A005?>6LZe1' -e "SELECT 1" 2>/dev/null`,
+   'User sally can log in before tests'
+);
+
+$output = output(
+   sub { pt_show_grants::main('-F', $cnf, qw(--only sally)); }
+);
+
+like(
+   $output,
+   qr/0x24412430303524/,
+   'Password printed in HEX'
+) or diag($output);
+
+diag(`/tmp/12345/use -u root -e "DROP USER 'sally'\@'%'"`);
+open(my $pipe, '|-', '/tmp/12345/use -u root');
+print $pipe $output;
+close($pipe);
+
+ok(
+   `/tmp/12345/use -s -u sally -p'A005?>6LZe1' -e "SELECT 1" 2>/dev/null`,
+   'User sally can log in'
+) or diag($output);
+
+diag(`/tmp/12345/use -u root -e "DROP USER 'sally'\@'%'"`);
+
+# #############################################################################
+# Done.
+# #############################################################################
+$sb->wipe_clean($dbh);
+ok($sb->ok(), "Sandbox servers") or BAIL_OUT(__FILE__ . " broke the sandbox");
+done_testing;


### PR DESCRIPTION
- Implemented the fix
- Added test case

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documentation updated
- [x] Test suite update
