### PR TITLE
PT-2453: Add -skip-pod-summary for pt-k8s-debug-collector

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -39,6 +39,7 @@ extend-ignore-re = [
 "END_ND_TOOLTIPS" = "END_ND_TOOLTIPS"
 "EXPLAINed" = "EXPLAINed"
 "FH_ND_FILE" = "FH_ND_FILE"
+"GTI" = "GTI"
 "GTID" = "GTID"
 "INSERTs" = "INSERTs"
 "IST" = "IST"

--- a/.typos.toml
+++ b/.typos.toml
@@ -41,6 +41,7 @@ extend-ignore-re = [
 "FH_ND_FILE" = "FH_ND_FILE"
 "GTI" = "GTI"
 "GTID" = "GTID"
+"GTIDs" = "GTIDs"
 "INSERTs" = "INSERTs"
 "IST" = "IST"
 "istError" = "istError"

--- a/.typos.toml
+++ b/.typos.toml
@@ -39,6 +39,7 @@ extend-ignore-re = [
 "END_ND_TOOLTIPS" = "END_ND_TOOLTIPS"
 "EXPLAINed" = "EXPLAINed"
 "FH_ND_FILE" = "FH_ND_FILE"
+"GTID" = "GTID"
 "INSERTs" = "INSERTs"
 "IST" = "IST"
 "istError" = "istError"

--- a/src/go/pt-k8s-debug-collector/dumper/dumper.go
+++ b/src/go/pt-k8s-debug-collector/dumper/dumper.go
@@ -28,31 +28,33 @@ type sslSecret struct {
 
 // Dumper struct is for dumping cluster
 type Dumper struct {
-	cmd           string
-	kubeconfig    string
-	resources     []string
-	filePaths     []string
-	fileContainer string
-	namespace     string
-	location      string
-	errors        string
-	mode          int64
-	crType        string
-	forwardport   string
-	sslSecrets    []sslSecret
+	cmd            string
+	kubeconfig     string
+	resources      []string
+	filePaths      []string
+	fileContainer  string
+	namespace      string
+	location       string
+	errors         string
+	mode           int64
+	crType         string
+	forwardport    string
+	sslSecrets     []sslSecret
+	skipPodSummary bool
 }
 
 var resourcesRe = regexp.MustCompile(`(\w+\.(\w+).percona\.com)`)
 
 // New return new Dumper object
-func New(location, namespace, resource string, kubeconfig string, forwardport string) Dumper {
+func New(location, namespace, resource string, kubeconfig string, forwardport string, skipPodSummary bool) Dumper {
 	d := Dumper{
-		cmd:         "kubectl",
-		kubeconfig:  kubeconfig,
-		location:    "cluster-dump",
-		mode:        int64(0o777),
-		namespace:   namespace,
-		forwardport: forwardport,
+		cmd:            "kubectl",
+		kubeconfig:     kubeconfig,
+		location:       "cluster-dump",
+		mode:           int64(0o777),
+		namespace:      namespace,
+		forwardport:    forwardport,
+		skipPodSummary: skipPodSummary,
 	}
 	resources := []string{
 		"pods",
@@ -352,18 +354,20 @@ func (d *Dumper) DumpCluster() error {
 					crName = pod.Labels["app.kubernetes.io/instance"]
 				}
 				// Get summary
-				output, err = d.getPodSummary(resourceType(d.crType), pod.Name, crName, ns.Name)
-				if err != nil {
-					d.logError(err.Error(), d.crType, pod.Name)
-					err = addToArchive(location, d.mode, []byte(err.Error()), tw)
+				if !d.skipPodSummary {
+					output, err = d.getPodSummary(resourceType(d.crType), pod.Name, crName, ns.Name)
 					if err != nil {
-						log.Printf("Error: create summary errors archive for pod %s in namespace %s: %v", pod.Name, ns.Name, err)
-					}
-				} else {
-					err = addToArchive(location, d.mode, output, tw)
-					if err != nil {
-						d.logError(err.Error(), "create summary archive for pod "+pod.Name)
-						log.Printf("Error: create summary  archive for pod %s: %v", pod.Name, err)
+						d.logError(err.Error(), d.crType, pod.Name)
+						err = addToArchive(location, d.mode, []byte(err.Error()), tw)
+						if err != nil {
+							log.Printf("Error: create summary errors archive for pod %s in namespace %s: %v", pod.Name, ns.Name, err)
+						}
+					} else {
+						err = addToArchive(location, d.mode, output, tw)
+						if err != nil {
+							d.logError(err.Error(), "create summary archive for pod "+pod.Name)
+							log.Printf("Error: create summary  archive for pod %s: %v", pod.Name, err)
+						}
 					}
 				}
 

--- a/src/go/pt-k8s-debug-collector/main.go
+++ b/src/go/pt-k8s-debug-collector/main.go
@@ -28,6 +28,7 @@ func main() {
 	kubeconfig := ""
 	forwardport := ""
 	version := false
+	skipPodSummary := false
 
 	flag.StringVar(&namespace, "namespace", "", "Namespace for collecting data. If empty data will be collected from all namespaces")
 	flag.StringVar(&resource, "resource", "auto", "Collect data, specific to the resource. Supported values: pxc, psmdb, pg, pgv2, ps, none, auto")
@@ -35,6 +36,7 @@ func main() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig")
 	flag.StringVar(&forwardport, "forwardport", "", "Port to use for  port forwarding")
 	flag.BoolVar(&version, "version", false, "Print version")
+	flag.BoolVar(&skipPodSummary, "skip-pod-summary", false, "Skip pod summary collection")
 	flag.Parse()
 
 	if version {
@@ -50,7 +52,7 @@ func main() {
 		resource += "/" + clusterName
 	}
 
-	d := dumper.New("", namespace, resource, kubeconfig, forwardport)
+	d := dumper.New("", namespace, resource, kubeconfig, forwardport, skipPodSummary)
 	log.Println("Start collecting cluster data")
 
 	err := d.DumpCluster()

--- a/src/go/pt-k8s-debug-collector/main_test.go
+++ b/src/go/pt-k8s-debug-collector/main_test.go
@@ -366,6 +366,106 @@ func TestSSLResourceOption(t *testing.T) {
 }
 
 /*
+Tests for option --skip-pod-summary
+*/
+func TestPT_2453(t *testing.T) {
+	testcmd := []string{"sh", "-c", "tar -tf cluster-dump.tar.gz --wildcards '*/summary.txt' 2>/dev/null | wc -l"}
+	tests := []struct {
+		name       string
+		resource   string
+		want       string
+		kubeconfig string
+	}{
+		{
+			name:       "none",
+			resource:   "none",
+			want:       "0",
+			kubeconfig: "",
+		},
+		{
+			name:       "pxc",
+			resource:   "pxc",
+			want:       "0",
+			kubeconfig: os.Getenv("KUBECONFIG_PXC"),
+		},
+		{
+			name:       "ps",
+			resource:   "ps",
+			want:       "0",
+			kubeconfig: os.Getenv("KUBECONFIG_PS"),
+		},
+		{
+			name:       "psmdb",
+			resource:   "psmdb",
+			want:       "0",
+			kubeconfig: os.Getenv("KUBECONFIG_PSMDB"),
+		},
+		{
+			name:       "pg",
+			resource:   "pg",
+			want:       "0",
+			kubeconfig: os.Getenv("KUBECONFIG_PG"),
+		},
+		{
+			name:       "pgv2",
+			resource:   "pgv2",
+			want:       "0",
+			kubeconfig: os.Getenv("KUBECONFIG_PG2"),
+		},
+		{
+			name:       "auto pxc",
+			resource:   "auto",
+			want:       "0",
+			kubeconfig: os.Getenv("KUBECONFIG_PXC"),
+		},
+		{
+			name:       "auto ps",
+			resource:   "auto",
+			want:       "0",
+			kubeconfig: os.Getenv("KUBECONFIG_PS"),
+		},
+		{
+			name:       "auto psmdb",
+			resource:   "auto",
+			want:       "0",
+			kubeconfig: os.Getenv("KUBECONFIG_PSMDB"),
+		},
+		{
+			name:       "auto pg",
+			resource:   "auto",
+			want:       "0",
+			kubeconfig: os.Getenv("KUBECONFIG_PG"),
+		},
+		{
+			name:       "auto pgv2",
+			resource:   "auto",
+			want:       "0",
+			kubeconfig: os.Getenv("KUBECONFIG_PG2"),
+		},
+	}
+
+	for _, test := range tests {
+		cmd := exec.Command("../../../bin/pt-k8s-debug-collector", "--kubeconfig", test.kubeconfig, "--forwardport", os.Getenv("FORWARDPORT"), "--resource", test.resource, "--skip-pod-summary")
+		if err := cmd.Run(); err != nil {
+			t.Errorf("error executing pt-k8s-debug-collector: %s\nCommand: %s", err.Error(), cmd.String())
+		}
+		defer func() {
+			cmd = exec.Command("rm", "-f", "cluster-dump.tar.gz")
+			if err := cmd.Run(); err != nil {
+				t.Errorf("error cleaning up test data: %s", err.Error())
+			}
+		}()
+		out, err := exec.Command(testcmd[0], testcmd[1:]...).Output()
+		if err != nil {
+			t.Errorf("test %s, error running command %s:\n%s\n\nCommand output:\n%s", test.name, testcmd, err.Error(), out)
+		}
+		if strings.TrimRight(bytes.NewBuffer(out).String(), "\n") != test.want {
+			t.Errorf("test %s, output is not as expected\nOutput: %s\nWanted: %s", test.name, out, test.want)
+		}
+	}
+}
+
+/*
 Option --version
 */
 func TestVersionOption(t *testing.T) {


### PR DESCRIPTION
In some cases, collecting additional data from pods is unnecessary and, due to the current tool design, can cause significant delays. This commit introduces a workaround to skip such collection when it's not required.