### PR TITLE
Swap to term.ReadPassword to remove outdated gopass dependency and stop using ssh/terminal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-version v1.8.0
-	github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef
 	github.com/lib/pq v1.12.0
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/montanaflynn/stats v0.8.2
@@ -29,6 +28,7 @@ require (
 	go.mongodb.org/mongo-driver v1.17.9
 	golang.org/x/crypto v0.49.0
 	golang.org/x/exp v0.0.0-20251125195548-87e1e737ad39
+	golang.org/x/term v0.41.0
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.35.3
@@ -62,7 +62,6 @@ require (
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/term v0.41.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,6 @@ github.com/hashicorp/go-version v1.8.0 h1:KAkNb1HAiZd1ukkxDFGmokVZe1Xy9HG6NUp+bP
 github.com/hashicorp/go-version v1.8.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
-github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef h1:A9HsByNhogrvm9cWb28sjiS3i7tcKCkflWFEkHfuAgM=
-github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=

--- a/src/go/pt-mongodb-query-digest/main.go
+++ b/src/go/pt-mongodb-query-digest/main.go
@@ -25,12 +25,12 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/howeyc/gopass"
 	"github.com/pborman/getopt"
 	log "github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"golang.org/x/term"
 
 	"github.com/percona/percona-toolkit/src/go/lib/config"
 	"github.com/percona/percona-toolkit/src/go/lib/versioncheck"
@@ -343,7 +343,7 @@ func getOptions() (*cliOptions, error) {
 
 	if gop.IsSet("password") && opts.Password == "" {
 		print("Password: ")
-		pass, err := gopass.GetPasswd()
+		pass, err := term.ReadPassword(0)
 		if err != nil {
 			return nil, err
 		}

--- a/src/go/pt-mongodb-summary/main.go
+++ b/src/go/pt-mongodb-summary/main.go
@@ -32,7 +32,6 @@ import (
 	"time"
 
 	version "github.com/hashicorp/go-version"
-	"github.com/howeyc/gopass"
 	"github.com/pborman/getopt"
 	"github.com/pkg/errors"
 	"github.com/shirou/gopsutil/process"
@@ -41,6 +40,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"golang.org/x/term"
 
 	"github.com/percona/percona-toolkit/src/go/lib/config"
 	"github.com/percona/percona-toolkit/src/go/lib/versioncheck"
@@ -1036,7 +1036,7 @@ func parseFlags() (*cliOptions, error) {
 	if gop.IsSet("password") && opts.Password == "" {
 		print("Password: ")
 
-		pass, err := gopass.GetPasswd()
+		pass, err := term.ReadPassword(0)
 		if err != nil {
 			return opts, err
 		}

--- a/src/go/pt-secure-collect/main.go
+++ b/src/go/pt-secure-collect/main.go
@@ -30,7 +30,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 type cliOptions struct {
@@ -333,7 +333,7 @@ func validateMySQLParams(opts *cliOptions, mycnf *myDefaults) error {
 func askMySQLPassword(opts *cliOptions) error {
 	if *opts.AskMySQLPass {
 		fmt.Printf("MySQL password for user %q:", *opts.MySQLUser)
-		passb, err := terminal.ReadPassword(0)
+		passb, err := term.ReadPassword(0)
 		if err != nil {
 			return errors.Wrap(err, "Cannot read MySQL password from the terminal")
 		}
@@ -345,14 +345,14 @@ func askMySQLPassword(opts *cliOptions) error {
 func askEncryptionPassword(opts *cliOptions, requireConfirmation bool) error {
 	if !*opts.NoEncrypt && *opts.EncryptPassword == "" {
 		fmt.Print("Encryption password: ")
-		passa, err := terminal.ReadPassword(0)
+		passa, err := term.ReadPassword(0)
 		if err != nil {
 			return errors.Wrap(err, "Cannot read encryption password from the terminal")
 		}
 		fmt.Println("")
 		if requireConfirmation {
 			fmt.Print("Re type password: ")
-			passb, err := terminal.ReadPassword(0)
+			passb, err := term.ReadPassword(0)
 			if err != nil {
 				return errors.Wrap(err, "Cannot read encryption password confirmation from the terminal")
 			}


### PR DESCRIPTION
The [howeyc/gopass](https://github.com/howeyc/gopass) dependency has been archived and unmaintained for around 5 years now, and recommends using `golang.org/x/crypto/ssh/terminal` as a replacement. This PR replaces `gopass.GetPasswd()` instances with `terminal.ReadPassword(0)` to allow the dependency to be removed. This is what is currently done in `pt-secure-collect`, making this a bit more consistent across tools too. 

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documentation updated
- [ ] Test suite update
