### PR TITLE
PT-2219 - Collect PXC files from pxc container when logs sidecar is disabled

### DIFF
--- a/src/go/pt-k8s-debug-collector/dumper/dumper.go
+++ b/src/go/pt-k8s-debug-collector/dumper/dumper.go
@@ -67,10 +67,10 @@ type Dumper struct {
 
 // individualFile struct is used to dump the necessary files from the containers
 type individualFile struct {
-	resourceName  string
-	containerName string
-	filepaths     []string
-	dirpaths      map[string][]string // map[tarFolder][]dirPaths
+	resourceName   string
+	containerNames []string
+	filepaths      []string
+	dirpaths       map[string][]string // map[tarFolder][]dirPaths
 }
 
 // resourceMap struct is used to dump the resources from namespace scope or cluster scope
@@ -91,7 +91,7 @@ func New(location, namespace, kubeconfig, clusterName, forwardport, resource str
 	log.AddHook(&ErrorArchiveHook{safeLogger: safeLog})
 
 	if clusterName == "" {
-		_,  clusterName = parseResourceSpec(resource)
+		_, clusterName = parseResourceSpec(resource)
 	}
 
 	config, err := buildRestConfig(kubeconfig, clusterName)

--- a/src/go/pt-k8s-debug-collector/dumper/individual_files.go
+++ b/src/go/pt-k8s-debug-collector/dumper/individual_files.go
@@ -36,6 +36,17 @@ func replaceEnvVars(input string, envMap map[string]string) string {
 	return result
 }
 
+func selectContainer(pod corev1.Pod, candidates []string) (string, bool) {
+	for _, candidate := range candidates {
+		for _, c := range pod.Spec.Containers {
+			if c.Name == candidate {
+				return candidate, true
+			}
+		}
+	}
+	return "", false
+}
+
 func (d *Dumper) getIndividualFiles(ctx context.Context, job exportJob, crType string) {
 	normalizedCRType := resourceType(crType)
 
@@ -44,17 +55,23 @@ func (d *Dumper) getIndividualFiles(ctx context.Context, job exportJob, crType s
 			continue
 		}
 
+		container, ok := selectContainer(job.Pod, indf.containerNames)
+		if !ok {
+			log.Warnf("None of the containers %v found in pod %s/%s, skipping", indf.containerNames, job.Pod.Namespace, job.Pod.Name)
+			continue
+		}
+
 		// Parse environment variables once for this container
-		envMap, err := d.getContainerEnvMap(job.Pod, indf.containerName)
+		envMap, err := d.getContainerEnvMap(job.Pod, container)
 		if err != nil {
-			log.Warnf("Failed to get env for container %q: %v", indf.containerName, err)
+			log.Warnf("Failed to get env for container %q: %v", container, err)
 			continue
 		}
 
 		// Process individual files
 		for _, indPath := range indf.filepaths {
 			resolvedPath := replaceEnvVars(indPath, envMap)
-			if err := d.processSingleFile(ctx, job, indf.containerName, "", resolvedPath); err != nil {
+			if err := d.processSingleFile(ctx, job, container, "", resolvedPath); err != nil {
 				log.Warnf("Failed to process file %q: %v", resolvedPath, err)
 			}
 		}
@@ -63,7 +80,7 @@ func (d *Dumper) getIndividualFiles(ctx context.Context, job exportJob, crType s
 		for tarFolder, dirPaths := range indf.dirpaths {
 			for _, dirPath := range dirPaths {
 				resolvedPath := replaceEnvVars(dirPath, envMap)
-				if err := d.processDir(ctx, job, indf.containerName, tarFolder, resolvedPath); err != nil {
+				if err := d.processDir(ctx, job, container, tarFolder, resolvedPath); err != nil {
 					log.Warnf("Skipping directory %q: %v", resolvedPath, err)
 				}
 			}

--- a/src/go/pt-k8s-debug-collector/dumper/resources.go
+++ b/src/go/pt-k8s-debug-collector/dumper/resources.go
@@ -17,9 +17,9 @@ func (d *Dumper) addPg1() error {
 	}
 
 	d.individualFiles = append(d.individualFiles, individualFile{
-		resourceName:  "pgo",
-		containerName: "database",
-		dirpaths:      dirpaths,
+		resourceName:   "pgo",
+		containerNames: []string{"database"},
+		dirpaths:       dirpaths,
 	})
 	return nil
 }
@@ -30,9 +30,9 @@ func (d *Dumper) addPg2() error {
 	}
 
 	d.individualFiles = append(d.individualFiles, individualFile{
-		resourceName:  "pgv2",
-		containerName: "database",
-		dirpaths:      dirpaths,
+		resourceName:   "pgv2",
+		containerNames: []string{"database"},
+		dirpaths:       dirpaths,
 	})
 	return nil
 }
@@ -50,9 +50,9 @@ func (d *Dumper) addPxc() error {
 	}
 
 	d.individualFiles = append(d.individualFiles, individualFile{
-		resourceName:  "pxc",
-		containerName: "logs",
-		filepaths:     filepaths,
+		resourceName:   "pxc",
+		containerNames: []string{"logs", "pxc"},
+		filepaths:      filepaths,
 	})
 	return nil
 }


### PR DESCRIPTION
pt-k8s-debug-collector collected the PXC `var/lib/mysql` files only from the `logs` sidecar container. When the log collector is disabled (or absent), that container does not exist and the files were silently skipped.
    
- [ ] The contributed code is licensed under GPL v2.0
- [ ] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documentation updated
- [ ] Test suite update
