### PR TITLE
Remove unused variable force_concat_enums

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -5862,8 +5862,6 @@ sub _nibble_params {
       );
       PTDEBUG && _d('Ascend params:', Dumper($asc));
 
-      my $force_concat_enums;
-
 
       my $from     = "$tbl->{name} FORCE INDEX(`$index`)";
       my $order_by = join(', ', map {$q->quote($_)} @{$index_cols});

--- a/bin/pt-table-checksum
+++ b/bin/pt-table-checksum
@@ -6683,8 +6683,6 @@ sub _nibble_params {
       );
       PTDEBUG && _d('Ascend params:', Dumper($asc));
 
-      my $force_concat_enums;
-
 
       my $from     = "$tbl->{name} FORCE INDEX(`$index`)";
       my $order_by = join(', ', map {$q->quote($_)} @{$index_cols});

--- a/lib/NibbleIterator.pm
+++ b/lib/NibbleIterator.pm
@@ -208,10 +208,6 @@ sub _nibble_params {
       );
       PTDEBUG && _d('Ascend params:', Dumper($asc));
 
-      # Check if enum fields items are sorted or not.
-      # If they are sorted we can skip adding CONCAT to improve the queries eficiency.
-      my $force_concat_enums;
-
       # Make SQL statements, prepared on first call to next().  FROM and
       # ORDER BY are the same for all statements.  FORCE IDNEX and ORDER BY
       # are needed to ensure deterministic nibbling.

--- a/util/update-modules
+++ b/util/update-modules
@@ -137,6 +137,10 @@ if [ ! -f $tool_file ]; then
    die "$tool_file does not exist"
 fi
 
+if [ -h $tool_file ]; then
+   die "$tool_file is a symbolic link"
+fi
+
 if [ -n "$(head -n 1 $tool_file | grep perl)" ]; then
    tool_lang="perl"
 else


### PR DESCRIPTION
- Removed variable
- Adjusted utils/update-modules, so it does not process symlinks

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] util/update-modules has been ran
- [x] Documentation updated
- [x] Test suite update
