### PR TITLE
PT-2536 - Correct EMA calculation for WeightedAvgRate internal averages

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -5659,8 +5659,8 @@ sub update {
    PTDEBUG && _d('Source op time:', $n, 'n /', $t, 's');
 
    if ( $self->{avg_n} && $self->{avg_t} ) {
-      $self->{avg_n}    = ($self->{avg_n} * $self->{weight}) + $n;
-      $self->{avg_t}    = ($self->{avg_t} * $self->{weight}) + $t;
+      $self->{avg_n}    = ($self->{avg_n} * $self->{weight}) + ($n * (1 - $self->{weight}));
+      $self->{avg_t}    = ($self->{avg_t} * $self->{weight}) + ($t * (1 - $self->{weight}));
       $self->{avg_rate} = $self->{avg_n}  / $self->{avg_t};
       PTDEBUG && _d('Weighted avg rate:', $self->{avg_rate}, 'n/s');
    }

--- a/bin/pt-table-checksum
+++ b/bin/pt-table-checksum
@@ -9724,8 +9724,8 @@ sub update {
    PTDEBUG && _d('Source op time:', $n, 'n /', $t, 's');
 
    if ( $self->{avg_n} && $self->{avg_t} ) {
-      $self->{avg_n}    = ($self->{avg_n} * $self->{weight}) + $n;
-      $self->{avg_t}    = ($self->{avg_t} * $self->{weight}) + $t;
+      $self->{avg_n}    = ($self->{avg_n} * $self->{weight}) + ($n * (1 - $self->{weight}));
+      $self->{avg_t}    = ($self->{avg_t} * $self->{weight}) + ($t * (1 - $self->{weight}));
       $self->{avg_rate} = $self->{avg_n}  / $self->{avg_t};
       PTDEBUG && _d('Weighted avg rate:', $self->{avg_rate}, 'n/s');
    }

--- a/lib/WeightedAvgRate.pm
+++ b/lib/WeightedAvgRate.pm
@@ -69,8 +69,8 @@ sub update {
    PTDEBUG && _d('Source op time:', $n, 'n /', $t, 's');
 
    if ( $self->{avg_n} && $self->{avg_t} ) {
-      $self->{avg_n}    = ($self->{avg_n} * $self->{weight}) + $n;
-      $self->{avg_t}    = ($self->{avg_t} * $self->{weight}) + $t;
+      $self->{avg_n}    = ($self->{avg_n} * $self->{weight}) + ($n * (1 - $self->{weight}));
+      $self->{avg_t}    = ($self->{avg_t} * $self->{weight}) + ($t * (1 - $self->{weight}));
       $self->{avg_rate} = $self->{avg_n}  / $self->{avg_t};
       PTDEBUG && _d('Weighted avg rate:', $self->{avg_rate}, 'n/s');
    }

--- a/t/lib/WeightedAvgRate.t
+++ b/t/lib/WeightedAvgRate.t
@@ -36,7 +36,7 @@ for (1..5) {
 }
 is(
    $rll->update(1000, 2),
-   540,
+   548,
    "Decrease rate, decrease n"
 );
 


### PR DESCRIPTION
Average number of rows and average time taken to process rows are convergent to the average by adding the 1-weight to the calculation.

Previous calculation was divergent and a not correct implementation of ema (Exponential Moving Average);

The result of update() is not affected due to the proportional calculation of number-rows/time-taken

You can verify the behavior of current calculation with :

```perl

use WeightedAvgRate;

my $weight = 0.8;
my $w = WeightedAvgRate->new( target_t => 10, weight => $weight );
my @fake_n = ( 10, 5, 3, 1, 10, 3, 5, 10, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20 );

my ( $avg, $avg_ewma, $count, $sum ) = ( 0, 0, 0, 0 );
for my $n (@fake_n) {
    $sum   += $n;
    $count += 1;
    $avg = $sum / $count;
    $w->update( $n, 1 );
    $avg_ewma = $avg_ewma * $weight + $n * (1-$weight);
    printf( "%2.0f | %5.2f | %5.2f | %5.2f\n",
        $n, $avg, $w->{avg_n}, $avg, $avg_ewma );
}

1;
```

Root cause

The current calculation of average number of rows (avg_n) and average time (avg_t) seems to implement an smoothing algorithm to add some lag into the average convergence to protect estimation form sudden changes in a single datapoint, but also offer a faster convergence to that value on the long dataset (100+ data-points).

However, the current calculation is divergent serie because it does not apply a reduction factor to new data point every iteration.

As consequence, the avg_n and avg_t will increase forever and never converge to the "most common representative value";
Current formula is (avg * accumulative-factor) + new-value;
When it should be (avg * accumulative-factor) + (new-value * smooth-factor);


- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] util/update-modules has been ran
- [x] Documentation updated
- [x] Test suite update