### PR TITLE
PT-2498 - pt-sift does not work starting from version 3.7.0

### DIFF
--- a/bin/pt-sift
+++ b/bin/pt-sift
@@ -94,6 +94,53 @@ rm_tmpdir() {
 # ###########################################################################
 
 # ###########################################################################
+# alt_cmds package
+# This package is a copy without comments from the original.  The original
+# with comments and its test file can be found in the GitHub repository at,
+#   lib/bash/alt_cmds.sh
+#   t/lib/bash/alt_cmds.sh
+# See https://github.com/percona/percona-toolkit for more information.
+# ###########################################################################
+
+
+set -u
+
+_seq() {
+   local i="$1"
+   awk "BEGIN { for(i=1; i<=$i; i++) print i; }"
+}
+
+_pidof() {
+   local cmd="$1"
+   if ! pidof "$cmd" 2>/dev/null; then
+      ps -eo pid,ucomm | awk -v comm="$cmd" '$2 == comm { print $1 }'
+   fi
+}
+
+_lsof() {
+   local pid="$1"
+   if ! lsof -p $pid 2>/dev/null; then
+      /bin/ls -l /proc/$pid/fd 2>/dev/null
+   fi
+}
+
+
+
+_which() {
+   if [ -x /usr/bin/which ]; then
+      /usr/bin/which "$1" 2>/dev/null | awk '{print $1}'
+   elif which which 1>/dev/null 2>&1; then
+      which "$1" 2>/dev/null | awk '{print $1}'
+   else
+      echo "$1"
+   fi
+}
+
+# ###########################################################################
+# End alt_cmds package
+# ###########################################################################
+
+# ###########################################################################
 # parse_options package
 # This package is a copy without comments from the original.  The original
 # with comments and its test file can be found in the GitHub repository at,

--- a/t/pt-sift/pt-sift.t
+++ b/t/pt-sift/pt-sift.t
@@ -9,11 +9,29 @@ BEGIN {
 use strict;
 use warnings FATAL => 'all';
 use English qw(-no_match_vars);
-use Test::More tests => 1;
+use Test::More tests => 2;
 
 use PerconaTest;
 
-pass();
+my ($tool) = $PROGRAM_NAME =~ m/([\w-]+)\.t$/;
+
+my $output = `$trunk/bin/$tool $trunk/bin 2>&1`;
+
+# https://perconadev.atlassian.net/browse/PT-2498
+# We do not test interactive tool here
+# But we at least ensure it works and prints
+# proper error message if called without correct path
+isnt(
+   $?,
+   0,
+   "Error for the directory that does not contain pt-stalk files"
+) or diag($output);
+
+like(
+   $output,
+   qr/Error: There are no pt-stalk files in $trunk\/bin/,
+   "Correct error message"
+) or diag($output);
 
 # #############################################################################
 # Done.


### PR DESCRIPTION
- Added missed module into the tool
- Modified test case, so it tests if this interactive tool works, so we do not miss cases like this in the future

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] util/update-modules has been ran
- [ ] Documentation updated
- [x] Test suite update
