### PR TITLE
Fix replica tracking and undefined DSN value warnings in pt-online-schema-change

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -4377,10 +4377,10 @@ sub recurse_to_replicas {
 
    DBH: {
       if ( !defined $dbh ) {
-         foreach my $known_slave ( @{$args->{slaves}} ) {
-            if (($known_slave->{dsn}->{h} // '') eq ($slave_dsn->{h} // '') and
-                ($known_slave->{dsn}->{P} // '') eq ($slave_dsn->{P} // '')) {
-               $dbh = $known_slave->{dbh};
+         foreach my $known_replica ( @{$args->{replicas}} ) {
+            if (($known_replica->{dsn}->{h} // '') eq ($replica_dsn->{h} // '') and
+                ($known_replica->{dsn}->{P} // '') eq ($replica_dsn->{P} // '')) {
+               $dbh = $known_replica->{dbh};
                last DBH;
             }
         }

--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -4377,13 +4377,13 @@ sub recurse_to_replicas {
 
    DBH: {
       if ( !defined $dbh ) {
-         foreach my $known_replica ( @{$args->{replicas}} ) {
-            if ($known_replica->{dsn}->{h} eq $replica_dsn->{h} and
-                $known_replica->{dsn}->{P} eq $replica_dsn->{P} ) {
-               $dbh = $known_replica->{dbh};
+         foreach my $known_slave ( @{$args->{slaves}} ) {
+            if (($known_slave->{dsn}->{h} // '') eq ($slave_dsn->{h} // '') and
+                ($known_slave->{dsn}->{P} // '') eq ($slave_dsn->{P} // '')) {
+               $dbh = $known_slave->{dbh};
                last DBH;
             }
-         }
+        }
          $get_dbh->();
       }
    }


### PR DESCRIPTION
…-schema-change

Avoids "Use of uninitialized value in string eq" warnings in ReplicaLagWaiter by safely handling undefined DSN host/port values. This change uses the defined-or operator (// '') to ensure comparisons work even when DSN fields are not initialized, preventing unnecessary reconnections to replicas.

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documentation updated
- [ ] Test suite update
