### PR TITLE
PT-1151 - LP #1225577: pt-online-schema-change can silently drop rows

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -11211,7 +11211,7 @@ sub get_unique_index_fields {
    $clean .= $suffix;
 
    my $fields = [];
-   my $fields_re = qr/\s(?:PRIMARY|UNIQUE)\s+(?:INDEX|KEY|)\s*(?:.*?)\s*\((.*?)\)/i;
+   my $fields_re = qr/\s(?:(?:(?:PRIMARY|UNIQUE)\s+(?:INDEX|KEY|))|UNIQUE)\s*(?:.*?)\s*\((.*?)\)/i;
 
    while($clean =~ /$fields_re/g) {
       push @$fields, [ split /\s*,\s*/, $1 ];

--- a/t/pt-online-schema-change/pt-153.t
+++ b/t/pt-online-schema-change/pt-153.t
@@ -19,7 +19,7 @@ use Sandbox;
 use SqlModes;
 use File::Temp qw/ tempdir /;
 
-plan tests => 6;
+plan tests => 10;
 
 require "$trunk/bin/pt-online-schema-change";
 
@@ -44,7 +44,7 @@ $sb->load_file('source', "$sample/pt-153.sql");
 
 ($output, $exit_status) = full_output(
    sub { pt_online_schema_change::main(@args, "$source_dsn,D=test,t=t1",
-         '--execute', 
+         '--execute',
          '--alter', "ADD UNIQUE INDEX c1 (f2, f3)",
          ),
       },
@@ -64,7 +64,7 @@ like(
 
 ($output, $exit_status) = full_output(
    sub { pt_online_schema_change::main(@args, "$source_dsn,D=test,t=t1",
-         '--execute', 
+         '--execute',
          '--alter', "ADD UNIQUE INDEX c1 (f2, f3), PRIMARY KEY (f3), UNIQUE KEY k2 (f3)",
          ),
       },
@@ -86,6 +86,47 @@ like(
       $output,
       qr/SELECT IF\(COUNT\(DISTINCT f2, f3\).*?SELECT IF\(COUNT\(DISTINCT f3\)/s,
       "PT-153 Adding multiple unique indexes -> multime example queries.",
+);
+
+# UNIQUE is possible without INDEX or KEY, we need to check this as well.
+($output, $exit_status) = full_output(
+   sub { pt_online_schema_change::main(@args, "$source_dsn,D=test,t=t1",
+         '--execute',
+         '--alter', "ADD UNIQUE c1 (f2, f3)",
+         ),
+      },
+);
+
+isnt(
+      $exit_status,
+      0,
+      "PT-153 Adding unique index without index/key keyword exit status != 0.",
+);
+
+like(
+      $output,
+      qr/You are trying to add an unique key. This can result in data loss if the data is not unique/s,
+      "PT-153 Adding unique index without index/key keyword warning message.",
+);
+
+($output, $exit_status) = full_output(
+   sub { pt_online_schema_change::main(@args, "$source_dsn,D=test,t=t1",
+         '--execute',
+         '--alter', "ADD UNIQUE(f2, f3)",
+         ),
+      },
+);
+
+isnt(
+      $exit_status,
+      0,
+      "PT-153 Adding unique index without index/key keyword and index name exit status != 0.",
+);
+
+like(
+      $output,
+      qr/You are trying to add an unique key. This can result in data loss if the data is not unique/s,
+      "PT-153 Adding unique index without index/key keyword and index name warning message.",
 );
 
 $source_dbh->do("DROP DATABASE IF EXISTS test");


### PR DESCRIPTION
- Found case when --check-unique-index-change does not catch error: UNIQUE without KEY or INDEX keyword and fixed regular expression

- [ ] The contributed code is licensed under GPL v2.0
- [ ] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documentation updated
- [ ] Test suite update
