### PR TITLE
fix(pt-online-schema-change): correct --remove-data-dir default behav…

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -458,7 +458,9 @@ sub _parse_specs {
          $opt->{spec} =~ s/=./=s/ if ( $type && $type =~ m/[HhAadzm]/ );
 
          if ( (my ($def) = $opt->{desc} =~ m/default\b(?: ([^)]+))?/) ) {
-            $self->{defaults}->{$long} = defined $def ? $def : 1;
+            $def = defined $def ? $def : 1;
+            $def = $def eq 'yes' ? 1 : $def eq 'no' ? 0 : $def;
+            $self->{defaults}->{$long} = $def;
             PTDEBUG && _d($long, 'default:', $def);
          }
 
@@ -11400,6 +11402,10 @@ sub create_new_table {
          $sql =~ s/DATA DIRECTORY\s*=\s*'.*?'//;
          PTDEBUG && _d("removing data dir");
       }
+      if ( $o->got('remove-tablespace') ) {
+         $sql =~ s/TABLESPACE\s+`[^`]+`\s*//;
+         PTDEBUG && _d("removing tablespace");
+      }
       PTDEBUG && _d($sql);
       eval {
          $cxn->dbh()->do($sql);
@@ -12459,7 +12465,7 @@ sub exec_nibble {
 #
 # Required Arguments:
 #   * tbl  - Standard tbl hashref
-#   * sth  - Sth with EXLAIN <statement>
+#   * sth  - Sth with EXPLAIN <statement>
 #   * vals - Values for sth, if any
 #
 # Returns:
@@ -13170,7 +13176,14 @@ than remove-data-dir.
 default: no
 
 If the original table was created using the DATA DIRECTORY feature, remove it and create
-the new table in MySQL default directory without creating a new isl file.
+the new table in MySQL directory without creating a new isl file.
+
+=item --remove-tablespace
+
+default: no
+
+If the original table was created using the TABLESPACE feature, remove it and create
+the new table without the TABLESPACE specification.
 
 =item --defaults-file
 

--- a/t/lib/TableParser.t
+++ b/t/lib/TableParser.t
@@ -1344,6 +1344,111 @@ is_deeply(
     },
     'Column having the word "generated" as part of the comment is OK',
 ) or diag Data::Dumper::Dumper($tbl);
+
+# #############################################################################
+# Test tablespace removal functionality
+# #############################################################################
+
+# Test the regex pattern used in pt-online-schema-change for removing tablespace
+my $ddl_with_tablespace = "CREATE TABLE `test_table` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(50) DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 TABLESPACE `test_tablespace`";
+
+my $ddl_without_tablespace = "CREATE TABLE `test_table` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(50) DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+
+# Test the exact regex pattern used in pt-online-schema-change
+my $test_ddl = $ddl_with_tablespace;
+$test_ddl =~ s/TABLESPACE\s+`[^`]+`\s*//;
+
+is(
+   $test_ddl,
+   $ddl_without_tablespace,
+   'Tablespace clause removed correctly'
+);
+
+# Test with different tablespace names
+my $ddl_with_different_tablespace = "CREATE TABLE `test_table` (
+  `id` int(11) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB TABLESPACE `different_tablespace_name`";
+
+my $ddl_without_different_tablespace = "CREATE TABLE `test_table` (
+  `id` int(11) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB";
+
+$test_ddl = $ddl_with_different_tablespace;
+$test_ddl =~ s/TABLESPACE\s+`[^`]+`\s*//;
+
+is(
+   $test_ddl,
+   $ddl_without_different_tablespace,
+   'Different tablespace name removed correctly'
+);
+
+# Test with tablespace that has underscores and numbers
+my $ddl_with_complex_tablespace = "CREATE TABLE `test_table` (
+  `id` int(11) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB TABLESPACE `my_tablespace_123`";
+
+my $ddl_without_complex_tablespace = "CREATE TABLE `test_table` (
+  `id` int(11) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB";
+
+$test_ddl = $ddl_with_complex_tablespace;
+$test_ddl =~ s/TABLESPACE\s+`[^`]+`\s*//;
+
+is(
+   $test_ddl,
+   $ddl_without_complex_tablespace,
+   'Complex tablespace name with underscores and numbers removed correctly'
+);
+
+# Test that tablespace removal doesn't affect other parts of the DDL
+my $ddl_with_other_options = "CREATE TABLE `test_table` (
+  `id` int(11) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci TABLESPACE `test_tablespace` ROW_FORMAT=DYNAMIC";
+
+my $ddl_without_tablespace_other_options = "CREATE TABLE `test_table` (
+  `id` int(11) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC";
+
+$test_ddl = $ddl_with_other_options;
+$test_ddl =~ s/TABLESPACE\s+`[^`]+`\s*//;
+
+is(
+   $test_ddl,
+   $ddl_without_tablespace_other_options,
+   'Tablespace removal preserves other table options'
+);
+
+# Test that DDL without tablespace is not affected
+my $ddl_without_tablespace_original = "CREATE TABLE `test_table` (
+  `id` int(11) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+
+$test_ddl = $ddl_without_tablespace_original;
+$test_ddl =~ s/TABLESPACE\s+`[^`]+`\s*//;
+
+is(
+   $test_ddl,
+   $ddl_without_tablespace_original,
+   'DDL without tablespace is not affected by removal regex'
+);
+
 # #############################################################################
 # Done.
 # #############################################################################

--- a/t/pt-online-schema-change/remove_tablespace.t
+++ b/t/pt-online-schema-change/remove_tablespace.t
@@ -1,0 +1,213 @@
+#!/usr/bin/env perl
+
+BEGIN {
+   die "The PERCONA_TOOLKIT_BRANCH environment variable is not set.\n"
+      unless $ENV{PERCONA_TOOLKIT_BRANCH} && -d $ENV{PERCONA_TOOLKIT_BRANCH};
+   unshift @INC, "$ENV{PERCONA_TOOLKIT_BRANCH}/lib";
+};
+
+use strict;
+use warnings FATAL => 'all';
+use English qw(-no_match_vars);
+use Test::More;
+
+use Data::Dumper;
+use PerconaTest;
+use Sandbox;
+use SqlModes;
+
+require "$trunk/bin/pt-online-schema-change";
+
+my $dp = new DSNParser(opts=>$dsn_opts);
+my $sb = new Sandbox(basedir => '/tmp', DSNParser => $dp);
+
+if ($sandbox_version lt '5.7') {
+    plan skip_all => 'This test needs MySQL 5.7+ for general tablespace support';
+} else {
+    plan tests => 12;
+}
+
+my $source_dbh = $sb->get_dbh_for('source');
+my $replica_dbh = $sb->get_dbh_for('replica1');
+
+if ( !$source_dbh ) {
+   plan skip_all => 'Cannot connect to sandbox source';
+}
+elsif ( !$replica_dbh ) {
+   plan skip_all => 'Cannot connect to sandbox replica';
+}
+
+# The sandbox servers run with lock_wait_timeout=3 and it's not dynamic
+# so we need to specify --set-vars innodb_lock_wait_timeout=3 else the
+# tool will die.
+my @args = qw(--set-vars innodb_lock_wait_timeout=3);
+my $output;
+my $exit_status;
+my $dsn = "h=127.1,P=12345,u=msandbox,p=msandbox";
+my $sample = "t/pt-online-schema-change/samples";
+
+# #############################################################################
+# Test 1: Basic functionality - remove tablespace from table
+# #############################################################################
+
+$sb->load_file('source', "$sample/remove_tablespace.sql");
+
+# Verify the table was created with tablespace
+my $ddl = $source_dbh->selectrow_arrayref("SHOW CREATE TABLE test.test_table");
+like(
+   $ddl->[1],
+   qr/TABLESPACE `test_tablespace`/,
+   "Table created with tablespace"
+);
+
+# Get original row count
+my $orig_rows = $source_dbh->selectall_arrayref(
+   "SELECT * FROM test.test_table ORDER BY id"
+);
+
+($output, $exit_status) = full_output(
+   sub { pt_online_schema_change::main(@args, "$dsn,D=test,t=test_table",
+         '--execute', 
+         '--alter', "ADD COLUMN new_col INT DEFAULT 42",
+         '--remove-tablespace',
+      )},
+   stderr => 1,
+);
+
+is(
+   $exit_status,
+   0,
+   "Successfully altered table with --remove-tablespace"
+);
+
+like(
+   $output,
+   qr/Successfully altered/s,
+   "Got successfully altered message"
+);
+
+# Verify tablespace was removed from the table
+$ddl = $source_dbh->selectrow_arrayref("SHOW CREATE TABLE test.test_table");
+unlike(
+   $ddl->[1],
+   qr/TABLESPACE `test_tablespace`/,
+   "Tablespace removed from table definition"
+);
+
+# Verify data integrity
+my $new_rows = $source_dbh->selectall_arrayref(
+   "SELECT id, name, created_at FROM test.test_table ORDER BY id"
+);
+is_deeply(
+   $new_rows,
+   $orig_rows,
+   "Data integrity maintained after removing tablespace"
+);
+
+# #############################################################################
+# Test 2: Dry-run mode - verify tablespace removal is planned
+# #############################################################################
+
+$sb->load_file('source', "$sample/remove_tablespace.sql");
+
+($output, $exit_status) = full_output(
+   sub { pt_online_schema_change::main(@args, "$dsn,D=test,t=test_table",
+         '--dry-run', 
+         '--alter', "ADD COLUMN dry_run_col VARCHAR(10)",
+         '--remove-tablespace',
+      )},
+   stderr => 1,
+);
+
+is(
+   $exit_status,
+   0,
+   "Dry-run with --remove-tablespace exits successfully"
+);
+
+like(
+   $output,
+   qr/CREATE TABLE.*test_table.*\(/,
+   "Dry-run shows CREATE TABLE statement"
+);
+
+unlike(
+   $output,
+   qr/TABLESPACE `test_tablespace`/,
+   "Dry-run CREATE TABLE does not include tablespace"
+);
+
+# Verify original table still has tablespace (dry-run didn't change it)
+$ddl = $source_dbh->selectrow_arrayref("SHOW CREATE TABLE test.test_table");
+like(
+   $ddl->[1],
+   qr/TABLESPACE `test_tablespace`/,
+   "Original table still has tablespace after dry-run"
+);
+
+# #############################################################################
+# Test 3: Test with second table
+# #############################################################################
+
+($output, $exit_status) = full_output(
+   sub { pt_online_schema_change::main(@args, "$dsn,D=test,t=test_table2",
+         '--execute', 
+         '--alter', "ADD COLUMN second_col BOOLEAN DEFAULT FALSE",
+         '--remove-tablespace',
+      )},
+   stderr => 1,
+);
+
+is(
+   $exit_status,
+   0,
+   "Successfully altered second table with --remove-tablespace"
+);
+
+# Verify tablespace was removed from the second table
+$ddl = $source_dbh->selectrow_arrayref("SHOW CREATE TABLE test.test_table2");
+unlike(
+   $ddl->[1],
+   qr/TABLESPACE `test_tablespace`/,
+   "Tablespace removed from second table definition"
+);
+
+# #############################################################################
+# Test 4: Test without --remove-tablespace (control test)
+# #############################################################################
+
+$sb->load_file('source', "$sample/remove_tablespace.sql");
+
+($output, $exit_status) = full_output(
+   sub { pt_online_schema_change::main(@args, "$dsn,D=test,t=test_table",
+         '--execute', 
+         '--alter', "ADD COLUMN control_col INT DEFAULT 0",
+      )},
+   stderr => 1,
+);
+
+is(
+   $exit_status,
+   0,
+   "Successfully altered table without --remove-tablespace"
+);
+
+# Verify tablespace is preserved when not using --remove-tablespace
+$ddl = $source_dbh->selectrow_arrayref("SHOW CREATE TABLE test.test_table");
+like(
+   $ddl->[1],
+   qr/TABLESPACE `test_tablespace`/,
+   "Tablespace preserved when not using --remove-tablespace"
+);
+
+# #############################################################################
+# Cleanup
+# #############################################################################
+
+$source_dbh->do("DROP DATABASE IF EXISTS test");
+$source_dbh->do("DROP TABLESPACE IF EXISTS test_tablespace");
+
+$sb->wipe_clean($source_dbh);
+$sb->wipe_clean($replica_dbh);
+ok($sb->ok(), "Sandbox servers") or BAIL_OUT(__FILE__ . " broke the sandbox");
+done_testing; 

--- a/t/pt-online-schema-change/remove_tablespace_basic.t
+++ b/t/pt-online-schema-change/remove_tablespace_basic.t
@@ -1,0 +1,199 @@
+#!/usr/bin/env perl
+
+BEGIN {
+   die "The PERCONA_TOOLKIT_BRANCH environment variable is not set.\n"
+      unless $ENV{PERCONA_TOOLKIT_BRANCH} && -d $ENV{PERCONA_TOOLKIT_BRANCH};
+   unshift @INC, "$ENV{PERCONA_TOOLKIT_BRANCH}/lib";
+};
+
+use strict;
+use warnings FATAL => 'all';
+use English qw(-no_match_vars);
+use Test::More;
+
+use Data::Dumper;
+use PerconaTest;
+use Sandbox;
+use SqlModes;
+
+require "$trunk/bin/pt-online-schema-change";
+
+my $dp = new DSNParser(opts=>$dsn_opts);
+my $sb = new Sandbox(basedir => '/tmp', DSNParser => $dp);
+
+if ($sandbox_version lt '5.6') {
+    plan skip_all => 'This test needs MySQL 5.6+';
+} else {
+    plan tests => 8;
+}
+
+my $source_dbh = $sb->get_dbh_for('source');
+my $replica_dbh = $sb->get_dbh_for('replica1');
+
+if ( !$source_dbh ) {
+   plan skip_all => 'Cannot connect to sandbox source';
+}
+elsif ( !$replica_dbh ) {
+   plan skip_all => 'Cannot connect to sandbox replica';
+}
+
+# The sandbox servers run with lock_wait_timeout=3 and it's not dynamic
+# so we need to specify --set-vars innodb_lock_wait_timeout=3 else the
+# tool will die.
+my @args = qw(--set-vars innodb_lock_wait_timeout=3);
+my $output;
+my $exit_status;
+my $dsn = "h=127.1,P=12345,u=msandbox,p=msandbox";
+my $sample = "t/pt-online-schema-change/samples";
+
+# #############################################################################
+# Test 1: Basic functionality - test regex removal
+# #############################################################################
+
+$sb->load_file('source', "$sample/remove_tablespace_file_per_table.sql");
+
+# Get original row count
+my $orig_rows = $source_dbh->selectall_arrayref(
+   "SELECT * FROM test.test_table ORDER BY id"
+);
+
+($output, $exit_status) = full_output(
+   sub { pt_online_schema_change::main(@args, "$dsn,D=test,t=test_table",
+         '--execute', 
+         '--alter', "ADD COLUMN new_col INT DEFAULT 42",
+         '--remove-tablespace',
+      )},
+   stderr => 1,
+);
+
+is(
+   $exit_status,
+   0,
+   "Successfully altered table with --remove-tablespace"
+);
+
+like(
+   $output,
+   qr/Successfully altered/s,
+   "Got successfully altered message"
+);
+
+# Verify data integrity
+my $new_rows = $source_dbh->selectall_arrayref(
+   "SELECT id, name, created_at FROM test.test_table ORDER BY id"
+);
+is_deeply(
+   $new_rows,
+   $orig_rows,
+   "Data integrity maintained after removing tablespace"
+);
+
+# #############################################################################
+# Test 2: Dry-run mode - verify tablespace removal is planned
+# #############################################################################
+
+$sb->load_file('source', "$sample/remove_tablespace_file_per_table.sql");
+
+($output, $exit_status) = full_output(
+   sub { pt_online_schema_change::main(@args, "$dsn,D=test,t=test_table",
+         '--dry-run', 
+         '--alter', "ADD COLUMN dry_run_col VARCHAR(10)",
+         '--remove-tablespace',
+      )},
+   stderr => 1,
+);
+
+is(
+   $exit_status,
+   0,
+   "Dry-run with --remove-tablespace exits successfully"
+);
+
+like(
+   $output,
+   qr/CREATE TABLE.*test_table.*\(/,
+   "Dry-run shows CREATE TABLE statement"
+);
+
+# #############################################################################
+# Test 3: Test without --remove-tablespace (control test)
+# #############################################################################
+
+$sb->load_file('source', "$sample/remove_tablespace_file_per_table.sql");
+
+($output, $exit_status) = full_output(
+   sub { pt_online_schema_change::main(@args, "$dsn,D=test,t=test_table",
+         '--execute', 
+         '--alter', "ADD COLUMN control_col INT DEFAULT 0",
+      )},
+   stderr => 1,
+);
+
+is(
+   $exit_status,
+   0,
+   "Successfully altered table without --remove-tablespace"
+);
+
+# #############################################################################
+# Test 4: Test regex functionality with manual tablespace addition
+# #############################################################################
+
+# Create a table and manually add a tablespace clause to test the regex
+$source_dbh->do("DROP TABLE IF EXISTS test.test_table");
+$source_dbh->do("CREATE TABLE test.test_table (
+    id INT PRIMARY KEY,
+    name VARCHAR(50)
+) ENGINE=InnoDB");
+
+# Manually modify the DDL to include a tablespace clause for testing
+my $ddl = $source_dbh->selectrow_arrayref("SHOW CREATE TABLE test.test_table");
+my $modified_ddl = $ddl->[1];
+$modified_ddl =~ s/\) ENGINE=InnoDB/\) ENGINE=InnoDB TABLESPACE `test_tablespace`/;
+
+# Create a temporary table with the modified DDL
+$source_dbh->do("DROP TABLE IF EXISTS test.test_table");
+$source_dbh->do($modified_ddl);
+
+# Verify the table has the tablespace clause
+$ddl = $source_dbh->selectrow_arrayref("SHOW CREATE TABLE test.test_table");
+like(
+   $ddl->[1],
+   qr/TABLESPACE `test_tablespace`/,
+   "Table created with manual tablespace clause"
+);
+
+# Test the --remove-tablespace functionality
+($output, $exit_status) = full_output(
+   sub { pt_online_schema_change::main(@args, "$dsn,D=test,t=test_table",
+         '--execute', 
+         '--alter', "ADD COLUMN regex_test_col INT DEFAULT 100",
+         '--remove-tablespace',
+      )},
+   stderr => 1,
+);
+
+is(
+   $exit_status,
+   0,
+   "Successfully removed manually added tablespace clause"
+);
+
+# Verify tablespace clause was removed
+$ddl = $source_dbh->selectrow_arrayref("SHOW CREATE TABLE test.test_table");
+unlike(
+   $ddl->[1],
+   qr/TABLESPACE `test_tablespace`/,
+   "Manually added tablespace clause was removed"
+);
+
+# #############################################################################
+# Cleanup
+# #############################################################################
+
+$source_dbh->do("DROP DATABASE IF EXISTS test");
+
+$sb->wipe_clean($source_dbh);
+$sb->wipe_clean($replica_dbh);
+ok($sb->ok(), "Sandbox servers") or BAIL_OUT(__FILE__ . " broke the sandbox");
+done_testing; 

--- a/t/pt-online-schema-change/remove_tablespace_help.t
+++ b/t/pt-online-schema-change/remove_tablespace_help.t
@@ -1,0 +1,41 @@
+#!/usr/bin/env perl
+
+BEGIN {
+   die "The PERCONA_TOOLKIT_BRANCH environment variable is not set.\n"
+      unless $ENV{PERCONA_TOOLKIT_BRANCH} && -d $ENV{PERCONA_TOOLKIT_BRANCH};
+   unshift @INC, "$ENV{PERCONA_TOOLKIT_BRANCH}/lib";
+};
+
+use strict;
+use warnings FATAL => 'all';
+use English qw(-no_match_vars);
+use Test::More;
+
+use PerconaTest;
+
+require "$trunk/bin/pt-online-schema-change";
+
+plan tests => 2;
+
+# #############################################################################
+# Test that --remove-tablespace option is documented in help
+# #############################################################################
+
+my ($output, $exit_status) = full_output(
+   sub { pt_online_schema_change::main('--help') },
+   stderr => 1,
+);
+
+is(
+   $exit_status,
+   0,
+   "Help command exits successfully"
+);
+
+like(
+   $output,
+   qr/--remove-tablespace/,
+   "Help output includes --remove-tablespace option"
+);
+
+done_testing; 

--- a/t/pt-online-schema-change/samples/remove_tablespace.sql
+++ b/t/pt-online-schema-change/samples/remove_tablespace.sql
@@ -1,0 +1,35 @@
+-- Sample table with tablespace for testing --remove-tablespace functionality
+-- This requires MySQL 5.7+ for general tablespace support
+
+CREATE DATABASE IF NOT EXISTS test;
+USE test;
+
+-- Create a general tablespace first (MySQL 5.7+)
+CREATE TABLESPACE test_tablespace ADD DATAFILE 'test_tablespace.ibd';
+
+-- Create table with tablespace
+CREATE TABLE test_table (
+    id INT PRIMARY KEY,
+    name VARCHAR(50),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) TABLESPACE test_tablespace;
+
+-- Insert some test data
+INSERT INTO test_table (id, name) VALUES 
+(1, 'Alice'),
+(2, 'Bob'),
+(3, 'Charlie'),
+(4, 'David'),
+(5, 'Eve');
+
+-- Create another table with tablespace for testing multiple tables
+CREATE TABLE test_table2 (
+    id INT PRIMARY KEY,
+    description TEXT,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) TABLESPACE test_tablespace;
+
+INSERT INTO test_table2 (id, description) VALUES 
+(1, 'First record'),
+(2, 'Second record'),
+(3, 'Third record'); 

--- a/t/pt-online-schema-change/samples/remove_tablespace_file_per_table.sql
+++ b/t/pt-online-schema-change/samples/remove_tablespace_file_per_table.sql
@@ -1,0 +1,32 @@
+-- Sample table with file-per-table tablespace for testing --remove-tablespace functionality
+-- This works with MySQL 5.6+ (file-per-table tablespaces)
+
+CREATE DATABASE IF NOT EXISTS test;
+USE test;
+
+-- Create table (will use file-per-table tablespace by default in MySQL 5.6+)
+CREATE TABLE test_table (
+    id INT PRIMARY KEY,
+    name VARCHAR(50),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+-- Insert some test data
+INSERT INTO test_table (id, name) VALUES 
+(1, 'Alice'),
+(2, 'Bob'),
+(3, 'Charlie'),
+(4, 'David'),
+(5, 'Eve');
+
+-- Create another table for testing multiple tables
+CREATE TABLE test_table2 (
+    id INT PRIMARY KEY,
+    description TEXT,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+INSERT INTO test_table2 (id, description) VALUES 
+(1, 'First record'),
+(2, 'Second record'),
+(3, 'Third record'); 


### PR DESCRIPTION
…ior (#PT-2458)

- Fixed issue where --remove-data-dir incorrectly defaulted to true

feat(pt-online-schema-change): add support for TABLESPACE removal (#PT-2457)
- Implemented detection and removal of TABLESPACE clause during schema changes

- [X] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [X] Documentation updated
- [X] Test suite update
