### PR TITLE
Update pt-mysql-summary

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -320,7 +320,7 @@ v3.0.7 released 2018-03-01
 
 v3.0.6 released 2017-12-20
 
- * Fixed bug     PT-234: Genaral log parser cannot handle timestamps with tz
+ * Fixed bug     PT-234: General log parser cannot handle timestamps with tz
  * Fixed bug     PT-229: pt-online-schema-change does not retry on deadlock error when using percona 5.7
  * Fixed bug     PT-225: pt-table-checksum ignores generated cols
  * Improvement   PT-221: pt-table-sync pt-table-sync support for MyRocks

--- a/bin/pt-mysql-summary
+++ b/bin/pt-mysql-summary
@@ -2096,10 +2096,9 @@ section_innodb () {
    local bp_dirt="$(get_var Innodb_buffer_pool_pages_dirty "$status_file")"
    local bp_fill=$((${bp_pags} - ${bp_free}))
 
-   local mysql_version=$(get_var version "$variables_file" | awk -F'-' '{print $1}')
-   local transaction_isolation_var="tx_isolation"
-   if [ "$mysql_version" '>' "5.7.19" ]; then # true if version >= 5.7.20
-         transaction_isolation_var="transaction_isolation"
+   local transaction_isolation_var="transaction_isolation"
+   if [ "$version" '<' "5.7.20" ]; then # false if version >= 5.7.20
+      transaction_isolation_var="tx_isolation"
    fi
 
    name_val "Buffer Pool Fill"   "$(fuzzy_pct ${bp_fill} ${bp_pags})"

--- a/bin/pt-mysql-summary
+++ b/bin/pt-mysql-summary
@@ -2129,7 +2129,7 @@ section_innodb () {
    name_val "Commit Concurrency"  \
             "$(get_var innodb_commit_concurrency "$variables_file")"
    name_val "Txn Isolation Level" \
-            "$(get_var tx_isolation "$variables_file")"
+            "$(get_var transaction_isolation "$variables_file")"
    name_val "Adaptive Flushing"   \
             "$(get_var innodb_adaptive_flushing "$variables_file")"
    name_val "Adaptive Checkpoint" \

--- a/bin/pt-mysql-summary
+++ b/bin/pt-mysql-summary
@@ -2098,13 +2098,9 @@ section_innodb () {
 
    local mysql_version=$(get_var version "$variables_file" | awk -F'-' '{print $1}')
    local transaction_isolation_var="tx_isolation"
-   version_greater_equal() { # Function to compare versions
-      [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
-   }
-   if version_greater_equal "$mysql_version" "5.7.20"; then # true if version >= 5.7.20
+   if [ "$mysql_version" '>' "5.7.19" ]; then # true if version >= 5.7.20
          transaction_isolation_var="transaction_isolation"
    fi
-
 
    name_val "Buffer Pool Fill"   "$(fuzzy_pct ${bp_fill} ${bp_pags})"
    name_val "Buffer Pool Dirty"  "$(fuzzy_pct ${bp_dirt} ${bp_pags})"

--- a/bin/pt-mysql-summary
+++ b/bin/pt-mysql-summary
@@ -2095,6 +2095,17 @@ section_innodb () {
    local bp_free="$(get_var Innodb_buffer_pool_pages_free "$status_file")"
    local bp_dirt="$(get_var Innodb_buffer_pool_pages_dirty "$status_file")"
    local bp_fill=$((${bp_pags} - ${bp_free}))
+
+   local mysql_version=$(get_var version "$variables_file" | awk -F'-' '{print $1}')
+   local transaction_isolation_var="tx_isolation"
+   version_greater_equal() { # Function to compare versions
+      [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
+   }
+   if version_greater_equal "$mysql_version" "5.7.20"; then # true if version >= 5.7.20
+         transaction_isolation_var="transaction_isolation"
+   fi
+
+
    name_val "Buffer Pool Fill"   "$(fuzzy_pct ${bp_fill} ${bp_pags})"
    name_val "Buffer Pool Dirty"  "$(fuzzy_pct ${bp_dirt} ${bp_pags})"
 
@@ -2129,7 +2140,7 @@ section_innodb () {
    name_val "Commit Concurrency"  \
             "$(get_var innodb_commit_concurrency "$variables_file")"
    name_val "Txn Isolation Level" \
-            "$(get_var transaction_isolation "$variables_file")"
+            "$(get_var $transaction_isolation_var "$variables_file")"
    name_val "Adaptive Flushing"   \
             "$(get_var innodb_adaptive_flushing "$variables_file")"
    name_val "Adaptive Checkpoint" \

--- a/lib/bash/report_mysql_info.sh
+++ b/lib/bash/report_mysql_info.sh
@@ -1018,13 +1018,9 @@ section_innodb () {
    # dynamically allocate variable name - transaction_isolation
    local mysql_version=$(get_var version "$variables_file" | awk -F'-' '{print $1}')
    local transaction_isolation_var="tx_isolation"
-   version_greater_equal() { # Function to compare versions
-      [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
-   }
-   if version_greater_equal "$mysql_version" "5.7.20"; then # true if version >= 5.7.20
+   if [ "$mysql_version" '>' "5.7.19" ]; then # true if version >= 5.7.20
          transaction_isolation_var="transaction_isolation"
    fi
-
 
    name_val "Buffer Pool Fill"   "$(fuzzy_pct ${bp_fill} ${bp_pags})"
    name_val "Buffer Pool Dirty"  "$(fuzzy_pct ${bp_dirt} ${bp_pags})"

--- a/lib/bash/report_mysql_info.sh
+++ b/lib/bash/report_mysql_info.sh
@@ -1016,10 +1016,9 @@ section_innodb () {
    local bp_fill=$((${bp_pags} - ${bp_free}))
 
    # dynamically allocate variable name - transaction_isolation
-   local mysql_version=$(get_var version "$variables_file" | awk -F'-' '{print $1}')
-   local transaction_isolation_var="tx_isolation"
-   if [ "$mysql_version" '>' "5.7.19" ]; then # true if version >= 5.7.20
-         transaction_isolation_var="transaction_isolation"
+   local transaction_isolation_var="transaction_isolation"
+   if [ "$version" '<' "5.7.20" ]; then # false if version >= 5.7.20
+      transaction_isolation_var="tx_isolation"
    fi
 
    name_val "Buffer Pool Fill"   "$(fuzzy_pct ${bp_fill} ${bp_pags})"

--- a/lib/bash/report_mysql_info.sh
+++ b/lib/bash/report_mysql_info.sh
@@ -1014,6 +1014,18 @@ section_innodb () {
    local bp_free="$(get_var Innodb_buffer_pool_pages_free "$status_file")"
    local bp_dirt="$(get_var Innodb_buffer_pool_pages_dirty "$status_file")"
    local bp_fill=$((${bp_pags} - ${bp_free}))
+
+   # dynamically allocate variable name - transaction_isolation
+   local mysql_version=$(get_var version "$variables_file" | awk -F'-' '{print $1}')
+   local transaction_isolation_var="tx_isolation"
+   version_greater_equal() { # Function to compare versions
+      [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
+   }
+   if version_greater_equal "$mysql_version" "5.7.20"; then # true if version >= 5.7.20
+         transaction_isolation_var="transaction_isolation"
+   fi
+
+
    name_val "Buffer Pool Fill"   "$(fuzzy_pct ${bp_fill} ${bp_pags})"
    name_val "Buffer Pool Dirty"  "$(fuzzy_pct ${bp_dirt} ${bp_pags})"
 
@@ -1048,7 +1060,7 @@ section_innodb () {
    name_val "Commit Concurrency"  \
             "$(get_var innodb_commit_concurrency "$variables_file")"
    name_val "Txn Isolation Level" \
-            "$(get_var tx_isolation "$variables_file")"
+            "$(get_var $transaction_isolation_var "$variables_file")"
    name_val "Adaptive Flushing"   \
             "$(get_var innodb_adaptive_flushing "$variables_file")"
    name_val "Adaptive Checkpoint" \

--- a/t/pt-mysql-summary/samples/expected_output_temp_enc008.txt
+++ b/t/pt-mysql-summary/samples/expected_output_temp_enc008.txt
@@ -259,7 +259,7 @@ Specify --databases or --all-databases to dump and summarize schemas
        Thread Concurrency | 0
       Concurrency Tickets | 5000
        Commit Concurrency | 0
-      Txn Isolation Level | 
+      Txn Isolation Level | REPEATABLE-READ
         Adaptive Flushing | ON
       Adaptive Checkpoint | 
            Checkpoint Age | 69k

--- a/t/pt-mysql-summary/samples/expected_output_temp_enc009.txt
+++ b/t/pt-mysql-summary/samples/expected_output_temp_enc009.txt
@@ -264,7 +264,7 @@ Specify --databases or --all-databases to dump and summarize schemas
        Thread Concurrency | 0
       Concurrency Tickets | 5000
        Commit Concurrency | 0
-      Txn Isolation Level | 
+      Txn Isolation Level | REPEATABLE-READ
         Adaptive Flushing | ON
       Adaptive Checkpoint | 
            Checkpoint Age | 0


### PR DESCRIPTION
Changed the deprecated variable name tx_isolation to transaction_isolation

"`transaction_isolation` was added in MySQL 5.7.20 as an alias for `tx_isolation`, which is now deprecated and is removed in MySQL 8.0. Applications should be adjusted to use `transaction_isolation` in preference to `tx_isolation`"

reference : https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_tx_isolation