### PR TITLE
PT-2406 Release notes for Percona Toolkit version 3.7.0

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,26 @@
 Release Notes
 ***************
 
+v3.7.0 released 2024-12-23
+==============================
+
+New Feature
+------------------------------------------------------------
+
+* :jirabug:`PT-2340`: Support MySQL 8.4
+
+Improvements
+------------------------------------------------------------
+
+* :jirabug:`PT-2347`: Improper use of sha256 hash algorithm in percona-toolkit/src/go/pt-secure-collect /encrypt.go. Note that this improvement is an incompatible change. pt-secure-collect now uses KDF to encrypt and decrypt user passwords. As a result, pt-secure-collect v3.7.0 cannot decrypt data collected by earlier versions and vice versa.
+* `PR-862`: Fixed flaky tests (Thanks to Henning Pöttker for the contribution)
+* `PR-839`: Update pt-mysql-summary (Thanks to GOKUL S for the contribution)
+
+Bugs Fixed
+------------
+
+* :jirabug:`PT-2371`: pt-summary errors out with "STATUS_THP_SYSTEM: unbound variable" (Thanks to Jason Ng for the contribution)
+
 v3.6.0 released 2024-06-12
 ==============================
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -12,7 +12,7 @@ New Feature
 Improvements
 ------------------------------------------------------------
 
-* :jirabug:`PT-2347`: Improper use of sha256 hash algorithm in percona-toolkit/src/go/pt-secure-collect /encrypt.go. Note that this improvement is an incompatible change. pt-secure-collect now uses KDF to encrypt and decrypt user passwords. As a result, pt-secure-collect v3.7.0 cannot decrypt data collected by earlier versions and vice versa.
+* :jirabug:`PT-2347`: Improper use of sha256 hash algorithm in percona-toolkit/src/go/pt-secure-collect /encrypt.go. Note that this improvement is an **incompatible change**. pt-secure-collect now uses KDF to encrypt and decrypt user passwords. As a result, pt-secure-collect v3.7.0 cannot decrypt data collected by earlier versions and vice versa.
 * `PR-862`: Fixed flaky tests (Thanks to Henning Pöttker for the contribution)
 * `PR-839`: Update pt-mysql-summary (Thanks to GOKUL S for the contribution)
 

--- a/requirements-docbuild.txt
+++ b/requirements-docbuild.txt
@@ -16,8 +16,6 @@ sphinx-tabs
 certifi>=2024.7.4 # not directly required, pinned by Snyk to avoid a vulnerability
 jinja2>=3.1.4 # not directly required, pinned by Snyk to avoid a vulnerability
 pygments>=2.15.0 # not directly required, pinned by Snyk to avoid a vulnerability
-requests>=2.32.2 # not directly required, pinned by Snyk to avoid a vulnerability
-setuptools>=70.0.0 # not directly required, pinned by Snyk to avoid a vulnerability
-urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability
-zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
+requests>=2.31.0 # not directly required, pinned by Snyk to avoid a vulnerability
+setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
 idna>=3.7 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
	modified:   docs/release_notes.rst

- [ ] The contributed code is licensed under GPL v2.0
- [ ] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [x] Documentation updated
- [ ] Test suite update
