### PR TITLE
PT-2508 - fix SIGSEGV error

### DIFF
--- a/src/go/pt-mongodb-index-check/main.go
+++ b/src/go/pt-mongodb-index-check/main.go
@@ -92,7 +92,8 @@ func main() {
 		resp.Unused = findUnused(ctx, client, args.Databases, args.Collections)
 		resp.Duplicated = findDuplicated(ctx, client, args.Databases, args.Collections)
 	default:
-		kong.DefaultHelpPrinter(kong.HelpOptions{}, kongctx)
+		kongctx.PrintUsage(false)
+		return
 	}
 
 	fmt.Println(output(resp, args.JSON))

--- a/src/go/pt-mongodb-index-check/main_test.go
+++ b/src/go/pt-mongodb-index-check/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os/exec"
 	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -18,5 +19,18 @@ func TestVersionOption(t *testing.T) {
 	re := regexp.MustCompile(toolname + `\n.*Version v?\d+\.\d+\.\d+\n`)
 	if !re.Match(out) {
 		t.Errorf("%s --version returns wrong result:\n%s", toolname, out)
+	}
+}
+
+func TestNoCommand(t *testing.T) {
+	mockMongo := "mongodb://127.0.0.1:27017"
+	out, err := exec.Command("../../../bin/"+toolname, "--mongodb.uri", mockMongo).Output()
+	if err != nil {
+		t.Errorf("error executing %s with no command: %s", toolname, err.Error())
+	}
+
+	want := "Usage: pt-mongodb-index-check show-help"
+	if !strings.Contains(string(out), want) {
+		t.Errorf("Output missmatch. Output %q should contain %q", string(out), want)
 	}
 }


### PR DESCRIPTION
When running pt-mongodb-index-check with missing arguments SIGSEGV error occurs. This error is fixed by removing DefaultHelpPrinter

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] util/update-modules has been ran
- [x] Documentation updated
- [] Test suite update
