### PR TITLE
fix(ci): pin trivy-action to known-good SHA v0.35.0

### DIFF
--- a/.github/workflows/toolkit.yml
+++ b/.github/workflows/toolkit.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Build the Docker image
       run: echo "FROM oraclelinux:9-slim" > Dockerfile; echo "RUN microdnf -y update" >> Dockerfile; echo "COPY bin/* /usr/bin/" >> Dockerfile; docker build . --file Dockerfile --tag percona-toolkit:${{ github.sha }}
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
       with:
           image-ref: 'percona-toolkit:${{ github.sha }}'
           format: 'table'


### PR DESCRIPTION
## Summary
- Pin `aquasecurity/trivy-action` to known-good SHA `57a97c7e7821a5776cebc9bb87c984fa69cba8f1` (v0.35.0)
- Current reference uses mutable tag `@0.35.0` which is vulnerable to tag force-push attacks
- Mitigates the aquasecurity/trivy-action supply chain compromise (ref: internal security review)
- Affected workflow: `toolkit.yml`