### PR TITLE
Default chunk size should be 1 instead of 1000 (PT-1423)

### DIFF
--- a/bin/pt-table-checksum
+++ b/bin/pt-table-checksum
@@ -13295,7 +13295,7 @@ N columns of the index is a workaround for the bug in some cases.
 
 =item --chunk-size
 
-type: size; default: 1000
+type: size; default: 1
 
 Number of rows to select for each checksum query.  Allowable suffixes are
 k, M, G.  You should not use this option in most cases; prefer L<"--chunk-time">


### PR DESCRIPTION
There isn't a significant downside to having the chunk-size default to 1, as the chunk resizing algorithm will very quickly scale it up as it can.

There is a big downside to having the chunk-size start higher than 1, in the case of tables whose rows take a long time to chunk.

- [ N/A ] The contributed code is licensed under GPL v2.0
- [ x ] Contributor Licence Agreement (CLA) is signed
- [ N/A ] util/update-modules has been ran
- [ N/A (automatic) ] Documentation updated
- [ N/A ] Test suite update
