### PR TITLE
PT-2371 - fix transparent huge pages status check

### DIFF
--- a/bin/pt-summary
+++ b/bin/pt-summary
@@ -2345,6 +2345,7 @@ report_system_summary () { local PTFUNCNAME=report_system_summary;
 
 report_transparent_huge_pages () {
 
+  STATUS_THP_SYSTEM=0
   if [ -f /sys/kernel/mm/transparent_hugepage/enabled ]; then
     CONTENT_TRANSHP=$(</sys/kernel/mm/transparent_hugepage/enabled)
     STATUS_THP_SYSTEM=$(echo $CONTENT_TRANSHP | grep -cv '\[never\]')

--- a/lib/bash/report_system_info.sh
+++ b/lib/bash/report_system_info.sh
@@ -1147,6 +1147,7 @@ report_system_summary () { local PTFUNCNAME=report_system_summary;
 
 report_transparent_huge_pages () {
 
+  STATUS_THP_SYSTEM=0
   if [ -f /sys/kernel/mm/transparent_hugepage/enabled ]; then
     CONTENT_TRANSHP=$(</sys/kernel/mm/transparent_hugepage/enabled)
     STATUS_THP_SYSTEM=$(echo $CONTENT_TRANSHP | grep -cv '\[never\]')


### PR DESCRIPTION
In `lib/bash/report_system_info.sh`

```sh
report_transparent_huge_pages () {

  if [ -f /sys/kernel/mm/transparent_hugepage/enabled ]; then
    CONTENT_TRANSHP=$(</sys/kernel/mm/transparent_hugepage/enabled)
    STATUS_THP_SYSTEM=$(echo $CONTENT_TRANSHP | grep -cv '\[never\]')
  fi
  if [ $STATUS_THP_SYSTEM = 0 ]; then
    echo "Transparent huge pages are currently disabled on the system."
  else
    echo "Transparent huge pages are enabled."
  fi

}
```

Variable `STATUS_THP_SYSTEM` is only set when file `/sys/kernel/mm/transparent_hugepage/enabled` exists. So on those system (e.g. Xen hypervisor kernels) that doesn’t have this file, it errors out with `STATUS_THP_SYSTEM: unbound variable` (because set -u is set)

Example output:

```
# RAID Controller ############################################
  Controller | No RAID controller detected
# Network Config #############################################
# Top Processes ##############################################
cat: /tmp/pt-summary.3191.1RjmKy/data/processes: No such file or directory
# Notable Processes ##########################################
  PID    OOM    COMMAND
    ?      ?    sshd doesn't appear to be running
# Memory management ##########################################
/usr/bin/pt-summary: line 2352: STATUS_THP_SYSTEM: unbound variable
```


- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] util/update-modules has been ran
- [ ] Documentation updated
- [ ] Test suite update
