### PR TITLE
Replace validation logic for data-dir in pt-osc to use innodb_directories.

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -9838,6 +9838,7 @@ sub main {
             Quoter           => $q,
             OptionParser     => $o,
             TableParser      => $tp,
+            server_version   => $server_version,
          );
       };
       if ( $EVAL_ERROR ) {
@@ -11372,6 +11373,7 @@ sub create_new_table {
    }
    my ($new_table_name, $orig_tbl, $cxn, $q, $o, $tp) = @args{@required_args};
    my $new_table_prefix = $args{new_table_prefix};
+   my $server_version = $args{server_version};
 
    # Get the original table struct.
    my $ddl = $tp->get_create_table(
@@ -11438,21 +11440,36 @@ sub create_new_table {
          $sql =~ s/\s+ENGINE=\S+//;
       }
       if ( $o->get('data-dir') && !$o->got('remove-data-dir') ) {
-         # The directory must be in innodb_directories
+         # Starting from 8.0, the directory must be known to InnoDB.
+
+         my $innodb_dirs = '';
+
+         my (undef, $innodb_data_home_dir) = $cxn->dbh->selectrow_array("SHOW VARIABLES LIKE 'innodb_data_home_dir'");
+         if ( $innodb_data_home_dir ) {
+            _d("InnoDB data home dir: $innodb_data_home_dir");
+            $innodb_dirs .= $innodb_data_home_dir;
+         }
+
          my (undef, $innodb_directories) = $cxn->dbh->selectrow_array("SHOW VARIABLES LIKE 'innodb_directories'");
          if ( $innodb_directories ) {
-            my @dirs = split(/\s*;\s*/, $innodb_directories);
-            my %dirs_lookup = map { $_ => 1 } @dirs;
-            if ($dirs_lookup{$o->get('data-dir')}) {
-               $sql = insert_data_directory($sql, $o->get('data-dir'));
-               PTDEBUG && _d("adding data dir ".$o->get('data-dir'));
-               PTDEBUG && _d("New query\n$sql\n");
-            } else {
-               die "Data directory " . $o->get('data-dir') . " is not in innodb_directories variable: " . $innodb_directories;
-            }
+            _d("InnoDB directories: $innodb_directories");
+            $innodb_dirs .= ';' . $innodb_directories;
+         }
+
+         my @dirs = map {
+            my $dir = $_;
+            $dir =~ s{(?<!^)/\z}{};
+            $dir;
+         } split(/\s*;\s*/, $innodb_dirs);
+         my %dirs_lookup = map { $_ => 1 } @dirs;
+         my $data_dir = $o->get('data-dir');
+         $data_dir =~ s{(?<!^)/\z}{};
+         if ($dirs_lookup{$data_dir} || $server_version < '8.0') {
+            $sql = insert_data_directory($sql, $data_dir);
+            PTDEBUG && _d("adding data dir " . $data_dir);
+            PTDEBUG && _d("New query\n$sql\n");
          } else {
-            # There is no innodb_directories variable or it is empty
-            die "Could not get innodb_directories variable from server or it is empty.";
+            die "Data directory " . $data_dir . " is not known to InnoDB.\nDirectories known to InnoDB are: " . $innodb_dirs . "\n";
          }
       }
       if ( $o->got('remove-data-dir') ) {

--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -11438,13 +11438,22 @@ sub create_new_table {
          $sql =~ s/\s+ENGINE=\S+//;
       }
       if ( $o->get('data-dir') && !$o->got('remove-data-dir') ) {
-          if ( (-d $o->get('data-dir')) && (-w $o->get('data-dir')) ){
-             $sql = insert_data_directory($sql, $o->get('data-dir'));
-             PTDEBUG && _d("adding data dir ".$o->get('data-dir'));
-             PTDEBUG && _d("New query\n$sql\n");
-          } else {
-              die $o->get('data-dir') . " is not a directory or it is not writable";
-          }
+         # The directory must be in innodb_directories
+         my (undef, $innodb_directories) = $cxn->dbh->selectrow_array("SHOW VARIABLES LIKE 'innodb_directories'");
+         if ( $innodb_directories ) {
+            my @dirs = split(/\s*;\s*/, $innodb_directories);
+            my %dirs_lookup = map { $_ => 1 } @dirs;
+            if ($dirs_lookup{$o->get('data-dir')}) {
+               $sql = insert_data_directory($sql, $o->get('data-dir'));
+               PTDEBUG && _d("adding data dir ".$o->get('data-dir'));
+               PTDEBUG && _d("New query\n$sql\n");
+            } else {
+               die "Data directory " . $o->get('data-dir') . " is not in innodb_directories variable: " . $innodb_directories;
+            }
+         } else {
+            # There is no innodb_directories variable or it is empty
+            die "Could not get innodb_directories variable from server or it is empty.";
+         }
       }
       if ( $o->got('remove-data-dir') ) {
          $sql =~ s/DATA DIRECTORY\s*=\s*'.*?'//;

--- a/t/pt-online-schema-change/data-dir.t
+++ b/t/pt-online-schema-change/data-dir.t
@@ -1,0 +1,224 @@
+#!/usr/bin/env perl
+
+BEGIN {
+   die "The PERCONA_TOOLKIT_BRANCH environment variable is not set.\n"
+   unless $ENV{PERCONA_TOOLKIT_BRANCH} && -d $ENV{PERCONA_TOOLKIT_BRANCH};
+   unshift @INC, "$ENV{PERCONA_TOOLKIT_BRANCH}/lib";
+};
+
+use strict;
+use warnings FATAL => 'all';
+use threads;
+use threads::shared;
+use Thread::Semaphore;
+
+use English qw(-no_match_vars);
+use Test::More;
+
+use Data::Dumper;
+use PerconaTest;
+use Sandbox;
+use SqlModes;
+use File::Path qw(make_path remove_tree);
+
+if ($sandbox_version lt '8.0') {
+   plan skip_all => 'This test needs MySQL 8.0+';
+}
+
+require "$trunk/bin/pt-online-schema-change";
+
+my $dp = new DSNParser(opts=>$dsn_opts);
+my $sb = new Sandbox(basedir => '/tmp', DSNParser => $dp);
+
+my $source3_port   = 2900;
+my $source_basedir = "/tmp/$source3_port";
+my $source3_cnf    = "$source_basedir/my.sandbox.cnf";
+
+my $new_dir_a      = '/tmp/pt-osc-data-dir-a';
+my $new_dir_b      = '/tmp/pt-osc-data-dir-b';
+my $unknown_dir    = '/tmp/pt-osc-data-dir-unknown';
+my $home_test_dir  = '/tmp/pt-osc-innodb-home-test';
+
+my $extra_defaults_file = '/tmp/pt-data-dir-my.sandbox.cnf';
+
+my $dbh3;
+my $dsn3;
+
+sub _reload_source3 {
+   $dbh3 = $sb->get_dbh_for('source3');
+   $dsn3 = $sb->dsn_for('source3');
+}
+
+sub _rewrite_source3_config {
+   my (%opts) = @_;
+
+   open my $in, '<', $source3_cnf or die "Cannot read $source3_cnf: $OS_ERROR";
+   my @lines = <$in>;
+   close $in;
+
+   @lines = grep { $_ !~ /^\s*(?:innodb_directories)\s*=/ } @lines;
+
+   if ( defined $opts{innodb_directories} ) {
+      push @lines, "innodb_directories='" . $opts{innodb_directories} . "'\n";
+   }
+
+   open my $out, '>', $source3_cnf or die "Cannot write $source3_cnf: $OS_ERROR";
+   print {$out} @lines;
+   close $out;
+}
+
+sub _restart_source3 {
+   diag(`$source_basedir/stop >/dev/null`);
+   diag(`$source_basedir/start >/dev/null`);
+   #diag(`cat /tmp/$source3_port/data/mysqld.log`);
+   _reload_source3();
+}
+
+sub _run_pt_osc_with_data_dir {
+   my ($dir) = @_;
+
+   my @args = (qw(--set-vars innodb_lock_wait_timeout=3));
+   my ($output, $exit_status) = full_output(
+      sub {
+         pt_online_schema_change::main(
+            @args,
+            "$dsn3,D=test,t=t3",
+            '--execute',
+            '--alter', 'engine=innodb',
+            '--data-dir', $dir,
+         );
+      },
+      stderr => 1,
+   );
+
+   return ($output, $exit_status);
+}
+
+sub _reload_test_table {
+   $sb->load_file('source3', 't/pt-online-schema-change/samples/pt-244.sql');
+   $dbh3->do('FLUSH TABLES');
+}
+
+remove_tree($new_dir_a, $new_dir_b, $unknown_dir, $home_test_dir);
+make_path($new_dir_a, $new_dir_b, $unknown_dir, $home_test_dir);
+
+diag(`echo "[mysqld]\ninnodb_data_home_dir=$home_test_dir/" > /tmp/pt-data-dir-my.sandbox.cnf`);
+
+local $ENV{EXTRA_DEFAULTS_FILE} = $extra_defaults_file;
+diag(`$trunk/sandbox/stop-sandbox $source3_port >/dev/null`);
+diag(`$trunk/sandbox/start-sandbox source $source3_port >/dev/null`);
+
+_reload_source3();
+
+if ( !$dbh3 ) {
+   plan skip_all => 'Cannot connect to sandbox source'  ;
+}
+
+my ($datadir, $innodb_data_home_dir) =
+   $dbh3->selectrow_array('SELECT @@datadir, @@innodb_data_home_dir');
+
+# Case 1: allowed directory from multi-value innodb_directories.
+
+_rewrite_source3_config(
+   innodb_directories => "$new_dir_a;$new_dir_b",
+);
+
+_restart_source3();
+_reload_test_table();
+
+my ($output, $exit_status) = _run_pt_osc_with_data_dir($new_dir_b);
+
+is(
+   $exit_status,
+   0,
+   'data-dir works when directory is in multi-value innodb_directories'
+) or diag($output);
+
+like(
+   $output,
+   qr/Successfully altered/s,
+   'Got success message for allowed directory',
+) or diag($output);
+
+# Case 2: not allowed directory should fail.
+
+_reload_test_table();
+($output, $exit_status) = _run_pt_osc_with_data_dir($unknown_dir);
+
+isnt(
+   $exit_status,
+   0,
+   'data-dir fails when directory is unknown to InnoDB',
+) or diag($output);
+
+like(
+   $output,
+   qr/Data directory \Q$unknown_dir\E is not known to InnoDB/s,
+   'Got expected error for unknown directory',
+) or diag($output);
+
+# Case 3: no innodb_directories, data-dir in @@innodb_data_home_dir (if set).
+
+_reload_test_table();
+($output, $exit_status) = _run_pt_osc_with_data_dir($innodb_data_home_dir);
+is(
+    $exit_status,
+    0,
+    'data-dir works when using @@innodb_data_home_dir',
+) or diag($output);
+
+like(
+    $output,
+    qr/Successfully altered/s,
+    'Got success message for @@innodb_data_home_dir',
+) or diag($output);
+
+# Case 4: innodb_data_home_dir-only setup and known/unknown checks.
+# We set innodb_data_home_dir without setting innodb_directories, then
+# validate one known and one unknown directory.
+
+_rewrite_source3_config();
+_restart_source3();
+
+_reload_test_table();
+($output, $exit_status) = _run_pt_osc_with_data_dir($home_test_dir);
+
+is(
+   $exit_status,
+   0,
+   'data-dir works when directory is known via innodb_data_home_dir and innodb_directories is unset',
+) or diag($output);
+
+like(
+   $output,
+   qr/Successfully altered/s,
+   'Got success message for innodb_data_home_dir-only setup',
+) or diag($output);
+
+_reload_test_table();
+my $home_unknown_dir = '/tmp/pt-osc-innodb-home-unknown';
+make_path($home_unknown_dir);
+($output, $exit_status) = _run_pt_osc_with_data_dir($home_unknown_dir);
+
+isnt(
+   $exit_status,
+   0,
+   'data-dir fails when directory is unknown in innodb_data_home_dir-only setup',
+) or diag($output);
+
+like(
+   $output,
+   qr/Data directory \Q$home_unknown_dir\E is not known to InnoDB/s,
+   'Got expected unknown-directory error in innodb_data_home_dir-only setup',
+) or diag($output);
+
+$dbh3->do('DROP DATABASE IF EXISTS test');
+
+# #############################################################################
+# Done.
+# #############################################################################
+$sb->wipe_clean($dbh3);
+diag(`$trunk/sandbox/stop-sandbox $source3_port >/dev/null`);
+diag(`rm -rf $new_dir_a $new_dir_b $unknown_dir $home_test_dir $extra_defaults_file`);
+ok($sb->ok(), "Sandbox servers") or BAIL_OUT(__FILE__ . " broke the sandbox");
+done_testing;

--- a/t/pt-online-schema-change/pt-244.t
+++ b/t/pt-online-schema-change/pt-244.t
@@ -62,7 +62,6 @@ my @args = (qw(--set-vars innodb_lock_wait_timeout=3));
 my $output;
 my $exit_status;
 
-diag("1");
 $sb->load_file('source3', "t/pt-online-schema-change/samples/pt-244.sql");
 
 my $num_rows = 1000;
@@ -72,7 +71,6 @@ diag("$num_rows rows loaded. Starting tests.");
 
 $dbh3->do("FLUSH TABLES");
 
-diag("2");
 ($output, $exit_status) = full_output(
     sub { pt_online_schema_change::main(@args, "$dsn3,D=test,t=t3",
             '--execute', 
@@ -82,7 +80,6 @@ diag("2");
     },
     stderr => 1,
 );
-diag("3");
 
 is(
     $exit_status,


### PR DESCRIPTION
- [X] The contributed code is licensed under GPL v2.0
- [X] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documentation updated
- [ ] Test suite update

Current validation checks that the directory exists and is writable by the user running pt-osc. This does not make sense because the tool can be executed remotely, and even locally, access is not required for the user running the tool. What is required is that the directory exists in `innodb_directories`.

This change removes the old validation and checks if the directory passed in data-dir exists.