### PR TITLE
PT-2218 - Add test to check per container logs for pxc

### DIFF
--- a/src/go/pt-k8s-debug-collector/main_test.go
+++ b/src/go/pt-k8s-debug-collector/main_test.go
@@ -328,6 +328,43 @@ func (s *CollectorSuite) TestIndividualFiles() {
 				return in[:nl]
 			},
 		},
+		{
+			namespace: "pxc",
+			// If pod logs are exported as one file per container
+			name: "pxc_container_logs_split_by_container",
+			// tar -tf cluster-dump.tar.gz --wildcards 'cluster-dump/pxc/*/*.log'
+			cmd:  []string{"tar", "-tf", "cluster-dump.tar.gz", "--wildcards", "cluster-dump/pxc/*/*.log"},
+			want: []string{"logrotate.log", "logs.log", "pxc-init.log", "pxc.log"},
+			preprocessor: func(in string) string {
+				required := map[string]bool{
+					"logrotate.log": true,
+					"logs.log":      true,
+					"pxc-init.log":  true,
+					"pxc.log":       true,
+				}
+
+				files := strings.Split(in, "\n")
+				var result []string
+				for _, f := range files {
+					rel := strings.TrimPrefix(f, "cluster-dump/pxc/")
+					parts := strings.Split(rel, "/")
+					if len(parts) != 2 {
+						continue
+					}
+
+					b := parts[1]
+					if !required[b] {
+						continue
+					}
+
+					if !slices.Contains(result, b) && b != "." && b != "" {
+						result = append(result, b)
+					}
+				}
+				slices.Sort(result)
+				return strings.Join(result, "\n")
+			},
+		},
 	}
 
 	if s.Namespace != "pxc" {

--- a/src/go/pt-k8s-debug-collector/main_test.go
+++ b/src/go/pt-k8s-debug-collector/main_test.go
@@ -305,7 +305,11 @@ func (s *CollectorSuite) TestIndividualFiles() {
 				var result []string
 				for _, f := range files {
 					b := path.Base(f)
-					if !slices.Contains(result, b) && b != "." && b != "" {
+					if b == "." || b == "" {
+						continue
+					}
+
+					if !slices.Contains(result, b) {
 						result = append(result, b)
 					}
 				}
@@ -336,11 +340,11 @@ func (s *CollectorSuite) TestIndividualFiles() {
 			cmd:  []string{"tar", "-tf", "cluster-dump.tar.gz", "--wildcards", "cluster-dump/pxc/*/*.log"},
 			want: []string{"logrotate.log", "logs.log", "pxc-init.log", "pxc.log"},
 			preprocessor: func(in string) string {
-				required := map[string]bool{
-					"logrotate.log": true,
-					"logs.log":      true,
-					"pxc-init.log":  true,
-					"pxc.log":       true,
+				required := map[string]struct{}{
+					"logrotate.log": {},
+					"logs.log":      {},
+					"pxc-init.log":  {},
+					"pxc.log":       {},
 				}
 
 				files := strings.Split(in, "\n")
@@ -353,11 +357,11 @@ func (s *CollectorSuite) TestIndividualFiles() {
 					}
 
 					b := parts[1]
-					if !required[b] {
+					if _, ok := required[b]; !ok {
 						continue
 					}
 
-					if !slices.Contains(result, b) && b != "." && b != "" {
+					if !slices.Contains(result, b) {
 						result = append(result, b)
 					}
 				}


### PR DESCRIPTION
This issue have been fixed since #1054 was merged. This PR introduces modification of already existing test, to check if logs are indeed separated by container for `pxc`.
- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [x] Documentation updated
- [x] Test suite update
