### PR TITLE
PT-2396 - Add check in tests for postgresclusters resource

### DIFF
--- a/src/go/pt-k8s-debug-collector/main_test.go
+++ b/src/go/pt-k8s-debug-collector/main_test.go
@@ -693,6 +693,7 @@ func (s *CollectorSuite) TestRequiredFilesExist() {
 			fmt.Sprintf("%s/perconapgbackups.yaml", s.Namespace),
 			fmt.Sprintf("%s/perconapgrestores.yaml", s.Namespace),
 			fmt.Sprintf("%s/perconapgclusters.yaml", s.Namespace),
+			fmt.Sprintf("%s/postgresclusters.yaml", s.Namespace), // PT-2396
 		}, requiredNewFiles...),
 	}
 


### PR DESCRIPTION
This issue have been fixed since #1054 was merged. This PR introduces modification of already existing test, to check if exported `postgresclusters` resource is exported.

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] util/update-modules has been ran
- [x] Documentation updated
- [x] Test suite update
