### PR TITLE
PT-2424 - Typo in pt-table-checksum error message "--resume and --no-…

### DIFF
--- a/bin/pt-table-checksum
+++ b/bin/pt-table-checksum
@@ -10272,11 +10272,11 @@ sub main {
 
 
    if ( $o->get('truncate-replicate-table') && $o->get('resume') ) {
-       die "--resume and truncate-replicate-table are mutually exclusive";
+      die "--resume and truncate-replicate-table are mutually exclusive";
    }
 
    if ( $o->get('truncate-replicate-table') && !$o->get('empty-replicate-table') ) {
-       die "--resume and --no-empty-replicate-table are mutually exclusive";
+      die "--truncate-replicate-table and --no-empty-replicate-table are mutually exclusive";
    }
 
    # ########################################################################

--- a/t/pt-table-checksum/bugs.t
+++ b/t/pt-table-checksum/bugs.t
@@ -378,6 +378,29 @@ is(
 diag(`/tmp/12346/stop >/dev/null`); 
 diag(`/tmp/12346/start >/dev/null`); 
 
+# #############################################################################
+# typo in pt-table-checksum error message
+# https://perconadev.atlassian.net/browse/PT-2424
+# #############################################################################
+
+$output = output(sub {
+   pt_table_checksum::main($source_dsn,
+      qw(--no-empty-replicate-table --truncate-replicate-table)
+   )},
+   stderr => 1,
+);
+
+unlike(
+   $output,
+   qr/--resume and --no-empty-replicate-table are mutually exclusive/,
+   "PT-2424: no typo in the error message"
+);
+
+like(
+   $output,
+   qr/--truncate-replicate-table and --no-empty-replicate-table are mutually exclusive/,
+   "PT-2424: correct error message"
+);
 
 #
 # #############################################################################


### PR DESCRIPTION
…empty-replicate-table are mutually exclusive"

- Fixed typo
- Added test case

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documentation updated
- [x] Test suite update
