### PR TITLE
Added users data to history table

### DIFF
--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -9464,16 +9464,16 @@ sub set_history_options {
 }
 
 sub set_review_history {
-   my ( $self, $id, $sample, %data ) = @_;
+   my ( $self, $id, $sample, $data, $users) = @_;
    foreach my $thing ( qw(min max) ) {
-      next unless defined $data{ts} && defined $data{ts}->{$thing};
-      $data{ts}->{$thing} = parse_timestamp($data{ts}->{$thing});
+      next unless defined $data->{ts} && defined $data->{ts}->{$thing};
+      $data->{ts}->{$thing} = parse_timestamp($data->{ts}->{$thing});
    }
    $self->history_sth->execute(
       make_checksum($id),
-      $data{'user'}{'min'},
+      join(" ", sort keys %{$users}),
       $sample,
-      map { $data{$_->[0]}->{$_->[1]} } @{$self->history_metrics});
+      map { $data->{$_->[0]}->{$_->[1]} } @{$self->history_metrics});
 }
 
 sub _d {
@@ -15083,6 +15083,10 @@ sub update_query_history_table {
 
    foreach my $worst_info ( @$worst ) {
       my $item        = $worst_info->[0];
+      my %users       = ();
+      if (defined $ea->results->{'classes'}{$item}{'user'}{'unq'}) {
+         %users       = %{$ea->results->{'classes'}{$item}{'user'}{'unq'}};
+      }
       my $sample      = $ea->results->{samples}->{$item};
 
       my %history;
@@ -15093,7 +15097,7 @@ sub update_query_history_table {
          );
       }
       $qh->set_review_history(
-         $item, $sample->{arg} || '', %history);
+         $item, $sample->{arg} || '', \%history, \%users);
    }
 
    return;
@@ -15213,6 +15217,10 @@ sub sanitize_event {
    if ( $event->{Schema} ) {
       $event->{Schema} =~ s/^`//;
       $event->{Schema} =~ s/`$//;
+   }
+
+   if ( $event->{arg} ) {
+      $event->{arg} =~ s/ -- user_id: \d+//;
    }
 
    return;
@@ -16024,8 +16032,8 @@ MAGIC_create_history_table
 
  CREATE TABLE IF NOT EXISTS query_history (
    checksum             CHAR(32) NOT NULL,
-   username             VARCHAR(64),
-   sample               TEXT NOT NULL,
+   username             TEXT,
+   sample               MEDIUMTEXT NOT NULL,
    ts_min               DATETIME,
    ts_max               DATETIME,
    ts_cnt               FLOAT,

--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -15231,10 +15231,6 @@ sub sanitize_event {
       $event->{Schema} =~ s/`$//;
    }
 
-   if ( $event->{arg} ) {
-      $event->{arg} =~ s/ -- user_id: \d+//;
-   }
-
    return;
 }
 
@@ -16044,7 +16040,7 @@ MAGIC_create_history_table
 
  CREATE TABLE IF NOT EXISTS query_history (
    checksum             CHAR(32) NOT NULL,
-   sample               MEDIUMTEXT NOT NULL,
+   sample               TEXT NOT NULL,
    usernames            JSON,
    ts_min               DATETIME,
    ts_max               DATETIME,

--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -9405,6 +9405,11 @@ has history_metrics => (
    isa => 'ArrayRef',
 );
 
+has main_columns => (
+   is => 'rw',
+   isa => 'ArrayRef',
+);
+
 has column_pattern => (
    is       => 'ro',
    isa      => 'Regexp',
@@ -9426,29 +9431,32 @@ sub set_history_options {
    my $col_pat = $self->column_pattern();
 
    my @cols;
+   my @main_cols;
    my @metrics;
    foreach my $col ( @{$args{tbl_struct}->{cols}} ) {
       my ( $attr, $metric ) = $col =~ m/$col_pat/;
-      next unless $attr && $metric;
+      if ( $attr && $metric ) {
+        $attr = ucfirst $attr if $attr =~ m/_/;
+        $attr = 'Filesort' if $attr eq 'filesort';
 
+        $attr =~ s/^Qc_hit/QC_Hit/;  # Qc_hit is really QC_Hit
+        $attr =~ s/^Innodb/InnoDB/g; # Innodb is really InnoDB
+        $attr =~ s/_io_/_IO_/g;      # io is really IO
 
-      $attr = ucfirst $attr if $attr =~ m/_/;
-      $attr = 'Filesort' if $attr eq 'filesort';
-
-      $attr =~ s/^Qc_hit/QC_Hit/;  # Qc_hit is really QC_Hit
-      $attr =~ s/^Innodb/InnoDB/g; # Innodb is really InnoDB
-      $attr =~ s/_io_/_IO_/g;      # io is really IO
-
-      push @cols, $col;
-      push @metrics, [$attr, $metric];
+        push @cols, $col;
+        push @metrics, [$attr, $metric];
+      } else {
+          push @main_cols, $col;
+      }
    }
 
    my $ts_default = $self->ts_default;
 
    my $sql = "REPLACE INTO $args{table}("
       . join(', ',
-         map { Quoter->quote($_) } ('checksum', 'sample', 'usernames', @cols))
-      . ') VALUES (?, ?, ?'
+         map { Quoter->quote($_) } (@main_cols, @cols))
+      . ') VALUES ('
+      . join(', ', map { '?' } @main_cols)
       . (@cols ? ', ' : '')  # issue 1265
       . join(', ', map {
          $_ eq 'ts_min' || $_ eq 'ts_max'
@@ -9459,6 +9467,7 @@ sub set_history_options {
 
    $self->history_sth($self->history_dbh->prepare($sql));
    $self->history_metrics(\@metrics);
+   $self->main_columns(\@main_cols);
 
    return;
 }
@@ -9469,11 +9478,14 @@ sub set_review_history {
       next unless defined $data->{ts} && defined $data->{ts}->{$thing};
       $data->{ts}->{$thing} = parse_timestamp($data->{ts}->{$thing});
    }
-   $self->history_sth->execute(
-      make_checksum($id),
-      $sample,
-      "[".join(",", map { "\"".$_."\""} sort keys %{$users})."]",
-      map { $data->{$_->[0]}->{$_->[1]} } @{$self->history_metrics});
+   my @execute_params;
+   for my $col (@{$self->main_columns}) {
+     push @execute_params, make_checksum($id) if $col eq 'checksum';
+     push @execute_params, $sample if $col eq 'sample';
+     push @execute_params, "[".join(",", map { "\"".$_."\""} sort keys %{$users})."]" if $col eq 'usernames';
+   }
+   push @execute_params, map { $data->{$_->[0]}->{$_->[1]} } @{$self->history_metrics};
+   $self->history_sth->execute(@execute_params);
 }
 
 sub _d {

--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -9447,7 +9447,7 @@ sub set_history_options {
 
    my $sql = "REPLACE INTO $args{table}("
       . join(', ',
-         map { Quoter->quote($_) } ('checksum', 'username', 'sample', @cols))
+         map { Quoter->quote($_) } ('checksum', 'usernames', 'sample', @cols))
       . ') VALUES (?, ?, ?'
       . (@cols ? ', ' : '')  # issue 1265
       . join(', ', map {
@@ -9471,7 +9471,7 @@ sub set_review_history {
    }
    $self->history_sth->execute(
       make_checksum($id),
-      join(" ", sort keys %{$users}),
+      "[".join(",", map { "\"".$_."\""} sort keys %{$users})."]",
       $sample,
       map { $data->{$_->[0]}->{$_->[1]} } @{$self->history_metrics});
 }
@@ -16032,7 +16032,7 @@ MAGIC_create_history_table
 
  CREATE TABLE IF NOT EXISTS query_history (
    checksum             CHAR(32) NOT NULL,
-   username             TEXT,
+   usernames            JSON,
    sample               MEDIUMTEXT NOT NULL,
    ts_min               DATETIME,
    ts_max               DATETIME,

--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -9447,7 +9447,7 @@ sub set_history_options {
 
    my $sql = "REPLACE INTO $args{table}("
       . join(', ',
-         map { Quoter->quote($_) } ('checksum', 'usernames', 'sample', @cols))
+         map { Quoter->quote($_) } ('checksum', 'sample', 'usernames', @cols))
       . ') VALUES (?, ?, ?'
       . (@cols ? ', ' : '')  # issue 1265
       . join(', ', map {
@@ -9471,8 +9471,8 @@ sub set_review_history {
    }
    $self->history_sth->execute(
       make_checksum($id),
-      "[".join(",", map { "\"".$_."\""} sort keys %{$users})."]",
       $sample,
+      "[".join(",", map { "\"".$_."\""} sort keys %{$users})."]",
       map { $data->{$_->[0]}->{$_->[1]} } @{$self->history_metrics});
 }
 
@@ -16032,8 +16032,8 @@ MAGIC_create_history_table
 
  CREATE TABLE IF NOT EXISTS query_history (
    checksum             CHAR(32) NOT NULL,
-   usernames            JSON,
    sample               MEDIUMTEXT NOT NULL,
+   usernames            JSON,
    ts_min               DATETIME,
    ts_max               DATETIME,
    ts_cnt               FLOAT,

--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -16013,6 +16013,8 @@ least the following columns:
     sample       TEXT NOT NULL
   );
 
+There could be also C<usernames JSON> column.
+
 Any columns not mentioned above are inspected to see if they follow a certain
 naming convention.  The column is special if the name ends with an underscore
 followed by any of these values:

--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -9447,8 +9447,8 @@ sub set_history_options {
 
    my $sql = "REPLACE INTO $args{table}("
       . join(', ',
-         map { Quoter->quote($_) } ('checksum', 'sample', @cols))
-      . ') VALUES (?, ?'
+         map { Quoter->quote($_) } ('checksum', 'username', 'sample', @cols))
+      . ') VALUES (?, ?, ?'
       . (@cols ? ', ' : '')  # issue 1265
       . join(', ', map {
          $_ eq 'ts_min' || $_ eq 'ts_max'
@@ -9471,6 +9471,7 @@ sub set_review_history {
    }
    $self->history_sth->execute(
       make_checksum($id),
+      $data{'user'}{'min'},
       $sample,
       map { $data{$_->[0]}->{$_->[1]} } @{$self->history_metrics});
 }
@@ -16023,6 +16024,7 @@ MAGIC_create_history_table
 
  CREATE TABLE IF NOT EXISTS query_history (
    checksum             CHAR(32) NOT NULL,
+   username             VARCHAR(64),
    sample               TEXT NOT NULL,
    ts_min               DATETIME,
    ts_max               DATETIME,

--- a/t/lib/samples/slowlogs/slow002.txt
+++ b/t/lib/samples/slowlogs/slow002.txt
@@ -49,7 +49,7 @@ WHERE  vab3concept1upload='6994465';
 SET insert_id=34484549,timestamp=1197996507;
 INSERT INTO db1.conch (word3, vid83)
 VALUES ('211', '18');
-# User@Host: [SQL_SLAVE] @  []
+# User@Host: [SQL_SLAVE1] @  []
 # Thread_id: 10
 # Query_time: 0.000530  Lock_time: 0.000027  Rows_sent: 0  Rows_examined: 0
 # QC_Hit: No  Full_scan: No  Full_join: No  Tmp_table: No  Tmp_table_on_disk: No

--- a/t/lib/samples/slowlogs/slow062.txt
+++ b/t/lib/samples/slowlogs/slow062.txt
@@ -49,7 +49,7 @@ WHERE  vab3concept1upload='6994465';
 SET insert_id=34484549,timestamp=1197996507;
 INSERT INTO db1.conch (word3, vid83)
 VALUES ('211', '18');
-# User@Host: [SQL_SLAVE] @  []
+# User@Host: [SQL_SLAVE1] @  []
 # Thread_id: 10
 # Query_time: 0.000530  Lock_time: 0.000027  Rows_sent: 0  Rows_examined: 0
 # QC_Hit: No  Full_scan: No  Full_join: No  Tmp_table: No  Tmp_table_on_disk: No

--- a/t/pt-query-digest/history.t
+++ b/t/pt-query-digest/history.t
@@ -306,6 +306,46 @@ unlike(
 );
 
 # #############################################################################
+# Issue 1265: mk-query-digest --review-history table with minimum 2 columns
+# #############################################################################
+$dbh->do('use test');
+$dbh->do('drop table test.query_review_history');
+
+# mqd says "The table must have at least the following columns:"
+my $usernames_tbl = "CREATE TABLE test.query_review_history (
+  checksum     CHAR(32) NOT NULL PRIMARY KEY,
+  sample       TEXT NOT NULL,
+  usernames    JSON
+)";
+$dbh->do($usernames_tbl);
+
+run_with("slow062.txt",
+         '--history', "$dsn,D=test,t=query_review_history",
+         '--no-report', '--filter', '$event->{arg} =~ m/foo\.bar/');
+
+$res = $dbh->selectall_arrayref( 'SELECT * FROM test.query_review_history',
+   { Slice => {} } );
+
+$expected = [
+  {
+    checksum => '32F63B9B2CE5A9B1B211BA2B8D6D065C',
+    usernames => '["[SQL_SLAVE1]", "[SQL_SLAVE]"]',
+    sample => 'UPDATE foo.bar
+SET    biz = \'91848182522\'',
+  }
+];
+
+normalize_numbers($res);
+normalize_numbers($expected);
+
+# 4
+is_deeply(
+   $res,
+   $expected,
+   "Review history with 3 main columns working",
+);
+
+# #############################################################################
 # Done.
 # #############################################################################
 $sb->wipe_clean($dbh);

--- a/t/pt-query-digest/history.t
+++ b/t/pt-query-digest/history.t
@@ -161,7 +161,7 @@ is($table, 'query_history', '--create-history-table creates both percona_schema 
 # #############################################################################
 $dbh->do('truncate table test.query_review_history');
 
-run_with("slow002.txt",
+run_with("slow062.txt",
          '--history', "$dsn,D=test,t=query_review_history",
          '--no-report', '--filter', '$event->{arg} =~ m/foo\.bar/');
 

--- a/t/pt-query-digest/history.t
+++ b/t/pt-query-digest/history.t
@@ -171,6 +171,7 @@ $res = $dbh->selectall_arrayref( 'SELECT * FROM test.query_review_history',
 $expected = [
   {
     checksum => '32F63B9B2CE5A9B1B211BA2B8D6D065C',
+    usernames => '["[SQL_SLAVE1]", "[SQL_SLAVE]"]',
     filesort_cnt => '2',
     filesort_on_disk_cnt => '2',
     filesort_on_disk_sum => '0',

--- a/t/pt-query-digest/history.t
+++ b/t/pt-query-digest/history.t
@@ -306,7 +306,7 @@ unlike(
 );
 
 # #############################################################################
-# Issue 1265: mk-query-digest --review-history table with minimum 2 columns
+# Review history with 3 main columns working 
 # #############################################################################
 $dbh->do('use test');
 $dbh->do('drop table test.query_review_history');


### PR DESCRIPTION
### Background
Idea behind this PR is to add information about DB users who executed a query to the **history** table. I've decided to add JSON column to store array of users for each query. There are probably more elegant solutions, but I wanted to keep **one table** concept.

### Summary of changes
- added optional **usernames** JSON type column with support for it in **history** table
- updated documentation
- updated existing and added new tests case