### PR TITLE
PT-2463 pt-galera-log-explainer broken conflicts due to md5 being rec…

### DIFF
--- a/src/go/pt-galera-log-explainer/regex/applicative.go
+++ b/src/go/pt-galera-log-explainer/regex/applicative.go
@@ -201,6 +201,26 @@ var ApplicativeMap = types.RegexMap{
 		},
 		Verbosity: types.DebugMySQL,
 	},
+
+	"RegexInconsistencyVoteRecomputed": &types.LogRegex{
+		Regex:         regexp.MustCompile("Recomputed vote based on error codes"),
+		InternalRegex: regexp.MustCompile("New vote " + regexErrorMD5 + " will be used.*Old Vote: (?P<" + groupErrorMD5 + "2" + ">[a-z0-9]*)"),
+		Handler: func(submatches map[string]string, logCtx types.LogCtx, log string, date time.Time) (types.LogCtx, types.LogDisplayer) {
+			oldMD5 := submatches[groupErrorMD5+"2"]
+			md5 := submatches[groupErrorMD5]
+
+			for _, conflict := range logCtx.Conflicts {
+				for node, vote := range conflict.VotePerNode {
+					if vote.MD5 == oldMD5 {
+						vote.MD5 = md5
+						conflict.VotePerNode[node] = vote
+					}
+				}
+			}
+			return logCtx, types.SimpleDisplayer("vote md5 recomputed from " + oldMD5 + " to " + md5)
+		},
+		Verbosity: types.DebugMySQL,
+	},
 }
 
 func voteResponse(vote types.ConflictVote, conflict types.Conflict) string {

--- a/src/go/pt-galera-log-explainer/regex/applicative_test.go
+++ b/src/go/pt-galera-log-explainer/regex/applicative_test.go
@@ -159,6 +159,18 @@ func TestApplicativeRegex(t *testing.T) {
 			expectedOut: "vote (success) inconsistent, leaving cluster",
 			key:         "RegexInconsistencyVoteInconsistentWithGroup",
 		},
+
+		{
+			log: "2001-01-01T01:01:01.000000Z 16 [ERROR] [MY-000000] [Galera] Recomputed vote based on error codes: 3638. New vote c4915064add984b1 will be used for further steps. Old Vote: b3be677140613e7",
+			input: regexTestState{
+				LogCtx: types.LogCtx{OwnNames: []string{"node2"}, Conflicts: types.Conflicts{&types.Conflict{InitiatedBy: []string{"node1"}, Seqno: "20", VotePerNode: map[string]types.ConflictVote{"node1": types.ConflictVote{MD5: "b3be677140613e7", Error: "some error"}, "node2": types.ConflictVote{MD5: "b3be677140613e7", Error: "some error"}}}}},
+			},
+			expected: regexTestState{
+				LogCtx: types.LogCtx{OwnNames: []string{"node2"}, Conflicts: types.Conflicts{&types.Conflict{InitiatedBy: []string{"node1"}, Seqno: "20", VotePerNode: map[string]types.ConflictVote{"node1": types.ConflictVote{MD5: "c4915064add984b1", Error: "some error"}, "node2": types.ConflictVote{MD5: "c4915064add984b1", Error: "some error"}}}}},
+			},
+			expectedOut: "vote md5 recomputed from b3be677140613e7 to c4915064add984b1",
+			key:         "RegexInconsistencyVoteRecomputed",
+		},
 	}
 
 	iterateRegexTest(t, ApplicativeMap, tests)


### PR DESCRIPTION
…omputed

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [ ] Documentation updated
- [x] Test suite update
