### PR TITLE
PT-2015 Fix pt-config-diff not sorting flags

### DIFF
--- a/bin/pt-config-diff
+++ b/bin/pt-config-diff
@@ -3701,6 +3701,10 @@ sub _normalize_value {
    $val = defined $val ? $val : '';
    $val = $alt_val_for{$val} if exists $alt_val_for{$val};
 
+   if ( $val =~ m/,/ && !$is_dir && !$base_path) {
+      $val = join(',', sort(split(',', $val)));
+   }
+
    if ( $val ) {
       if ( $is_dir ) {
          $val .= '/' unless $val =~ m/\/$/;

--- a/lib/MySQLConfigComparer.pm
+++ b/lib/MySQLConfigComparer.pm
@@ -295,6 +295,10 @@ sub _normalize_value {
    $val = defined $val ? $val : '';
    $val = $alt_val_for{$val} if exists $alt_val_for{$val};
 
+   if ( $val =~ m/,/ && !$is_dir && !$base_path) {
+      $val = join(',', sort(split(',', $val)));
+   }
+
    if ( $val ) {
       if ( $is_dir ) {
          $val .= '/' unless $val =~ m/\/$/;

--- a/t/lib/MySQLConfigComparer.t
+++ b/t/lib/MySQLConfigComparer.t
@@ -370,6 +370,30 @@ $c2 = new MySQLConfig(
 }
 
 # ############################################################################
+# PS-2015 pt-config-diff doesn't diff ordered flags
+# ############################################################################
+$c1 = new MySQLConfig(
+   result_set => [['log_slow_verbosity', 'innodb,microtime']],
+   format     => 'show_variables',
+);
+$c2 = new MySQLConfig(
+   result_set => [['log_slow_verbosity', 'microtime,innodb']],
+   format     => 'show_variables',
+);
+
+{
+   $diff = $cc->diff(
+      configs => [$c1, $c2],
+   );
+
+   is_deeply(
+      $diff,
+      undef,
+      "Values are same regardless of order"
+   ) or diag(Dumper($diff));
+}
+
+# ############################################################################
 # https://bugs.launchpad.net/percona-toolkit/+bug/889739
 # pt-config-diff doesn't diff quoted strings properly
 # ############################################################################


### PR DESCRIPTION
Previously, flags would be compared in the exact order they are output by MySQL, which can result in false negatives if the input ordering does not match.

Example from the ticket:

```
[root@avvr-dbm51 ~]# pt-config-diff /etc/my.cnf h=localhost,P=3047
1 config difference
Variable                  /etc/my.cnf  avvr-dbm51
========================= ============ ============
myisam_recover_options    FORCE,BACKUP BACKUP,FORCE
```

This commit fixes the issue by sorting the flags before comparison to ensure that any ordering differences will not report a diff.

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] util/update-modules has been ran
- [ ] Documentation updated
- [x] Test suite update
