### PR TITLE
PT-2410 - Fixing the export with output-format=csv when there are null values

### DIFF
--- a/bin/pt-archiver
+++ b/bin/pt-archiver
@@ -6966,7 +6966,7 @@ sub main {
           warn "Invalid output format:". $o->get('format');
           warn "Using default 'dump' format";
       } elsif ($o->get('output-format') || '' eq 'csv') {
-              $fields_separated_by = ", ";
+              $fields_separated_by = ",";
               $optionally_enclosed_by = '"';
       }
       my $need_hdr = $o->get('header') && !-f $archive_file;
@@ -7508,7 +7508,7 @@ sub escape {
       s/([\t\n\\])/\\$1/g if defined $_;  # Escape tabs etc
       my $s = defined $_ ? $_ : '\N';             # NULL = \N
       # var & ~var will return 0 only for numbers
-      if ($s !~ /^[0-9,.E]+$/  && $optionally_enclosed_by eq '"') {
+      if ($s !~ /^[0-9,.E]+$/  && $optionally_enclosed_by eq '"' && $s ne '\N') {
           $s =~ s/([^\\])"/$1\\"/g;
           $s = $optionally_enclosed_by."$s".$optionally_enclosed_by;
       }

--- a/t/pt-archiver/file.t
+++ b/t/pt-archiver/file.t
@@ -123,11 +123,11 @@ $output = output(
 );
 $output = `cat archive.test.table_2`;
 is($output, <<EOF
-1, 2, 3, 4
-2, "\\N", 3, 4
-3, 2, 3, "\\\t"
-4, 2, 3, "\\\n"
-5, 2, 3, "Zapp \\"Brannigan"
+1,2,3,4
+2,\\N,3,4
+3,2,3,"\\\t"
+4,2,3,"\\\n"
+5,2,3,"Zapp \\"Brannigan"
 EOF
 , '--output-format=csv');
 `rm -f archive.test.table_2`;

--- a/t/pt-archiver/pt-2410.t
+++ b/t/pt-archiver/pt-2410.t
@@ -1,0 +1,75 @@
+#!/usr/bin/env perl
+
+BEGIN {
+   die "The PERCONA_TOOLKIT_BRANCH environment variable is not set.\n"
+      unless $ENV{PERCONA_TOOLKIT_BRANCH} && -d $ENV{PERCONA_TOOLKIT_BRANCH};
+   unshift @INC, "$ENV{PERCONA_TOOLKIT_BRANCH}/lib";
+};
+
+use strict;
+use warnings FATAL => 'all';
+use English qw(-no_match_vars);
+use Test::More;
+
+use charnames ':full';
+
+use PerconaTest;
+use Sandbox;
+require "$trunk/bin/pt-archiver";
+
+my $dp  = new DSNParser(opts=>$dsn_opts);
+my $sb  = new Sandbox(basedir => '/tmp', DSNParser => $dp);
+my $dbh = $sb->get_dbh_for('source');
+
+if ( !$dbh ) {
+   plan skip_all => 'Cannot connect to sandbox source';
+}
+
+my $output;
+my $exit_status;
+my $cnf = "/tmp/12345/my.sandbox.cnf";
+my $cmd = "$trunk/bin/pt-archiver";
+
+$sb->wipe_clean($dbh);
+$sb->create_dbs($dbh, ['test']);
+
+$sb->load_file('source', 't/pt-archiver/samples/pt-2410.sql');
+
+($output, $exit_status) = full_output(
+   sub { pt_archiver::main(
+      qw(--where 1=1 --output-format=csv),
+      '--source', "L=1,D=pt_2410,t=test,F=$cnf",
+      '--file',   '/tmp/pt-2410.csv') },
+);
+
+is(
+   $exit_status,
+   0,
+   'pt-archiver comleted'
+);
+
+$output = `cat /tmp/pt-2410.csv`;
+like(
+   $output,
+   qr/1,\\N,"testing..."/,
+   'NULL values stored correctly'
+) or diag($output);
+
+$dbh->do("load data local infile '/tmp/pt-2410.csv' into table pt_2410.test COLUMNS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '\"'");
+
+$output = `/tmp/12345/use pt_2410 -N -e 'SELECT * FROM test'`;
+
+like(
+   $output,
+   qr/1	NULL	testing.../,
+   'NULL values loaded correctly'
+) or diag($output);
+
+# #############################################################################
+# Done.
+# #############################################################################
+diag(`rm -f /tmp/pt-2410.csv`);
+$sb->wipe_clean($dbh);
+ok($sb->ok(), "Sandbox servers") or BAIL_OUT(__FILE__ . " broke the sandbox");
+done_testing;
+exit;

--- a/t/pt-archiver/samples/pt-2410.sql
+++ b/t/pt-archiver/samples/pt-2410.sql
@@ -1,0 +1,10 @@
+CREATE DATABASE pt_2410;
+USE pt_2410;
+
+CREATE TABLE test(
+    id int not null primary key auto_increment,
+    column1 int default null,
+    column2 varchar(50) not null);
+
+INSERT INTO test VALUES (null,null,'testing...');
+INSERT INTO test VALUES (null,null,'testing...');


### PR DESCRIPTION
Fixing the bug reported at https://perconadev.atlassian.net/browse/PT-2410.

I added to the if on the escape function the \N to be escaped from the enclosed by ".