### PR TITLE
PT-2538 - fix compatible issues with DBD::MariaDB

### DIFF
--- a/bin/pt-archiver
+++ b/bin/pt-archiver
@@ -2362,6 +2362,14 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
@@ -2369,7 +2377,12 @@ sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -2485,6 +2498,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -2517,15 +2538,30 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -2547,14 +2583,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -2566,7 +2608,7 @@ sub get_dbh {
       }
    }
 
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       my ($charset) = $cxn_string =~ m/charset=([\w]+)/;
@@ -2578,7 +2620,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -2637,24 +2679,51 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
 
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');

--- a/bin/pt-config-diff
+++ b/bin/pt-config-diff
@@ -1912,6 +1912,14 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
@@ -1919,7 +1927,12 @@ sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -2035,6 +2048,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -2067,15 +2088,30 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -2097,14 +2133,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -2116,7 +2158,7 @@ sub get_dbh {
       }
    }
 
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       my ($charset) = $cxn_string =~ m/charset=([\w]+)/;
@@ -2128,7 +2170,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -2187,24 +2229,51 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
 
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');

--- a/bin/pt-deadlock-logger
+++ b/bin/pt-deadlock-logger
@@ -2259,6 +2259,14 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
@@ -2266,7 +2274,12 @@ sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -2382,6 +2395,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -2414,15 +2435,30 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -2444,14 +2480,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -2463,7 +2505,7 @@ sub get_dbh {
       }
    }
 
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       my ($charset) = $cxn_string =~ m/charset=([\w]+)/;
@@ -2475,7 +2517,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -2534,24 +2576,51 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
 
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');

--- a/bin/pt-duplicate-key-checker
+++ b/bin/pt-duplicate-key-checker
@@ -746,6 +746,14 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
@@ -753,7 +761,12 @@ sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -869,6 +882,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -901,15 +922,30 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -931,14 +967,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -950,7 +992,7 @@ sub get_dbh {
       }
    }
 
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       my ($charset) = $cxn_string =~ m/charset=([\w]+)/;
@@ -962,7 +1004,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -1021,24 +1063,51 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
 
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');

--- a/bin/pt-find
+++ b/bin/pt-find
@@ -138,6 +138,14 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
@@ -145,7 +153,12 @@ sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -261,6 +274,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -293,15 +314,30 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -323,14 +359,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -342,7 +384,7 @@ sub get_dbh {
       }
    }
 
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       my ($charset) = $cxn_string =~ m/charset=([\w]+)/;
@@ -354,7 +396,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -413,24 +455,51 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
 
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');

--- a/bin/pt-fk-error-logger
+++ b/bin/pt-fk-error-logger
@@ -1413,6 +1413,14 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
@@ -1420,7 +1428,12 @@ sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -1536,6 +1549,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -1568,15 +1589,30 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -1598,14 +1634,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -1617,7 +1659,7 @@ sub get_dbh {
       }
    }
 
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       my ($charset) = $cxn_string =~ m/charset=([\w]+)/;
@@ -1629,7 +1671,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -1688,24 +1730,51 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
 
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');

--- a/bin/pt-heartbeat
+++ b/bin/pt-heartbeat
@@ -2854,6 +2854,14 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
@@ -2861,7 +2869,12 @@ sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -2977,6 +2990,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -3009,15 +3030,30 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -3039,14 +3075,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -3058,7 +3100,7 @@ sub get_dbh {
       }
    }
 
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       my ($charset) = $cxn_string =~ m/charset=([\w]+)/;
@@ -3070,7 +3112,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -3129,24 +3171,51 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
 
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');
@@ -6219,7 +6288,7 @@ sub main {
 
    $dbh->{InactiveDestroy}  = 1; # Don't disconnect on fork
    $dbh->{FetchHashKeyName} = 'NAME_lc';
-   $dbh->{mysql_auto_reconnect} = 1;
+   ($dp->prop('dbidriver') eq 'MariaDB' ? $dbh->{mariadb_auto_reconnect} : $dbh->{mysql_auto_reconnect}) = 1;
    $dbh->do("USE `$db`");
 
    # ########################################################################

--- a/bin/pt-index-usage
+++ b/bin/pt-index-usage
@@ -148,6 +148,14 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
@@ -155,7 +163,12 @@ sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -271,6 +284,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -303,15 +324,30 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -333,14 +369,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -352,7 +394,7 @@ sub get_dbh {
       }
    }
 
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       my ($charset) = $cxn_string =~ m/charset=([\w]+)/;
@@ -364,7 +406,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -423,24 +465,51 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
 
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');

--- a/bin/pt-kill
+++ b/bin/pt-kill
@@ -1916,6 +1916,14 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
@@ -1923,7 +1931,12 @@ sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -2039,6 +2052,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -2071,15 +2092,30 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -2101,14 +2137,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -2120,7 +2162,7 @@ sub get_dbh {
       }
    }
 
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       my ($charset) = $cxn_string =~ m/charset=([\w]+)/;
@@ -2132,7 +2174,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -2191,24 +2233,51 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
 
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');
@@ -7428,7 +7497,7 @@ sub main {
    # ########################################################################
    my $daemon;
    my $utf8 = 0;
-   if ( $dbh && $dbh->{mysql_enable_utf8} ) {
+   if ( $dbh && ($dbh->{mysql_enable_utf8} || $dp->prop('dbidriver') eq 'MariaDB') ) {
       $utf8 = 1;
    }
    if ( $o->get('daemonize') || $o->get('pid')) {
@@ -7492,7 +7561,7 @@ sub main {
          Command  => $o->get('ignore-command'),
          db       => $o->get('ignore-db'),
          Host     => $o->get('ignore-host'),
-         Id       => $o->get('ignore-self') ? $dbh->{mysql_thread_id} : undef,
+         Id       => $o->get('ignore-self') ? ($dp->prop('dbidriver') eq 'MariaDB' ? $dbh->{mariadb_thread_id} : $dbh->{mysql_thread_id}) : undef,
          Info     => $o->get('ignore-info'),
          State    => $o->get('ignore-state'),
          User     => $o->get('ignore-user'),

--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -2166,6 +2166,14 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
@@ -2173,7 +2181,12 @@ sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -2289,6 +2302,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -2321,15 +2342,30 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -2351,14 +2387,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -2370,7 +2412,7 @@ sub get_dbh {
       }
    }
 
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       my ($charset) = $cxn_string =~ m/charset=([\w]+)/;
@@ -2382,7 +2424,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -2441,24 +2483,51 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
 
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');

--- a/bin/pt-query-digest
+++ b/bin/pt-query-digest
@@ -816,6 +816,14 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
@@ -823,7 +831,12 @@ sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -939,6 +952,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -971,15 +992,30 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -1001,14 +1037,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -1020,7 +1062,7 @@ sub get_dbh {
       }
    }
 
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       my ($charset) = $cxn_string =~ m/charset=([\w]+)/;
@@ -1032,7 +1074,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -1091,24 +1133,51 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
 
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');
@@ -13827,7 +13896,7 @@ sub main {
                      }
                      $cur_time = time();
                      $sth      = $ps_dbh->prepare('SHOW FULL PROCESSLIST');
-                     $cxn      = $ps_dbh->{mysql_thread_id};
+                     $cxn      = $dp->prop('dbidriver') eq 'MariaDB' ? $ps_dbh->{mariadb_thread_id} : $ps_dbh->{mysql_thread_id};
                      $sth->execute();
                   };
                   $err = $EVAL_ERROR;

--- a/bin/pt-replica-find
+++ b/bin/pt-replica-find
@@ -1844,6 +1844,14 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
@@ -1851,7 +1859,12 @@ sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -1967,6 +1980,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -1999,15 +2020,30 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -2029,14 +2065,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -2048,7 +2090,7 @@ sub get_dbh {
       }
    }
 
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       my ($charset) = $cxn_string =~ m/charset=([\w]+)/;
@@ -2060,7 +2102,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -2119,24 +2161,51 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
 
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');

--- a/bin/pt-replica-restart
+++ b/bin/pt-replica-restart
@@ -2258,6 +2258,14 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
@@ -2265,7 +2273,12 @@ sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -2381,6 +2394,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -2413,15 +2434,30 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -2443,14 +2479,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -2462,7 +2504,7 @@ sub get_dbh {
       }
    }
 
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       my ($charset) = $cxn_string =~ m/charset=([\w]+)/;
@@ -2474,7 +2516,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -2533,24 +2575,51 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
 
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');

--- a/bin/pt-show-grants
+++ b/bin/pt-show-grants
@@ -1188,6 +1188,14 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
@@ -1195,7 +1203,12 @@ sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -1311,6 +1324,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -1343,15 +1364,30 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -1373,14 +1409,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -1392,7 +1434,7 @@ sub get_dbh {
       }
    }
 
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       my ($charset) = $cxn_string =~ m/charset=([\w]+)/;
@@ -1404,7 +1446,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -1463,24 +1505,51 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
 
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');
@@ -2004,7 +2073,7 @@ sub main {
 
    print join("\n",
       "-- Grants dumped by pt-show-grants",
-      "-- Dumped from server " . ($dbh->{mysql_hostinfo} || '')
+      "-- Dumped from server " . (($dp->prop('dbidriver') eq 'MariaDB' ? $dbh->{mariadb_hostinfo} : $dbh->{mysql_hostinfo}) || '')
       . ($o->get('timestamp') ? ", MySQL $version at $ts" : ", MySQL $version"),
       ), "\n" if $o->get('header');
 

--- a/bin/pt-slave-delay
+++ b/bin/pt-slave-delay
@@ -1910,6 +1910,14 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
@@ -1917,7 +1925,12 @@ sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -2033,6 +2046,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -2065,15 +2086,30 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -2095,14 +2131,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -2114,7 +2156,7 @@ sub get_dbh {
       }
    }
 
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       my ($charset) = $cxn_string =~ m/charset=([\w]+)/;
@@ -2126,7 +2168,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -2185,24 +2227,51 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
 
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');

--- a/bin/pt-table-checksum
+++ b/bin/pt-table-checksum
@@ -1454,6 +1454,14 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
@@ -1461,7 +1469,12 @@ sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -1577,6 +1590,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -1609,15 +1630,30 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -1639,14 +1675,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -1658,7 +1700,7 @@ sub get_dbh {
       }
    }
 
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       my ($charset) = $cxn_string =~ m/charset=([\w]+)/;
@@ -1670,7 +1712,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -1729,24 +1771,51 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
 
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');

--- a/bin/pt-table-sync
+++ b/bin/pt-table-sync
@@ -2080,6 +2080,14 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
@@ -2087,7 +2095,12 @@ sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -2203,6 +2216,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -2235,15 +2256,30 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -2265,14 +2301,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -2284,7 +2326,7 @@ sub get_dbh {
       }
    }
 
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       my ($charset) = $cxn_string =~ m/charset=([\w]+)/;
@@ -2296,7 +2338,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -2355,24 +2397,51 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
 
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');
@@ -6133,8 +6202,8 @@ sub sync_table {
       my $src_sth = $src->{dbh}->prepare($src_sql);
       my $dst_sth = $dst->{dbh}->prepare($dst_sql);
       if ( $args{buffer_to_client} ) {
-         $src_sth->{mysql_use_result} = 1;
-         $dst_sth->{mysql_use_result} = 1;
+         ($dp->prop('dbidriver') eq 'MariaDB' ? $src_sth->{mariadb_use_result} : $src_sth->{mysql_use_result}) = 1;
+         ($dp->prop('dbidriver') eq 'MariaDB' ? $dst_sth->{mariadb_use_result} : $dst_sth->{mysql_use_result}) = 1;
       }
 
       my $executed_src = 0;

--- a/bin/pt-table-usage
+++ b/bin/pt-table-usage
@@ -90,6 +90,14 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
@@ -97,7 +105,12 @@ sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -213,6 +226,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -245,15 +266,30 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -275,14 +311,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -294,7 +336,7 @@ sub get_dbh {
       }
    }
 
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       my ($charset) = $cxn_string =~ m/charset=([\w]+)/;
@@ -306,7 +348,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -365,24 +407,51 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
 
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');

--- a/bin/pt-upgrade
+++ b/bin/pt-upgrade
@@ -813,6 +813,14 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
@@ -820,7 +828,12 @@ sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -936,6 +949,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -968,15 +989,30 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -998,14 +1034,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -1017,7 +1059,7 @@ sub get_dbh {
       }
    }
 
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       my ($charset) = $cxn_string =~ m/charset=([\w]+)/;
@@ -1029,7 +1071,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -1088,24 +1130,51 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
 
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');

--- a/bin/pt-variable-advisor
+++ b/bin/pt-variable-advisor
@@ -1913,6 +1913,14 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
@@ -1920,7 +1928,12 @@ sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -2036,6 +2049,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -2068,15 +2089,30 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -2098,14 +2134,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -2117,7 +2159,7 @@ sub get_dbh {
       }
    }
 
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       my ($charset) = $cxn_string =~ m/charset=([\w]+)/;
@@ -2129,7 +2171,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -2188,24 +2230,51 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
 
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');

--- a/bin/pt-visual-explain
+++ b/bin/pt-visual-explain
@@ -1874,6 +1874,14 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
@@ -1881,7 +1889,12 @@ sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -1997,6 +2010,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -2029,15 +2050,30 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -2059,14 +2095,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -2078,7 +2120,7 @@ sub get_dbh {
       }
    }
 
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       my ($charset) = $cxn_string =~ m/charset=([\w]+)/;
@@ -2090,7 +2132,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -2149,24 +2191,51 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
 
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');

--- a/config/deb/control
+++ b/config/deb/control
@@ -11,8 +11,8 @@ Vcs-Git: git://github.com/percona/percona-toolkit.git
 
 Package: percona-toolkit
 Architecture: @@ARCHITECTURE@@
-Depends: ${perl:Depends}, libdbi-perl (>= 1.13), libdbd-mysql-perl | libdbd-mysql-5.1-perl, libterm-readkey-perl (>=2.10),
-    libio-socket-ssl-perl
+Depends: ${perl:Depends}, libdbi-perl (>= 1.13), libdbd-mysql-perl | libdbd-mysql-5.1-perl | libdbd-mariadb-perl,
+    libterm-readkey-perl (>=2.10), libio-socket-ssl-perl
 Description: Advanced MySQL and system command-line tools
  Percona Toolkit is a collection of advanced command-line tools used by
  Percona (http://www.percona.com/) support staff to perform a variety of

--- a/config/rpm/percona-toolkit.spec
+++ b/config/rpm/percona-toolkit.spec
@@ -13,7 +13,8 @@ Source:    percona-toolkit-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 BuildRequires: perl(ExtUtils::MakeMaker) make
-Requires:  perl(DBI) >= 1.13, perl(DBD::mysql) >= 1.0, perl(Time::HiRes), perl(IO::Socket::SSL), perl(Digest::MD5), perl(Term::ReadKey)
+Requires:  perl(DBI) >= 1.13, (perl(DBD::mysql) >= 1.0 or perl(DBD::MariaDB) >= 1.0), perl(Time::HiRes), perl(IO::Socket::SSL), perl(Digest::MD5), perl(Term::ReadKey)
+Recommends: (perl(DBD::MariaDB) if (MariaDB-common and perl(DBD::MariaDB)) else perl(DBD::mysql))
 %if 0%{?rhel} > 9 || 0%{?amzn} >= 2023
 Requires:  perl(English)
 %endif

--- a/config/rpm/percona-toolkit.spec
+++ b/config/rpm/percona-toolkit.spec
@@ -13,7 +13,8 @@ Source:    percona-toolkit-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 BuildRequires: perl(ExtUtils::MakeMaker) make
-Requires:  perl(DBI) >= 1.13, perl(DBD::mysql) >= 1.0, perl(Time::HiRes), perl(IO::Socket::SSL), perl(Digest::MD5), perl(Term::ReadKey)
+Requires:  perl(DBI) >= 1.13, (perl(DBD::mysql) >= 1.0 or perl(DBD::MariaDB) >= 1.0), perl(Time::HiRes), perl(IO::Socket::SSL), perl(Digest::MD5), perl(Term::ReadKey)
+Recommends: (perl(DBD::MariaDB) if MariaDB-common else perl(DBD::mysql))
 %if 0%{?rhel} > 9 || 0%{?amzn} >= 2023
 Requires:  perl(English)
 %endif

--- a/lib/DSNParser.pm
+++ b/lib/DSNParser.pm
@@ -20,7 +20,7 @@
 {
 # Package: DSNParser
 # DSNParser parses DSNs and creates connections to MySQL using DBI and
-# DBD::mysql.
+# DBD::mysql or DBD::MariaDB.
 package DSNParser;
 
 use strict;
@@ -76,18 +76,32 @@ sub new {
          copy => $opt->{copy} || 0,
       };
    }
+
+   # Use DBD::MariaDB as default MySQL DBI driver if it's installed
+   eval{ require DBD::MariaDB };
+   if ($@) {
+      $self->{dbidriver} = 'mysql';
+   } else {
+      $self->{dbidriver} = 'MariaDB';
+   };
+
    return bless $self, $class;
 }
 
 # Recognized properties:
-# * dbidriver: which DBI driver to use; assumes mysql, supports Pg.
+# * dbidriver: which DBI driver to use; assumes mysql/MariaDB, supports Pg.
 # * required:  which parts are required (hashref).
 # * set-vars:  a list of variables to set after connecting
 sub prop {
    my ( $self, $prop, $value ) = @_;
    if ( @_ > 2 ) {
       PTDEBUG && _d('Setting', $prop, 'property');
-      $self->{$prop} = $value;
+      if ($prop eq 'dbidriver') {
+         $self->{$prop} = $value || $self->{$prop};
+      }
+      else {
+         $self->{$prop} = $value;
+      }
    }
    return $self->{$prop};
 }
@@ -239,6 +253,14 @@ sub get_cxn_params {
                      grep { defined $info->{$_} }
                      qw(h P));
    }
+   elsif ( $driver eq 'MariaDB' ) {
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
+         . join(';', map  { ($opts{$_}->{dsn} =~ s/mysql/mariadb/r) . "=$info->{$_}" }
+                     grep { defined $info->{$_} }
+                     qw(F h P S A s))
+         . ';mariadb_read_default_group=client'
+         . ($info->{L} ? ';mariadb_local_infile=1' : '');
+   }
    else {
       $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
@@ -275,18 +297,33 @@ sub get_dbh {
       RaiseError         => 1,
       PrintError         => 0,
       ShowErrorStatement => 1,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/i ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
+
+   my $mysql_defaults = { mysql_enable_utf8 => 0 };
+   my $mariadb_defaults = {};
+
+   if ($cxn_string =~ m/charset=utf8/i || $opts->{mysql_enable_utf8}) {
+      $mysql_defaults->{mysql_enable_utf8} = 1;
+   }
+
    if (delete $defaults->{L}) { # L for LOAD DATA LOCAL INFILE, our own extension
-      $defaults->{mysql_local_infile} = 1;
+      $mysql_defaults->{mysql_local_infile} = 1;
+      $mariadb_defaults->{mariadb_local_infile} = 1;
    }
 
    # Only add this if explicitly set because we're not sure if
    # mysql_use_result=0 would leave default mysql_store_result
    # enabled.
    if ( $opts->{mysql_use_result} ) {
-      $defaults->{mysql_use_result} = 1;
+      $mysql_defaults->{mysql_use_result} = 1;
+      $mariadb_defaults->{mariadb_use_result} = 1;
+   }
+
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      @{$defaults}{ keys %$mariadb_defaults } = values %$mariadb_defaults;
+   } elsif ($self->prop('dbidriver') ne 'Pg') {
+      @{$defaults}{ keys %$mysql_defaults } = values %$mysql_defaults;
    }
 
    if ( !$have_dbi ) {
@@ -309,14 +346,20 @@ sub get_dbh {
       $dbh = eval { DBI->connect($cxn_string, $user, $pass, $defaults) };
 
       if ( !$dbh && $EVAL_ERROR ) {
-         if ( $EVAL_ERROR =~ m/locate DBD\/mysql/i ) {
-            die "Cannot connect to MySQL because the Perl DBD::mysql module is "
-               . "not installed or not found.  Run 'perl -MDBD::mysql' to see "
-               . "the directories that Perl searches for DBD::mysql.  If "
-               . "DBD::mysql is not installed, try:\n"
+         if ( $EVAL_ERROR =~ m/locate DBD\/(mysql|MariaDB)/i ) {
+            die "Cannot connect to MySQL because the Perl DBD::mysql or DBD::MariaDB module is "
+               . "not installed or not found.  Run 'perl -MDBD::mysql' or 'perl -MDBD::MariaDB' "
+               . "to see the directories that Perl searches for.  If "
+               . "DBD::mysql or DBD::MariaDB is not installed, try:\n"
                . "  Debian/Ubuntu  apt-get install libdbd-mysql-perl\n"
+               . "                 or\n"
+               . "                 apt-get install libdbd-mariadb-perl\n"
                . "  RHEL/CentOS    yum install perl-DBD-MySQL\n"
-               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n";
+               . "                 or\n"
+               . "                 yum install perl-DBD-MariaDB\n"
+               . "  OpenSolaris    pkg install pkg:/SUNWapu13dbd-mysql\n"
+               . "                 or\n"
+               . "                 pkg install pkg:/SUNWapu13dbd-mariadb\n";
          }
          elsif ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
             PTDEBUG && _d('Going to try again without utf8 support');
@@ -329,7 +372,7 @@ sub get_dbh {
    }
 
    # If it's a MySQL connection, set some options.
-   if ( $cxn_string =~ m/mysql/i ) {
+   if ( $self->prop('dbidriver') =~ m/(mysql|mariadb)/i ) {
       my $sql;
 
       # Set character set and binmode on STDOUT.
@@ -342,7 +385,7 @@ sub get_dbh {
             die "Error setting NAMES to $charset: $EVAL_ERROR";
          }
       }
-      else {
+      elsif ($self->prop('dbidriver') eq 'mysql') {
          my ($mysql_version) = eval { $dbh->selectrow_array('SELECT VERSION()') };
          if ( $EVAL_ERROR ) {
             die "Cannot get MySQL version: $EVAL_ERROR";
@@ -407,16 +450,36 @@ sub get_dbh {
       }
    }
 
-   PTDEBUG && _d('DBH info: ',
-      $dbh,
-      Dumper($dbh->selectrow_hashref(
-         'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      'Connection info:',      $dbh->{mysql_hostinfo},
-      'Character set info:',   Dumper($dbh->selectall_arrayref(
-                     "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
-      '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
-      '$DBI::VERSION:',        $DBI::VERSION,
-   );
+   my @debug_info = ('DBH info: ', $dbh);
+   if ($self->{dbidriver} eq 'Pg') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT VERSION()/*!50038 , @@hostname*/')),
+         '$DBD::Pg::VERSION:', $DBD::Pg::VERSION,
+      );
+   }
+   elsif ($self->{dbidriver} eq 'MariaDB') {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mariadb_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {} })),
+         '$DBD::MariaDB::VERSION:', $DBD::MariaDB::VERSION,
+      );
+   } else {
+      push(@debug_info,
+         Dumper($dbh->selectrow_hashref(
+            'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
+         'Connection info:',      $dbh->{mysql_hostinfo},
+         'Character set info:',   Dumper($dbh->selectall_arrayref(
+                                    "SHOW VARIABLES LIKE 'character_set%'", { Slice => {}})),
+         '$DBD::mysql::VERSION:', $DBD::mysql::VERSION,
+      )
+   }
+   push(@debug_info, '$DBI::VERSION:', $DBI::VERSION);
+
+   PTDEBUG && _d(@debug_info);
 
    return $dbh;
 }
@@ -424,8 +487,15 @@ sub get_dbh {
 # Tries to figure out a hostname for the connection.
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
-      return $host;
+   if ($self->prop('dbidriver') eq 'MariaDB') {
+      if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
+   }
+   elsif ($self->prop('dbidriver') ne 'Pg') {
+      if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+         return $host;
+      }
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
       'SELECT /*!50038 @@hostname, */ 1');

--- a/lib/TableSyncer.pm
+++ b/lib/TableSyncer.pm
@@ -282,8 +282,8 @@ sub sync_table {
       my $src_sth = $src->{dbh}->prepare($src_sql);
       my $dst_sth = $dst->{dbh}->prepare($dst_sql);
       if ( $args{buffer_to_client} ) {
-         $src_sth->{mysql_use_result} = 1;
-         $dst_sth->{mysql_use_result} = 1;
+         ($dp->prop('dbidriver') eq 'MariaDB' ? $src_sth->{mariadb_use_result} : $src_sth->{mysql_use_result}) = 1;
+         ($dp->prop('dbidriver') eq 'MariaDB' ? $dst_sth->{mariadb_use_result} : $dst_sth->{mysql_use_result}) = 1;
       }
 
       # The first cycle should lock to begin work; after that, unlock only if

--- a/t/lib/DSNParser.t
+++ b/t/lib/DSNParser.t
@@ -318,6 +318,23 @@ is_deeply (
    'Got connection arguments for PostgreSQL',
 );
 
+$dp->prop('dbidriver', 'MariaDB');
+is_deeply (
+   [
+      $dp->get_cxn_params(
+         $dp->parse(
+            'u=a,p=b',
+            { D => 'foo', h => 'me' },
+            { S => 'bar', h => 'host' } ))
+   ],
+   [
+      'DBI:MariaDB:foo;host=me;mariadb_socket=bar;mariadb_read_default_group=client',
+      'a',
+      'b',
+   ],
+   'Got connection arguments for DBD::MariaDB',
+);
+
 $dp->prop('required', { h => 1 } );
 throws_ok (
    sub { $dp->parse('u=b') },
@@ -431,7 +448,7 @@ pop @$opts; # Remove t part.
 # Issue 93: DBI error messages can include full SQL
 # #############################################################################
 SKIP: {
-   skip 'ShowErrorStatement requires DBD::mysql 4.003', 1 unless $DBD::mysql::VERSION ge '4.003';
+   skip 'ShowErrorStatement requires DBD::mysql 4.003', 1 unless ($dp->prop('dbidriver') ne 'MariaDB' && $DBD::mysql::VERSION ge '4.003');
    skip 'Cannot connect to sandbox master', 1 unless $dbh;
    eval { $dbh->do('SELECT * FROM doesnt.exist WHERE foo = 1'); };
    like(

--- a/t/lib/Quoter.t
+++ b/t/lib/Quoter.t
@@ -217,7 +217,7 @@ SKIP: {
 };
 
 my $utf8_dbh = $sb->get_dbh_for('source');
-$utf8_dbh->{mysql_enable_utf8} = 1;
+if ($dp->prop('dbidriver') ne 'MariaDB' && $dp->prop('dbidriver') ne 'Pg') { $utf8_dbh->{mysql_enable_utf8} = 1 };
 $utf8_dbh->do("SET NAMES 'utf8'");
 SKIP: {
    skip 'Cannot connect to sandbox master', scalar @utf8_serialize_tests

--- a/t/pt-deadlock-logger/basics.t
+++ b/t/pt-deadlock-logger/basics.t
@@ -43,8 +43,8 @@ $dbh2->commit;
 $dbh1->{InactiveDestroy} = 1;
 $dbh2->{InactiveDestroy} = 1;
 
-$dbh1->{mysql_auto_reconnect} = 1;
-$dbh2->{mysql_auto_reconnect} = 1;
+($dp->prop('dbidriver') eq 'MariaDB' ? $dbh1->{mariadb_auto_reconnect} : $dbh1->{mysql_auto_reconnect}) = 1;
+($dp->prop('dbidriver') eq 'MariaDB' ? $dbh2->{mariadb_auto_reconnect} : $dbh2->{mysql_auto_reconnect}) = 1;
 
 sub make_deadlock {
    # Fork off two children to deadlock against each other.

--- a/t/pt-deadlock-logger/ssl.t
+++ b/t/pt-deadlock-logger/ssl.t
@@ -44,8 +44,8 @@ $dbh2->commit;
 $dbh1->{InactiveDestroy} = 1;
 $dbh2->{InactiveDestroy} = 1;
 
-$dbh1->{mysql_auto_reconnect} = 1;
-$dbh2->{mysql_auto_reconnect} = 1;
+($dp->prop('dbidriver') eq 'MariaDB' ? $dbh1->{mariadb_auto_reconnect} : $dbh1->{mysql_auto_reconnect}) = 1;
+($dp->prop('dbidriver') eq 'MariaDB' ? $dbh2->{mariadb_auto_reconnect} : $dbh2->{mysql_auto_reconnect}) = 1;
 
 sub make_deadlock {
    # Fork off two children to deadlock against each other.


### PR DESCRIPTION
Sometimes, DBD::MariaDB is more appreciated than DBD::mysql. For example, on a RHEL system, if you setup and install the MariaDB server from official MariaDB [mariadb_repo_setup](https://r.mariadb.com/downloads/mariadb_repo_setup) tool, and then you try to install the percona-toolkit package, you’re likely to encounter into an error similar to this:

```
Error: Transaction test error:
  file /usr/share/mysql/charsets/Index.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/armscii8.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/ascii.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/cp1250.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/cp1251.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/cp1256.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/cp1257.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/cp850.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/cp852.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/cp866.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/dec8.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/geostd8.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/greek.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/hebrew.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/hp8.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/keybcs2.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/koi8r.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/koi8u.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/latin1.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/latin2.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/latin5.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/latin7.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/macce.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/macroman.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
  file /usr/share/mysql/charsets/swe7.xml from install of mysql-common-8.0.45-1.el9_7.aarch64 conflicts with file from package MariaDB-common-10.6.25-1.el9.aarch64
```

Because percona-toolkit depends on DBD::mysql, which resolved as perl-DBD-MySQL package on rpm system, which then depends on the mysql-common package. And the mysql-common package is conflict with the MariaDB-common package from the official MariaDB repo. In this case, DBD::MariaDB is preferred for avoiding such conflicts.

In current percona-toolkit (3.7.x), DBD::MariaDB is not regarded at many places, this patch adds the regard and makes an adjustment to the rpm/deb packaging so that `perl(DBD::MariaDB)` could be a replacement to `perl(DBD::mysql)`, as a dependency.

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [x] util/update-modules has been ran
- [x] Documentation updated
- [x] Test suite update
