### PR TITLE
Pt 2052 tools should default to unbuffered stdout stderr

### DIFF
--- a/bin/pt-align
+++ b/bin/pt-align
@@ -528,6 +528,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -1265,6 +1269,13 @@ This tool accepts additional command-line arguments.  Refer to the
 L<"SYNOPSIS"> and usage information for details.
 
 =over
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --help
 

--- a/bin/pt-archiver
+++ b/bin/pt-archiver
@@ -1257,6 +1257,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -7768,6 +7772,13 @@ The danger is that a crash might cause lost data.
 
 The performance increase I have seen from using L<"--buffer"> is around 5 to 15
 percent.  Your mileage may vary.
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --bulk-delete
 

--- a/bin/pt-config-diff
+++ b/bin/pt-config-diff
@@ -1255,6 +1255,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -5737,6 +5741,13 @@ L<"SYNOPSIS"> and usage information for details.
 =item --ask-pass
 
 Prompt for a password when connecting to MySQL.
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --charset
 

--- a/bin/pt-deadlock-logger
+++ b/bin/pt-deadlock-logger
@@ -605,6 +605,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -5335,6 +5339,13 @@ L<"SYNOPSIS"> and usage information for details.
 =item --ask-pass
 
 Prompt for a password when connecting to MySQL.
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --charset
 

--- a/bin/pt-diskstats
+++ b/bin/pt-diskstats
@@ -601,6 +601,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -5473,6 +5477,13 @@ This tool accepts additional command-line arguments.  Refer to the
 L<"SYNOPSIS"> and usage information for details.
 
 =over
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --columns-regex
 

--- a/bin/pt-duplicate-key-checker
+++ b/bin/pt-duplicate-key-checker
@@ -1660,6 +1660,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -5450,6 +5454,13 @@ as a FULLTEXT index is not really a duplicate, for example.
 =item --ask-pass
 
 Prompt for a password when connecting to MySQL.
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --charset
 

--- a/bin/pt-fifo-split
+++ b/bin/pt-fifo-split
@@ -529,6 +529,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -1566,6 +1570,13 @@ This tool accepts additional command-line arguments.  Refer to the
 L<"SYNOPSIS"> and usage information for details.
 
 =over
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --config
 

--- a/bin/pt-find
+++ b/bin/pt-find
@@ -1048,6 +1048,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -4561,6 +4565,13 @@ L<"SYNOPSIS"> and usage information for details.
 =item --ask-pass
 
 Prompt for a password when connecting to MySQL.
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --case-insensitive
 

--- a/bin/pt-fingerprint
+++ b/bin/pt-fingerprint
@@ -530,6 +530,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -2136,6 +2140,13 @@ This tool accepts additional command-line arguments.  Refer to the
 L<"SYNOPSIS"> and usage information for details.
 
 =over
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --config
 

--- a/bin/pt-fk-error-logger
+++ b/bin/pt-fk-error-logger
@@ -600,6 +600,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -4458,6 +4462,13 @@ L<"SYNOPSIS"> and usage information for details.
 =item --ask-pass
 
 Prompt for a password when connecting to MySQL.
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --charset
 

--- a/bin/pt-heartbeat
+++ b/bin/pt-heartbeat
@@ -1558,6 +1558,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -7101,6 +7105,13 @@ L<"SYNOPSIS"> and usage information for details.
 =item --ask-pass
 
 Prompt for a password when connecting to MySQL.
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --charset
 

--- a/bin/pt-index-usage
+++ b/bin/pt-index-usage
@@ -1214,6 +1214,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -7199,6 +7203,13 @@ L<"SYNOPSIS"> and usage information for details.
 =item --ask-pass
 
 Prompt for a password when connecting to MySQL.
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --charset
 

--- a/bin/pt-kill
+++ b/bin/pt-kill
@@ -610,6 +610,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -8004,6 +8008,13 @@ L<"SYNOPSIS"> and usage information for details.
 =item --ask-pass
 
 Prompt for a password when connecting to MySQL.
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --charset
 

--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -667,6 +667,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -12922,6 +12926,13 @@ data type.
 This is useful when you change large tables with keys that include a binary
 data type or that have non-standard character sets.
 See L<"--history"> and L<"--resume">.
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --channel
 

--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -1882,6 +1882,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -15698,6 +15702,13 @@ This option deals with bugs in slow logging functionality that causes large
 values for attributes.  If the attribute's value is bigger than this, the
 last-seen value for that class of query is used instead.
 Disabled by default.
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --charset
 

--- a/bin/pt-replica-find
+++ b/bin/pt-replica-find
@@ -538,6 +538,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -4403,6 +4407,13 @@ L<"SYNOPSIS"> and usage information for details.
 =item --ask-pass
 
 Prompt for a password when connecting to MySQL.
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --charset
 

--- a/bin/pt-replica-restart
+++ b/bin/pt-replica-restart
@@ -760,6 +760,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -5909,6 +5913,13 @@ pt-replica-restart will not let you stop the replica manually if you want to!
 =item --ask-pass
 
 Prompt for a password when connecting to MySQL.
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --charset
 

--- a/bin/pt-show-grants
+++ b/bin/pt-show-grants
@@ -531,6 +531,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -2401,6 +2405,13 @@ L<"SYNOPSIS"> and usage information for details.
 =item --ask-pass
 
 Prompt for a password when connecting to MySQL.
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --charset
 

--- a/bin/pt-slave-delay
+++ b/bin/pt-slave-delay
@@ -604,6 +604,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }

--- a/bin/pt-table-checksum
+++ b/bin/pt-table-checksum
@@ -2364,6 +2364,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -13305,6 +13309,13 @@ L<"SYNOPSIS"> and usage information for details.
 group: Connection
 
 Prompt for a password when connecting to MySQL.
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --channel
 

--- a/bin/pt-table-sync
+++ b/bin/pt-table-sync
@@ -618,6 +618,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -12491,6 +12495,13 @@ time anyway, and use all your memory.
 For most non-trivial data sizes, you want to leave this option enabled.
 
 This option is disabled when L<"--bidirectional"> is used.
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --channel
 

--- a/bin/pt-table-usage
+++ b/bin/pt-table-usage
@@ -1650,6 +1650,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -8258,6 +8262,13 @@ L<"SYNOPSIS"> and usage information for details.
 =item --ask-pass
 
 Prompt for a password when connecting to MySQL.
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --charset
 

--- a/bin/pt-upgrade
+++ b/bin/pt-upgrade
@@ -1879,6 +1879,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -11090,6 +11094,13 @@ L<"SYNOPSIS"> and usage information for details.
 =item --ask-pass
 
 Prompt for a password when connecting to MySQL.
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --charset
 

--- a/bin/pt-variable-advisor
+++ b/bin/pt-variable-advisor
@@ -607,6 +607,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -6099,6 +6103,13 @@ L<"SYNOPSIS"> and usage information for details.
 =item --ask-pass
 
 Prompt for a password when connecting to MySQL.
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --charset
 

--- a/bin/pt-visual-explain
+++ b/bin/pt-visual-explain
@@ -1217,6 +1217,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }
@@ -3945,6 +3949,13 @@ L<"SYNOPSIS"> and usage information for details.
 =item --ask-pass
 
 Prompt for a password when connecting to MySQL.
+
+=item --[no]buffer-stdout
+
+default: yes
+
+Enables STDOUT buffering. Disable this option if you want to see live progress
+when using output post-processing tools such as C<tee> or C<kubectl logs>.
 
 =item --charset
 

--- a/lib/OptionParser.pm
+++ b/lib/OptionParser.pm
@@ -668,6 +668,10 @@ sub get_opts {
       }
    }
 
+   if ( exists $self->{opts}->{'buffer-stdout'} && $self->{opts}->{'buffer-stdout'}->{got} ) {
+      STDOUT->autoflush(1 - $self->{opts}->{'buffer-stdout'}->{value});
+   }
+
    if ( @ARGV && $self->{strict} ) {
       $self->save_error("Unrecognized command-line options @ARGV");
    }

--- a/t/pt-table-checksum/pt-2052.t
+++ b/t/pt-table-checksum/pt-2052.t
@@ -1,0 +1,112 @@
+#!/usr/bin/env perl
+
+BEGIN {
+   die "The PERCONA_TOOLKIT_BRANCH environment variable is not set.\n"
+      unless $ENV{PERCONA_TOOLKIT_BRANCH} && -d $ENV{PERCONA_TOOLKIT_BRANCH};
+   unshift @INC, "$ENV{PERCONA_TOOLKIT_BRANCH}/lib";
+};
+
+use strict;
+use warnings FATAL => 'all';
+use English qw(-no_match_vars);
+use Test::More;
+use Time::Local;
+
+use PerconaTest;
+use Sandbox;
+require "$trunk/bin/pt-table-checksum";
+
+my $dp  = new DSNParser(opts=>$dsn_opts);
+my $sb  = new Sandbox(basedir => '/tmp', DSNParser => $dp);
+my $dbh = $sb->get_dbh_for('source');
+
+my $output = `$trunk/bin/pt-table-checksum h=127.1,P=12345,u=msandbox,p=msandbox --set-vars innodb_lock_wait_timeout=3 --chunk-size=50 -d sakila --buffer-stdout 2>&1 | tee | ts '%m-%dT%H:%M:%S'`;
+
+my @lines = split(/\n/, $output);
+my @times = ( $lines[3] =~ m/\d\d-\d\dT\d\d:\d\d:\d\d/g );
+
+is(
+   scalar(@times),
+   2,
+   "Expected number of timestamp values"
+) or diag($output);
+
+my ($month, $day, $hour, $min, $sec) = split(/[T:-]+/, $times[0]);
+my $time_ts = timelocal($sec, $min, $hour, $day, $month);
+($month, $day, $hour, $min, $sec) = split(/[T:-]+/, $times[1]);
+my $time_tool = timelocal($sec, $min, $hour, $day, $month);
+
+cmp_ok(
+   $time_ts - $time_tool, 'gt', 1,
+   "Print delay is expected for the buffered output"
+) or diag($output); 
+
+$output = `$trunk/bin/pt-table-checksum h=127.1,P=12345,u=msandbox,p=msandbox --set-vars innodb_lock_wait_timeout=3 --chunk-size=50 -d sakila 2>&1 | tee | ts '%m-%dT%H:%M:%S'`;
+
+@lines = split(/\n/, $output);
+@times = ( $lines[3] =~ m/\d\d-\d\dT\d\d:\d\d:\d\d/g );
+
+is(
+   scalar(@times),
+   2,
+   "Expected number of timestamp values"
+) or diag($output);
+
+($month, $day, $hour, $min, $sec) = split(/[T:-]+/, $times[0]);
+$time_ts = timelocal($sec, $min, $hour, $day, $month);
+($month, $day, $hour, $min, $sec) = split(/[T:-]+/, $times[1]);
+$time_tool = timelocal($sec, $min, $hour, $day, $month);
+
+cmp_ok(
+   $time_ts - $time_tool, 'gt', 1,
+   "STDOUT is buffered by default"
+) or diag($output); 
+
+$output = `$trunk/bin/pt-table-checksum h=127.1,P=12345,u=msandbox,p=msandbox --set-vars innodb_lock_wait_timeout=3 --chunk-size=50 -d sakila --no-buffer-stdout 2>&1 | tee | ts '%m-%dT%H:%M:%S'`;
+
+@lines = split(/\n/, $output);
+@times = ( $lines[3] =~ m/\d\d-\d\dT\d\d:\d\d:\d\d/g );
+
+is(
+   scalar(@times),
+   2,
+   "Expected number of timestamp values"
+) or diag($output);
+
+($month, $day, $hour, $min, $sec) = split(/[T:-]+/, $times[0]);
+$time_ts = timelocal($sec, $min, $hour, $day, $month);
+($month, $day, $hour, $min, $sec) = split(/[T:-]+/, $times[1]);
+$time_tool = timelocal($sec, $min, $hour, $day, $month);
+
+cmp_ok(
+   $time_ts - $time_tool, 'le', 1,
+   "Print delay is not expected when buffering is disabled"
+) or diag($output); 
+
+$output = `$trunk/bin/pt-table-checksum h=127.1,P=12345,u=msandbox,p=msandbox --set-vars innodb_lock_wait_timeout=3 --chunk-size=50 -d sakila --nobuffer-stdout 2>&1 | tee | ts '%m-%dT%H:%M:%S'`;
+
+@lines = split(/\n/, $output);
+@times = ( $lines[3] =~ m/\d\d-\d\dT\d\d:\d\d:\d\d/g );
+
+is(
+   scalar(@times),
+   2,
+   "Expected number of timestamp values"
+) or diag($output);
+
+($month, $day, $hour, $min, $sec) = split(/[T:-]+/, $times[0]);
+$time_ts = timelocal($sec, $min, $hour, $day, $month);
+($month, $day, $hour, $min, $sec) = split(/[T:-]+/, $times[1]);
+$time_tool = timelocal($sec, $min, $hour, $day, $month);
+
+cmp_ok(
+   $time_ts - $time_tool, 'le', 1,
+   "Test 2: Print delay is not expected when buffering is disabled"
+) or diag($output); 
+
+# #############################################################################
+# Done.
+# #############################################################################
+$sb->wipe_clean($dbh);
+ok($sb->ok(), "Sandbox servers") or BAIL_OUT(__FILE__ . " broke the sandbox");
+done_testing;


### PR DESCRIPTION
Kept old behavior default and introduced new option: `--[no]buffer-stdout` available in all Perl tools.

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] util/update-modules has been ran
- [x] Documentation updated
- [x] Test suite update
