### PR TITLE
Fixed flaky tests

### DIFF
--- a/t/pt-table-sync/char_chunking.t
+++ b/t/pt-table-sync/char_chunking.t
@@ -37,13 +37,7 @@ $sb->create_dbs($source_dbh, ['test']);
 $sb->load_file('source', "t/lib/samples/char-chunking/ascii.sql", "test");
 $source_dbh->do('alter table test.ascii drop column `i`');
 
-wait_until(
-   sub {
-      my $row;
-      eval {$row = $replica_dbh->selectall_arrayref("select * from test.ascii");};
-      return 1 if $row && @$row > 100;
-   },
-);
+$sb->wait_for_replicas();
 
 $replica_dbh->do('delete from test.ascii where c like "Zesus%"');
 

--- a/t/pt-table-sync/issue_218.t
+++ b/t/pt-table-sync/issue_218.t
@@ -40,6 +40,8 @@ $sb->wipe_clean($replica_dbh);
 $sb->create_dbs($source_dbh, [qw(issue218)]);
 $sb->use('source', '-e "CREATE TABLE issue218.t1 (i INT)"');
 $sb->use('source', '-e "INSERT INTO issue218.t1 VALUES (NULL)"');
+$sb->wait_for_replicas();
+
 qx($trunk/bin/pt-table-sync --no-check-replica --print --database issue218 h=127.1,P=12345,u=msandbox,p=msandbox P=12346);
 ok(!$?, 'Issue 218: NULL values compare as equal');
 

--- a/t/pt-table-sync/pt-1256.t
+++ b/t/pt-table-sync/pt-1256.t
@@ -74,6 +74,8 @@ like(
    "PT-1256 Set the correct charset"
 );
 
+$sb->wait_for_replicas();
+
 SKIP: {
    my $vp = VersionParser->new($source_dbh);
    if ($vp->cmp('8.0') > -1 && $vp->cmp('8.0.14') < 0 && $vp->flavor() !~ m/maria/i) {
@@ -91,6 +93,8 @@ SKIP: {
     $output = `$trunk/bin/pt-table-sync --execute --lock-and-rename h=127.1,P=12345,u=msandbox,p=msandbox,D=test,t=t1 t=t2 2>&1`;
     $output = `/tmp/12345/use -e 'show create table test.t2'`;
     like($output, qr/COMMENT='test1'/, '--lock-and-rename worked');
+
+    $sb->wait_for_replicas();
     
     #4
     $row = $replica1_dbh->selectrow_hashref("SELECT f2 FROM test.t2 WHERE id = 1");


### PR DESCRIPTION
The tests previously tested assertions against the replica after executing changes in the source without waiting for the replication to converge.

At least on my machine, the tests currently fail at least a couple of times when executed in loops like
```
for i in $(seq 10); do prove t/pt-table-sync/pt-1256.t; done
```
or
```
for i in $(seq 10); do prove t/pt-table-sync/char_chunking.t; done
```

The code is my own creation and it can be distributed under the GPL2 licence.

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] util/update-modules has been ran
- [x] Documentation updated
- [x] Test suite update
