### PR TITLE
Add --force-drop-swap flag to require explicit acknowledgment

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -10655,6 +10655,16 @@ sub main {
       );
 
       if ( $alter_fk_method eq 'drop_swap' ) {
+         if ( !$o->get('force-drop-swap') ) {
+            my $msg = "Cannot use rebuild_constraints method because child tables are too large.\n"
+                    . "The tool would need to use the drop_swap method, but this requires\n"
+                    . "--force-drop-swap to acknowledge the risks.\n\n"
+                    . "The drop_swap method is risky: it disables foreign key checks and drops\n"
+                    . "the original table before renaming the new table into place. During this\n"
+                    . "brief window, the table does not exist and queries will fail.\n"
+                    . "If the rename fails, data loss may occur.";
+            _die($msg, INVALID_PARAMETERS);
+         }
          $o->set('swap-tables',    0);
          $o->set('drop-old-table', 0);
       }
@@ -13347,6 +13357,21 @@ This option bypasses confirmation in case of using alter-foreign-keys-method = n
 This option also allows to use option --where without options --no-drop-new-table and --no-swap-tables.
 
 This option also allows to bypass the safety check that prevents the tool from running on replica that is replicating from a source with binary log format ROW or MIXED.
+
+=item --force-drop-swap
+
+This option is required when C<--alter-foreign-keys-method=auto> determines
+that the C<drop_swap> method is necessary (because child tables are too large
+for C<rebuild_constraints>).
+
+The C<drop_swap> method is risky: it disables foreign key checks and drops the
+original table before renaming the new table into place. During this brief
+window, the table does not exist and queries will fail. If the rename fails,
+data loss may occur.
+
+If this flag is not specified and auto mode would choose C<drop_swap>,
+the tool will exit with an error instead of proceeding. This flag is not
+required when explicitly using C<--alter-foreign-keys-method=drop_swap>.
 
 =item --help
 


### PR DESCRIPTION
## Add `--force-drop-swap` flag to require explicit acknowledgment for risky FK method

### Summary

This PR introduces a new safety check for `pt-online-schema-change` when the `drop_swap` foreign key method is automatically selected.

### Problem

When using `--alter-foreign-keys-method=auto`, the tool automatically chooses between `rebuild_constraints` and `drop_swap` based on child table sizes. If child tables are too large for `rebuild_constraints`, it silently falls back to `drop_swap`.

The `drop_swap` method is inherently risky:
- Disables foreign key checks (`FOREIGN_KEY_CHECKS=0`)
- **Drops the original table before renaming the new table**
- Creates a brief window where the table doesn't exist (queries will fail)
- If the rename fails after the drop, **data loss may occur**

Users may not realize they're running this risky operation when they specify `auto`.

### Solution

Introduce `--force-drop-swap` flag that must be explicitly specified when `auto` mode determines `drop_swap` is necessary. This ensures users are aware of and accept the risks before proceeding.

**Behavior:**

| Scenario | Without `--force-drop-swap` | With `--force-drop-swap` |
|----------|----------------------------|--------------------------|
| Explicit `--alter-foreign-keys-method=drop_swap` | ✅ Proceeds (user already knows) | ✅ Proceeds |
| `--alter-foreign-keys-method=auto` → chooses `rebuild_constraints` | ✅ Proceeds | ✅ Proceeds |
| `--alter-foreign-keys-method=auto` → chooses `drop_swap` | ❌ **Errors with explanation** | ✅ Proceeds |

### Changes

- Added `--force-drop-swap` option documentation
- Added validation that errors out when `auto` mode would choose `drop_swap` without explicit acknowledgment
- Clear error message explaining the risks and required flag

### Testing

Existing tests should pass as they use small datasets where `rebuild_constraints` is always chosen. The new check only triggers when child tables exceed the threshold for `rebuild_constraints`.

### Licensing

The submitted code is my own creation and can be distributed under the GPL v2.0 license.