### PR TITLE
Backport commits from databricks-3.3.1 branch of repo databricks/percona-toolkit

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -10101,6 +10101,12 @@ sub main {
    my $limit      = $o->get('chunk-size-limit');  # brevity
    my $chunk_time = $o->get('chunk-time');        # brevity
 
+   my $countdown = 100;
+   my $temp_max_chunk_size = 0;
+   my $temp_min_chunk_size = 1000000;
+   my $temp_total_chunk_size = 0;
+   my $report_temp_countdown = $countdown;
+
    my $callbacks = {
       init => sub {
          my (%args) = @_;
@@ -10329,6 +10335,22 @@ sub main {
                         . " seconds to execute.\n");
                      $tbl->{warned_slow} = 1;
                   }
+               }
+
+               $temp_max_chunk_size = $tbl->{chunk_size} > $temp_max_chunk_size ? $tbl->{chunk_size} : $temp_max_chunk_size;
+               $temp_min_chunk_size = $tbl->{chunk_size} < $temp_min_chunk_size ? $tbl->{chunk_size} : $temp_min_chunk_size;
+               $temp_total_chunk_size += $tbl->{chunk_size};
+               $report_temp_countdown -= 1;
+               if ($report_temp_countdown == 0) {
+                  my $avg = $temp_total_chunk_size / $countdown;
+                  print ts("In the last $countdown chunks of rows copied: "
+                      . "min chunk size = $temp_min_chunk_size, "
+                      . "max chunk size = $temp_max_chunk_size, "
+                      . "avg chunk size = $avg\n");
+                  $temp_max_chunk_size = 0;
+                  $temp_min_chunk_size = 1000000;
+                  $temp_total_chunk_size = 0;
+                  $report_temp_countdown = $countdown;
                }
 
                # Update chunk-size based on the rate of rows/s.

--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -9705,7 +9705,7 @@ sub main {
       return unless $new_tbl_exists;
 
       my $sql = "DROP TABLE IF EXISTS $new_tbl->{name};";
-      if ( !$oktorun ) {
+      if ( !$oktorun && $o->get('preserve-new-table-after-interrupt') ) {
          # The tool was interrupted, so do not drop the new table
          # in case the user wants to resume.
          print "Not dropping the new table $new_tbl->{name} because "
@@ -9939,6 +9939,7 @@ sub main {
    # adding the triggers because if adding them fails, this will be
    # called which will drop whichever triggers were created.
    my $drop_triggers = $o->get('drop-triggers');
+   my $preserve_triggers_after_interrupt = $o->get('preserve-triggers-after-interrupt');
    push @cleanup_tasks, sub {
       PTDEBUG && _d('Clean up triggers');
       # --plugin hook
@@ -9950,7 +9951,7 @@ sub main {
          );
       }
 
-      if ( !$oktorun ) {
+      if ( !$oktorun && $preserve_triggers_after_interrupt ) {
          print "Not dropping triggers because the tool was interrupted.  "
              . "To drop the triggers, execute:\n"
              . join("\n", @drop_trigger_sqls) . "\n";
@@ -13102,12 +13103,29 @@ the tool leaves the original table in place.
 
 If C<--no-swap-tables> is specified, then there is no old table to drop.
 
+=item --[no]preserve-new-table-after-interrupt
+
+default: yes
+
+Keep new table after interrupting migration process. If
+C<--no-preserve-new-table-after-interrupt> is used, the tool drops new table
+if, for instance, interrupted by HUP, INT, PIPE and TERM signals. In other
+words, the tool will drop the new table after Ctrl-C. By default, it doesn't do
+so.
+
 =item --[no]drop-triggers
 
 default: yes
 
 Drop triggers on the old table.  C<--no-drop-triggers> forces
 C<--no-drop-old-table>.
+
+=item --[no]preserve-triggers-after-interrupt
+
+default: yes
+
+Similarly to C<--no-preserve-new-table-after-interrupt>, if set, the tool drops
+triggers if, for instance, it's interrupted by HUP, INT, PIPE or TERM signals.
 
 =item --dry-run
 

--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -11178,8 +11178,8 @@ sub nibble_is_safe {
          = $limit ? ($expl->{rows} || 0) >= $limit
          :          0;
 
-      printf "oversize_chunk=%s expl->{rows}=%d chunk-size-hard-limit=%d\n",
-         $oversize_chunk, $expl->{rows} || 0, $limit;
+      PTDEBUG && _d("oversize_chunk", $oversize_chunk,
+          "expl->{rows}", $expl->{rows} || 0, "chunk-size-hard-limit", $limit);
 
       if ( $oversize_chunk )
       {

--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -11156,12 +11156,9 @@ sub nibble_is_safe {
       my $oversize_chunk
          = $limit ? ($expl->{rows} || 0) >= $tbl->{chunk_size} * $limit
          :          0;
-
-      printf "oversize_chunk=%s expl->{rows}=%d chunk_size=%d chunk-size-limit=%d\n",
-         $oversize_chunk, $expl->{rows} || 0, $tbl->{chunk_size}, $limit;
-      printf "boundary: " . Dumper($boundary);
-
-      if ( $oversize_chunk )
+      if ( $oversize_chunk
+           && $nibble_iter->identical_boundaries($boundary->{upper},
+                                                 $boundary->{next_lower}) )
       {
          die ts("Error copying rows at chunk " . $nibble_iter->nibble_number()
             . " of $tbl->{db}.$tbl->{tbl} because it is oversized.  "
@@ -11169,6 +11166,26 @@ sub nibble_is_safe {
             . ($tbl->{chunk_size} * $limit)
             . " rows (chunk size=$tbl->{chunk_size}"
             . " * chunk size limit=$limit), but MySQL estimates "
+            . "that there are " . ($expl->{rows} || 0)
+            . " rows in the chunk.\n");
+      }
+   }
+
+   # Do not copy a chunk larger than this number of rows. It is an unconditional
+   # check that aborts a migration if an estimated chunk size exceeds the chosen number.
+   if ( my $limit = $o->get('chunk-size-hard-limit') ) {
+      my $oversize_chunk
+         = $limit ? ($expl->{rows} || 0) >= $limit
+         :          0;
+
+      printf "oversize_chunk=%s expl->{rows}=%d chunk-size-hard-limit=%d\n",
+         $oversize_chunk, $expl->{rows} || 0, $limit;
+
+      if ( $oversize_chunk )
+      {
+         die ts("Error copying rows at chunk " . $nibble_iter->nibble_number()
+            . " of $tbl->{db}.$tbl->{tbl} because it is oversized.  "
+            . "The current hard chunk size limit is $limit rows, but MySQL estimates "
             . "that there are " . ($expl->{rows} || 0)
             . " rows in the chunk.\n");
       }
@@ -12960,6 +12977,14 @@ value of 0.
 The tool also uses this option to determine how to handle foreign keys that
 reference the table to be altered. See L<"--alter-foreign-keys-method"> for
 details.
+
+=item --chunk-size-hard-limit
+
+type: size; default: 15000
+
+Do not copy a chunk larger than this number of rows. It is an unconditional
+check that aborts a migration if an estimated chunk size exceeds the chosen
+number.
 
 =item --chunk-time
 

--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -11156,6 +11156,11 @@ sub nibble_is_safe {
       my $oversize_chunk
          = $limit ? ($expl->{rows} || 0) >= $tbl->{chunk_size} * $limit
          :          0;
+
+      printf "oversize_chunk=%s expl->{rows}=%d chunk_size=%d chunk-size-limit=%d\n",
+         $oversize_chunk, $expl->{rows} || 0, $tbl->{chunk_size}, $limit;
+      printf "boundary: " . Dumper($boundary);
+
       if ( $oversize_chunk
            && $nibble_iter->identical_boundaries($boundary->{upper},
                                                  $boundary->{next_lower}) )

--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -10101,11 +10101,20 @@ sub main {
    my $limit      = $o->get('chunk-size-limit');  # brevity
    my $chunk_time = $o->get('chunk-time');        # brevity
 
-   my $countdown = 100;
-   my $temp_max_chunk_size = 0;
-   my $temp_min_chunk_size = 1000000;
-   my $temp_total_chunk_size = 0;
-   my $report_temp_countdown = $countdown;
+   # report chunk size stat every 10 second
+   my $report_chunk_period = $o->get('report-chunk-period');  # brevity
+   my $report_countdown = $chunk_time>0 && $report_chunk_period>0 ? $report_chunk_period/$chunk_time : 0;
+   my $report_max_size_chunk_size = 0;
+   my $report_max_size_chunk_time = 0;
+   my $report_max_time_chunk_size = 0;
+   my $report_max_time_chunk_time = 0;
+   my $report_min_size_chunk_size = 1000000000;
+   my $report_min_size_chunk_time = 1000000000;
+   my $report_min_time_chunk_size = 1000000000;
+   my $report_min_time_chunk_time = 1000000000;
+   my $report_total_size = 0;
+   my $report_total_time = 0;
+   my $cur_countdown = $report_countdown;
 
    my $callbacks = {
       init => sub {
@@ -10319,6 +10328,47 @@ sub main {
                   $tbl->{nibble_time}, # is this amount of time
                );
 
+               if ($report_countdown > 0) {
+                  if ($report_max_size_chunk_size < $cnt) {
+                     $report_max_size_chunk_size = $cnt;
+                     $report_max_size_chunk_time = $tbl->{nibble_time};
+                  }
+                  if ($report_max_time_chunk_time < $tbl->{nibble_time}) {
+                     $report_max_time_chunk_size = $cnt;
+                     $report_max_time_chunk_time = $tbl->{nibble_time};
+                  }
+                  if ($report_min_size_chunk_size > $cnt) {
+                     $report_min_size_chunk_size = $cnt;
+                     $report_min_size_chunk_time = $tbl->{nibble_time};
+                  }
+                  if ($report_min_time_chunk_time > $tbl->{nibble_time}) {
+                     $report_min_time_chunk_size = $cnt;
+                     $report_min_time_chunk_time = $tbl->{nibble_time};
+                  }
+                  $report_total_size += $cnt;
+                  $report_total_time += $tbl->{nibble_time};
+                  $cur_countdown -= 1;
+                  if ($cur_countdown == 0) {
+                     print ts("In the last $report_chunk_period secs, $report_countdown batches of rows are copied: \n"
+                         . "min-size-batch copied $report_min_size_chunk_size rows in $report_min_size_chunk_time secs \n"
+                         . "min-time-batch copied $report_min_time_chunk_size rows in $report_min_time_chunk_time secs \n"
+                         . "max-size-batch copied $report_max_size_chunk_size rows in $report_max_size_chunk_time secs \n"
+                         . "max-time-batch copied $report_max_time_chunk_size rows in $report_max_time_chunk_time secs \n"
+                         . "totally copied $report_total_size rows in $report_total_time secs\n");
+                     $report_max_size_chunk_size = 0;
+                     $report_max_size_chunk_time = 0;
+                     $report_max_time_chunk_size = 0;
+                     $report_max_time_chunk_time = 0;
+                     $report_min_size_chunk_size = 1000000000;
+                     $report_min_size_chunk_time = 1000000000;
+                     $report_min_time_chunk_size = 1000000000;
+                     $report_min_time_chunk_time = 1000000000;
+                     $report_total_size = 0;
+                     $report_total_time = 0;
+                     $cur_countdown = $report_countdown;
+                  }
+               }
+
                if ( $tbl->{chunk_size} < 1 ) {
                   # This shouldn't happen.  WeightedAvgRate::update() may
                   # return a value < 1, but minimum chunk size is 1.
@@ -10335,22 +10385,6 @@ sub main {
                         . " seconds to execute.\n");
                      $tbl->{warned_slow} = 1;
                   }
-               }
-
-               $temp_max_chunk_size = $tbl->{chunk_size} > $temp_max_chunk_size ? $tbl->{chunk_size} : $temp_max_chunk_size;
-               $temp_min_chunk_size = $tbl->{chunk_size} < $temp_min_chunk_size ? $tbl->{chunk_size} : $temp_min_chunk_size;
-               $temp_total_chunk_size += $tbl->{chunk_size};
-               $report_temp_countdown -= 1;
-               if ($report_temp_countdown == 0) {
-                  my $avg = $temp_total_chunk_size / $countdown;
-                  print ts("In the last $countdown chunks of rows copied: "
-                      . "min chunk size = $temp_min_chunk_size, "
-                      . "max chunk size = $temp_max_chunk_size, "
-                      . "avg chunk size = $avg\n");
-                  $temp_max_chunk_size = 0;
-                  $temp_min_chunk_size = 1000000;
-                  $temp_total_chunk_size = 0;
-                  $report_temp_countdown = $countdown;
                }
 
                # Update chunk-size based on the rate of rows/s.
@@ -13024,6 +13058,12 @@ If this option is set to zero, the chunk size doesn't auto-adjust, so query
 times will vary, but query chunk sizes will not. Another way to do the same
 thing is to specify a value for L<"--chunk-size"> explicitly, instead of leaving
 it at the default.
+
+=item --report-chunk-period
+
+type: size; default: 0
+
+Period of time when reporting chunk stats.
 
 =item --config
 

--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -11161,9 +11161,7 @@ sub nibble_is_safe {
          $oversize_chunk, $expl->{rows} || 0, $tbl->{chunk_size}, $limit;
       printf "boundary: " . Dumper($boundary);
 
-      if ( $oversize_chunk
-           && $nibble_iter->identical_boundaries($boundary->{upper},
-                                                 $boundary->{next_lower}) )
+      if ( $oversize_chunk )
       {
          die ts("Error copying rows at chunk " . $nibble_iter->nibble_number()
             . " of $tbl->{db}.$tbl->{tbl} because it is oversized.  "

--- a/t/pt-online-schema-change/no_drop_after_interrupt.t
+++ b/t/pt-online-schema-change/no_drop_after_interrupt.t
@@ -1,0 +1,177 @@
+#!/usr/bin/env perl
+
+BEGIN {
+   die "The PERCONA_TOOLKIT_BRANCH environment variable is not set.\n"
+      unless $ENV{PERCONA_TOOLKIT_BRANCH} && -d $ENV{PERCONA_TOOLKIT_BRANCH};
+   unshift @INC, "$ENV{PERCONA_TOOLKIT_BRANCH}/lib";
+};
+
+use strict;
+use warnings FATAL => 'all';
+use English qw(-no_match_vars);
+use Test::More;
+
+use PerconaTest;
+use Sandbox;
+require "$trunk/bin/pt-online-schema-change";
+
+use File::Temp qw/ tempfile /;
+use Time::HiRes qw(sleep);
+use Data::Dumper;
+$Data::Dumper::Indent    = 1;
+$Data::Dumper::Sortkeys  = 1;
+$Data::Dumper::Quotekeys = 0;
+
+my $table = "t";
+my $new_table = "_${table}_new";
+my $schema = "pt_osc";
+
+my $dp  = new DSNParser(opts=>$dsn_opts);
+my $sb  = new Sandbox(basedir => '/tmp', DSNParser => $dp);
+my $dbh = $sb->get_dbh_for('master');
+
+if ( !$dbh ) {
+   plan skip_all => 'Cannot connect to sandbox master';
+}
+
+my $master_dsn = $sb->dsn_for('master');
+my $sample     = "t/pt-online-schema-change/samples";
+
+sub start_and_kill_pt_osc {
+    my $extra_args = shift;
+
+    my ($pause_file_fh, $pause_file) = tempfile();
+    my $args = "$master_dsn,D=$schema,t=$table --alter='DROP COLUMN d' --execute --pause-file=$pause_file $extra_args";
+
+    my $pid = fork();
+    if (!$pid) {
+        open(STDERR, '>', $pause_file);
+        open(STDOUT, '>', $pause_file);
+        exec("$trunk/bin/pt-online-schema-change $args");
+        exit(1);
+    }
+
+    # wait for pt-osc to start
+    my $pt_osc_started = 0;
+    for (1..60) {
+        my $row = eval { $dbh->selectrow_arrayref("SHOW CREATE TABLE $schema.$new_table") };
+        if (defined $row) {
+            $pt_osc_started = 1;
+            last;
+        }
+
+        sleep(1);
+    }
+
+    die "pt-osc didn't start on time" unless $pt_osc_started;
+    kill('INT', $pid) or die "failed to send INT signal to pt-osc (pid: $pid)";
+    waitpid($pid, 0);
+    my $exit_code = $? >> 8;
+
+    my $output = do {
+        local $/ = undef;
+        <$pause_file_fh>;
+    };
+
+    unlink($pause_file);
+    close($pause_file_fh);
+
+    return ($output, $exit_code);
+}
+
+# #############################################################################
+# absent --preserve-table-after-interrupt --preserve-triggers-after-interrupt
+# #############################################################################
+{
+    # Loads pt_osc.t with cols id (pk), c (unique index),, d.
+    $sb->load_file('master', "$sample/basic_no_fks_innodb.sql");
+
+    my ($output, $exit_code) = start_and_kill_pt_osc("");
+
+    is(
+        $exit_code,
+        1,
+        "absent preserve-table-after-interrupt preserve-triggers-after-interrupt: exit code == 1 due to SIGINT"
+    );
+
+    my $tables = $dbh->selectall_arrayref("SHOW TABLES FROM $schema");
+    is_deeply(
+       $tables,
+       [ ['_t_new'], ['t'] ],
+       "absent preserve-table-after-interrupt preserve-triggers-after-interrupt: tables"
+    ) or diag(Dumper($tables), $output);
+
+    my $triggers = eval { $dbh->selectall_arrayref("SHOW TRIGGERS FROM $schema LIKE '$table'") };
+    is(
+       @$triggers,
+       3,
+       "absent preserve-table-after-interrupt preserve-triggers-after-interrupt: triggers"
+    ) or diag(Dumper($triggers), $output);
+}
+
+# #############################################################################
+# --preserve-table-after-interrupt --preserve-triggers-after-interrupt
+# #############################################################################
+{
+    # Loads pt_osc.t with cols id (pk), c (unique index),, d.
+    $sb->load_file('master', "$sample/basic_no_fks_innodb.sql");
+
+    my ($output, $exit_code) = start_and_kill_pt_osc("--preserve-new-table-after-interrupt --preserve-triggers-after-interrupt");
+
+    is(
+        $exit_code,
+        1,
+        "preserve-table-after-interrupt preserve-triggers-after-interrupt: exit code == 1 due to SIGINT"
+    );
+
+    my $tables = $dbh->selectall_arrayref("SHOW TABLES FROM $schema");
+    is_deeply(
+       $tables,
+       [ ['_t_new'], ['t'] ],
+       "preserve-table-after-interrupt preserve-triggers-after-interrupt: tables"
+    ) or diag(Dumper($tables), $output);
+
+    my $triggers = eval { $dbh->selectall_arrayref("SHOW TRIGGERS FROM $schema LIKE '$table'") };
+    is(
+       @$triggers,
+       3,
+       "preserve-table-after-interrupt preserve-triggers-after-interrupt: triggers"
+    ) or diag(Dumper($triggers), $output);
+}
+
+# #############################################################################
+# --no-preserve-table-after-interrupt --no-preserve-triggers-after-interrupt
+# #############################################################################
+{
+    # Loads pt_osc.t with cols id (pk), c (unique index),, d.
+    $sb->load_file('master', "$sample/basic_no_fks_innodb.sql");
+
+    my ($output, $exit_code) = start_and_kill_pt_osc("--no-preserve-new-table-after-interrupt --no-preserve-triggers-after-interrupt");
+
+    is(
+        $exit_code,
+        1,
+        "no-preserve-table-after-interrupt no-preserve-triggers-after-interrupt: exit code == 1 due to SIGINT"
+    );
+
+    my $tables = $dbh->selectall_arrayref("SHOW TABLES FROM $schema");
+    is_deeply(
+       $tables,
+       [ ['t'] ],
+       "no-preserve-table-after-interrupt no-preserve-triggers-after-interrupt: tables"
+    ) or diag(Dumper($tables), $output);
+
+    my $triggers = eval { $dbh->selectall_arrayref("SHOW TRIGGERS FROM $schema LIKE '$table'") };
+    is(
+       @$triggers,
+       0,
+       "no-preserve-table-after-interrupt no-preserve-triggers-after-interrupt: triggers"
+    ) or diag(Dumper($triggers), $output);
+}
+
+# #############################################################################
+# Done.
+# #############################################################################
+$sb->wipe_clean($dbh);
+ok($sb->ok(), "Sandbox servers") or BAIL_OUT(__FILE__ . " broke the sandbox");
+done_testing;


### PR DESCRIPTION
Backport commits from [databricks-3.3.1](https://github.com/databricks/percona-toolkit/tree/databricks-3.3.1) branch of repo `databricks/percona-toolkit`

Commits present in `databricks-3.3.1` not added in the backport
[make pt-osc respect MySQL's case insensitivity on Windows and osx](https://github.com/databricks/percona-toolkit/commit/b1f00ab52ce22d763102fdca45cd09080df8a776)
[[JOBS-4570] Handle case where lower_case_table_names=2](https://github.com/databricks/percona-toolkit/commit/a95e1b140687d07fbbf55935dfa56981008fd4db)
Reason: It seems fix is already added in percona kit 10 months ago
[PT-1860 make pt-osc respect case insesitive lookup on Windows and osx](https://github.com/kunalvallecha-db/percona-toolkit-3.6/commit/3e1e9b842545f698741ed20f45a8e620dd5fd707)