### PR TITLE
PT-2322 - Fixing the pt-mysql-summary to detect jemalloc

### DIFF
--- a/bin/pt-mysql-summary
+++ b/bin/pt-mysql-summary
@@ -2357,7 +2357,7 @@ report_jemalloc_enabled() {
    local variables_file="$2"
    local GENERAL_JEMALLOC_STATUS=0
 
-   for pid in $(grep '/mysqld ' "$instances_file" | awk '{print $1;}'); do
+   for pid in $(grep '/mysqld' "$instances_file" | awk '{print $1;}'); do
       local jemalloc_status="$(get_var "pt-summary-internal-jemalloc_enabled_for_pid_${pid}" "${variables_file}")"
       if [ -z $jemalloc_status ]; then
          continue


### PR DESCRIPTION
Fixing the bug reported at https://perconadev.atlassian.net/browse/PT-2322.

On function report_jemalloc_enabled, the script couldn't get the right data due to a space on the grep done to gather the information, hence showing the jemalloc value empty.