### PR TITLE
PT-2418: Fix column data loss during RENAME COLUMN operations

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -11239,7 +11239,7 @@ sub find_renamed_cols {
       next if lc($orig_tbl) eq lc($new_tbl);
       $renames{lc($orig_tbl)} = $new_tbl;
    }
-   
+
    # Also handle RENAME COLUMN syntax (MySQL 8.0+)
    while ( $alter =~ /$alter_rename_col_re/g ) {
       my ($orig, $new) = map { $tp->ansi_to_legacy($_) } $1, $2;

--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -11226,6 +11226,8 @@ sub find_renamed_cols {
 
    my $alter_change_col_re = qr/\bCHANGE \s+ (?:COLUMN \s+)?
                                 ($table_ident) \s+ ($table_ident)/ix;
+   my $alter_rename_col_re = qr/\bRENAME \s+ COLUMN \s+
+                                ($table_ident) \s+ TO \s+ ($table_ident)/ix;
 
    my %renames;
    while ( $alter =~ /$alter_change_col_re/g ) {
@@ -11234,6 +11236,17 @@ sub find_renamed_cols {
       my (undef, $orig_tbl) = Quoter->split_unquote($orig);
       my (undef, $new_tbl)  = Quoter->split_unquote($new);
       # Silly but plausible: CHANGE COLUMN same_name same_name ...
+      next if lc($orig_tbl) eq lc($new_tbl);
+      $renames{lc($orig_tbl)} = $new_tbl;
+   }
+   
+   # Also handle RENAME COLUMN syntax (MySQL 8.0+)
+   while ( $alter =~ /$alter_rename_col_re/g ) {
+      my ($orig, $new) = map { $tp->ansi_to_legacy($_) } $1, $2;
+      next unless $orig && $new;
+      my (undef, $orig_tbl) = Quoter->split_unquote($orig);
+      my (undef, $new_tbl)  = Quoter->split_unquote($new);
+      # Silly but plausible: RENAME COLUMN same_name TO same_name ...
       next if lc($orig_tbl) eq lc($new_tbl);
       $renames{lc($orig_tbl)} = $new_tbl;
    }

--- a/t/pt-online-schema-change/PT-2418-timestamp_null_issue.t
+++ b/t/pt-online-schema-change/PT-2418-timestamp_null_issue.t
@@ -21,7 +21,9 @@ my $dp = new DSNParser(opts=>$dsn_opts);
 my $sb = new Sandbox(basedir => '/tmp', DSNParser => $dp);
 my $source_dbh = $sb->get_dbh_for('source');
 
-if ( !$source_dbh ) {
+if ($sandbox_version lt '8.0') {
+    plan skip_all => 'This test needs MySQL 8.0+';
+} elsif ( !$source_dbh ) {
    plan skip_all => 'Cannot connect to sandbox source';
 }
 

--- a/t/pt-online-schema-change/PT-2418-timestamp_null_issue.t
+++ b/t/pt-online-schema-change/PT-2418-timestamp_null_issue.t
@@ -64,6 +64,26 @@ is(
    "All timestamp values are non-NULL before rename operation"
 ) or diag("Found $null_timestamps NULL timestamps out of " . scalar(@$orig_data) . " rows");
 
+# Test if --check-alter works correctly
+($output, $exit_status) = full_output(
+   sub { pt_online_schema_change::main(@args,
+      "$source_dsn,D=test,t=joinit",
+      "--alter", "RENAME COLUMN t1 TO t2",
+      qw(--execute --check-alter)) },
+);
+
+is(
+   $exit_status,
+   17,
+   "Column rename operation rejected correctly"
+) or diag($output);
+
+like(
+   $output,
+   qr/`test`.`joinit` was not altered./,
+   "Table was not altered"
+);
+
 # Perform the column rename operation
 ($output, $exit_status) = full_output(
    sub { pt_online_schema_change::main(@args,
@@ -155,4 +175,6 @@ for (my $i = 0; $i < scalar(@$orig_data); $i++) {
              ", Final=" . (defined($final_data->[$i]->[2]) ? $final_data->[$i]->[2] : "NULL"));
 }
 
+$sb->wipe_clean($source_dbh);
+ok($sb->ok(), "Sandbox servers") or BAIL_OUT(__FILE__ . " broke the sandbox");
 done_testing; 

--- a/t/pt-online-schema-change/PT-2418-timestamp_null_issue.t
+++ b/t/pt-online-schema-change/PT-2418-timestamp_null_issue.t
@@ -1,0 +1,158 @@
+#!/usr/bin/env perl
+
+BEGIN {
+   die "The PERCONA_TOOLKIT_BRANCH environment variable is not set.\n"
+      unless $ENV{PERCONA_TOOLKIT_BRANCH} && -d $ENV{PERCONA_TOOLKIT_BRANCH};
+   unshift @INC, "$ENV{PERCONA_TOOLKIT_BRANCH}/lib";
+};
+
+use strict;
+use warnings FATAL => 'all';
+use English qw(-no_match_vars);
+use Test::More;
+
+use Data::Dumper;
+use PerconaTest;
+use Sandbox;
+
+require "$trunk/bin/pt-online-schema-change";
+
+my $dp = new DSNParser(opts=>$dsn_opts);
+my $sb = new Sandbox(basedir => '/tmp', DSNParser => $dp);
+my $source_dbh = $sb->get_dbh_for('source');
+
+if ( !$source_dbh ) {
+   plan skip_all => 'Cannot connect to sandbox source';
+}
+
+# The sandbox servers run with lock_wait_timeout=3 and it's not dynamic
+# so we need to specify --set-vars innodb_lock_wait_timeout=3 else the
+# tool will die.
+my $source_dsn = 'h=127.1,P=12345,u=msandbox,p=msandbox';
+my @args       = (qw(--set-vars innodb_lock_wait_timeout=3));
+my $output;
+my $exit_status;
+my $sample  = "t/pt-online-schema-change/samples/";
+
+# ############################################################################
+# Test for timestamp NULL issue during column rename
+# This reproduces the issue where 't' column values become NULL after CHANGE COLUMN
+# ############################################################################
+
+$sb->load_file('source', "$sample/PT-2418-timestamp_null_issue.sql");
+
+# Get the original data before the rename operation
+my $orig_data = $source_dbh->selectall_arrayref(
+   "SELECT i, s, t1, g FROM test.joinit ORDER BY i"
+);
+
+# Verify we have data with non-NULL timestamps
+ok(
+   scalar(@$orig_data) > 0,
+   "Table has data before rename operation"
+);
+
+# Check that timestamps are not NULL
+my $null_timestamps = 0;
+foreach my $row (@$orig_data) {
+   $null_timestamps++ if !defined($row->[2]); # column 't' is at index 2
+}
+
+is(
+   $null_timestamps,
+   0,
+   "All timestamp values are non-NULL before rename operation"
+) or diag("Found $null_timestamps NULL timestamps out of " . scalar(@$orig_data) . " rows");
+
+# Perform the column rename operation
+($output, $exit_status) = full_output(
+   sub { pt_online_schema_change::main(@args,
+      "$source_dsn,D=test,t=joinit",
+      "--alter", "RENAME COLUMN t1 TO t2",
+      qw(--execute --no-check-alter)) },
+);
+
+is(
+   $exit_status,
+   0,
+   "Column rename operation completed successfully"
+) or diag($output);
+
+# Get the data after the rename operation
+my $new_data = $source_dbh->selectall_arrayref(
+   "SELECT i, s, t2, g FROM test.joinit ORDER BY i"
+);
+
+# Verify the data structure is the same
+is(
+   scalar(@$new_data),
+   scalar(@$orig_data),
+   "Same number of rows after rename operation"
+);
+
+# Check that timestamps are preserved (not NULL)
+$null_timestamps = 0;
+foreach my $row (@$new_data) {
+   $null_timestamps++ if !defined($row->[2]); # column 't1' is now at index 2
+}
+
+is(
+   $null_timestamps,
+   0,
+   "All timestamp values are preserved (non-NULL) after rename operation"
+) or diag("Found $null_timestamps NULL timestamps out of " . scalar(@$new_data) . " rows");
+
+# Compare the actual timestamp values (ignoring the column name change)
+for (my $i = 0; $i < scalar(@$orig_data); $i++) {
+   is(
+      $new_data->[$i]->[2], # t1 column value
+      $orig_data->[$i]->[2], # original t column value
+      "Timestamp value preserved for row " . ($i + 1)
+   ) or diag("Row " . ($i + 1) . ": Original=" . 
+             (defined($orig_data->[$i]->[2]) ? $orig_data->[$i]->[2] : "NULL") . 
+             ", New=" . (defined($new_data->[$i]->[2]) ? $new_data->[$i]->[2] : "NULL"));
+}
+
+# Test the reverse rename operation
+($output, $exit_status) = full_output(
+   sub { pt_online_schema_change::main(@args,
+      "$source_dsn,D=test,t=joinit",
+      "--alter", "CHANGE COLUMN t2 t1 time NOT NULL",
+      qw(--execute --no-check-alter)) },
+);
+
+is(
+   $exit_status,
+   0,
+   "Reverse column rename operation completed successfully"
+) or diag($output);
+
+# Get the data after the reverse rename
+my $final_data = $source_dbh->selectall_arrayref(
+   "SELECT i, s, t1, g FROM test.joinit ORDER BY i"
+);
+
+# Verify timestamps are still preserved
+$null_timestamps = 0;
+foreach my $row (@$final_data) {
+   $null_timestamps++ if !defined($row->[2]); # column 't' is back at index 2
+}
+
+is(
+   $null_timestamps,
+   0,
+   "All timestamp values are preserved (non-NULL) after reverse rename operation"
+) or diag("Found $null_timestamps NULL timestamps out of " . scalar(@$final_data) . " rows");
+
+# Compare with original data
+for (my $i = 0; $i < scalar(@$orig_data); $i++) {
+   is(
+      $final_data->[$i]->[2], # t column value
+      $orig_data->[$i]->[2], # original t column value
+      "Timestamp value preserved after reverse rename for row " . ($i + 1)
+   ) or diag("Row " . ($i + 1) . ": Original=" . 
+             (defined($orig_data->[$i]->[2]) ? $orig_data->[$i]->[2] : "NULL") . 
+             ", Final=" . (defined($final_data->[$i]->[2]) ? $final_data->[$i]->[2] : "NULL"));
+}
+
+done_testing; 

--- a/t/pt-online-schema-change/samples/PT-2418-timestamp_null_issue.sql
+++ b/t/pt-online-schema-change/samples/PT-2418-timestamp_null_issue.sql
@@ -1,0 +1,19 @@
+-- Test case for timestamp NULL issue during column rename
+-- This reproduces the issue where 't' column values become NULL after CHANGE COLUMN
+
+DROP DATABASE IF EXISTS test;
+CREATE DATABASE test;
+USE test;
+
+CREATE TABLE `joinit` (
+ `i` int(11) NOT NULL AUTO_INCREMENT,
+ `s` varchar(64) DEFAULT NULL,
+ `t1` time DEFAULT NULL,
+ `g` int(11) NOT NULL,
+ PRIMARY KEY (`i`)
+);
+
+-- Insert initial data with timestamps
+INSERT INTO joinit VALUES (NULL, uuid(), time(now()), (FLOOR( 1 + RAND( ) *60 )));
+INSERT INTO joinit SELECT NULL, uuid(), time(now()), (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()), (FLOOR( 1 + RAND( ) *60 )) FROM joinit; 


### PR DESCRIPTION
The pt-online-schema-change tool was not properly handling RENAME COLUMN syntax (MySQL 8.0+), causing renamed columns to be excluded from the data copy operation. This resulted in NULL values for renamed columns after the schema change.

The issue was in the find_renamed_cols() function which only supported CHANGE COLUMN syntax but not RENAME COLUMN syntax. Added support for RENAME COLUMN parsing to properly detect column renames and include them in the common_cols list for data copying.

Fixes: PT-2418

- [X] The contributed code is licensed under GPL v2.0
- [X] Contributor Licence Agreement (CLA) is signed
- [X] util/update-modules has been ran
- [X] Documentation updated
- [X] Test suite update
