### PR TITLE
Add flag for --client to provide path to kubectl

### DIFF
--- a/src/go/pt-k8s-debug-collector/README.rst
+++ b/src/go/pt-k8s-debug-collector/README.rst
@@ -159,7 +159,7 @@ Path to kubeconfig. Default configuration be used if none specified
 
 ``--client``
 
-Path to kubernetes client. Default 'kubectl' is used --client is not set
+Path to kubernetes client. Default 'kubectl' is used if --client is not set
 
 ``--forwardport``
 

--- a/src/go/pt-k8s-debug-collector/README.rst
+++ b/src/go/pt-k8s-debug-collector/README.rst
@@ -157,6 +157,10 @@ Targeted cluster. By default data from all available clusters to be collected
 
 Path to kubeconfig. Default configuration be used if none specified
 
+``--client``
+
+Path to kubernetes client. Default 'kubectl' is used --client is not set
+
 ``--forwardport``
 
 Port to use when collecting database-specific summaries. By default, 3306 will be used for PXC and MySQL, 27017 for MongoDB, and 5432 for PostgreSQL
@@ -168,11 +172,11 @@ Print version info
 Requirements
 ============
 
-- Installed, configured, and available in PATH ``kubectl``
 - Installed, configured, and available in PATH ``pt-mysql-summary`` for PXC and MySQL
 - Installed, configured, and available in PATH ``mysql`` for PXC and MySQL
 - Installed, configured, and available in PATH ``pt-mongodb-summary`` for MongoDB
 - Installed, configured, and available in PATH ``psql`` for PostgreSQL
+- Installed, configured, and available in PATH  kubernetes client like ``kubectl``. Can be overriden by --client flag
 
 Known Issues
 ============

--- a/src/go/pt-k8s-debug-collector/README.rst
+++ b/src/go/pt-k8s-debug-collector/README.rst
@@ -176,7 +176,7 @@ Requirements
 - Installed, configured, and available in PATH ``mysql`` for PXC and MySQL
 - Installed, configured, and available in PATH ``pt-mongodb-summary`` for MongoDB
 - Installed, configured, and available in PATH ``psql`` for PostgreSQL
-- Installed, configured, and available in PATH  kubernetes client like ``kubectl``. Can be overriden by --client flag
+- Installed, configured, and available in PATH  kubernetes client like ``kubectl``. Can be overridden by --client flag
 
 Known Issues
 ============

--- a/src/go/pt-k8s-debug-collector/dumper/dumper.go
+++ b/src/go/pt-k8s-debug-collector/dumper/dumper.go
@@ -36,9 +36,9 @@ type Dumper struct {
 var resourcesRe = regexp.MustCompile(`(\w+)\.(\w+).percona\.com`)
 
 // New return new Dumper object
-func New(location, namespace, resource string, kubeconfig string, forwardport string) Dumper {
+func New(location, namespace, resource string, kubeconfig string, client string, forwardport string) Dumper {
 	d := Dumper{
-		cmd:         "kubectl",
+		cmd:         client,
 		kubeconfig:  kubeconfig,
 		location:    "cluster-dump",
 		mode:        int64(0o777),

--- a/src/go/pt-k8s-debug-collector/main.go
+++ b/src/go/pt-k8s-debug-collector/main.go
@@ -27,11 +27,13 @@ func main() {
 	clusterName := ""
 	kubeconfig := ""
 	forwardport := ""
+	client := ""
 	version := false
 
 	flag.StringVar(&namespace, "namespace", "", "Namespace for collecting data. If empty data will be collected from all namespaces")
 	flag.StringVar(&resource, "resource", "auto", "Collect data, specific to the resource. Supported values: pxc, psmdb, pg, pgv2, ps, none, auto")
 	flag.StringVar(&clusterName, "cluster", "", "Cluster name")
+	flag.StringVar(&client, "client", "kubectl", "Path to kubernetes client like kubectl,oc")
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig")
 	flag.StringVar(&forwardport, "forwardport", "", "Port to use for  port forwarding")
 	flag.BoolVar(&version, "version", false, "Print version")
@@ -50,7 +52,7 @@ func main() {
 		resource += "/" + clusterName
 	}
 
-	d := dumper.New("", namespace, resource, kubeconfig, forwardport)
+	d := dumper.New("", namespace, resource, kubeconfig, client, forwardport)
 	log.Println("Start collecting cluster data")
 
 	err := d.DumpCluster()


### PR DESCRIPTION
- [ ] The contributed code is licensed under GPL v2.0
- [ ] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documentation updated
- [ ] Test suite update

This is useful for clients like openshift etc