### PR TITLE
PT-2485: Fix socket auth in pt-online-schema-change

### DIFF
--- a/bin/pt-online-schema-change
+++ b/bin/pt-online-schema-change
@@ -9187,13 +9187,43 @@ sub main {
       );
 
       # Check if we are not a replica of the source server with ROW or MIXED base replication
-      if ( !$o->get('force') ) {
+      #
+      # This check requires opening a *new* connection to whatever server
+      # SHOW [REPLICA|SLAVE] STATUS reports as our source. That server may
+      # not be reachable (firewalls, tunnels, IPv6-only routes, etc.) and,
+      # crucially, may not accept the same authentication that was used for
+      # the connection the user actually asked for -- e.g. when the tool
+      # was invoked relying on the MySQL/MariaDB unix_socket auth plugin
+      # (no --user/--password given; the OS user is trusted locally), that
+      # trust does not, and cannot, extend to a remote source server.
+      #
+      # Respect an explicit --recursion-method=none the same way the rest
+      # of the tool does elsewhere (see the replica-discovery code below):
+      # the user is telling us not to look at, or connect to, any other
+      # server. And even when the check does run, a failure to connect to
+      # the source should not abort the whole run -- just skip the check,
+      # like we already do for the tunnel/port-redirection case below.
+      if ( !$o->get('force')
+         && lc($o->get('recursion-method') || '') ne 'none' ) {
          my $source = $ms->get_source_dsn($cxn->dbh(), $dsn, $dp);
          if ( $source ) {
-            my $source_cxn = $make_cxn->(dsn => $source);
+            my $source_cxn = eval {
+               $make_cxn->(dsn => $source);
+            };
+
+            if ( $EVAL_ERROR ) {
+               PTDEBUG && _d('Could not connect to source', $dp->as_string($source),
+                  'to check replication safety:', $EVAL_ERROR);
+               warn "Could not connect to source " . $dp->as_string($source)
+                  . " to check replication safety (skipping this check): "
+                  . "$EVAL_ERROR"
+                  . "If you want to suppress this warning, specify option --force "
+                  . "or --recursion-method=none.\n";
+               $EVAL_ERROR = '';
+            }
 
             # Check source
-            my $is_source_of = eval {
+            my $is_source_of = $source_cxn && eval {
                $ms->is_source_of($source_cxn->{dbh}, $cxn->{dbh});
             };
 


### PR DESCRIPTION
Ticket number: PT-2485 PT-2510

MariaDB with root socket user. I can connect to the server with `mysql` without any password.

With percona-toolkit 3.7.0-2.el9 such command works:
```
# pt-online-schema-change --alter "MODIFY marshaled MEDIUMBLOB DEFAULT NULL" D=web,t=slip_log --execute --set-vars "sql_log_bin=0" --recursion-method=none --pause-file=/tmp/ptosc.pause
No replicas found.  See --recursion-method if host example.com has replicas.
Not checking replica lag because no replicas were found and --check-replica-lag was not specified.

Altering `web`.`slip_log`...
```
With  3.7.1-2.el9 this command does not work:
```
# pt-online-schema-change --alter "MODIFY marshaled MEDIUMBLOB DEFAULT NULL" D=web,t=slip_log --execute --set-vars "sql_log_bin=0" --recursion-method=none --pause-file=/tmp/ptosc.pause
Cannot connect to MySQL: DBI connect(';host=example.com;port=3306;mysql_read_default_group=client','',...) failed: Access denied for user 'root'@'2a05:d018:3ad:6102:77da:xxxx:xxxx:xxxx' (using password: NO) at /usr/bin/pt-online-schema-change line 2351.
18 at /usr/bin/pt-online-schema-change line 8927.
```
**Root cause:**

It's the PT-2305 feature ("pt-online-schema-change should error if server is a slave in row based replication").
In `main()`, right after connecting, unless `--force` is given, the tool now does:
```
my $source = $ms->get_source_dsn($cxn->dbh(), $dsn, $dp);
if ( $source ) {
   my $source_cxn = $make_cxn->(dsn => $source);   # <-- new, unconditional connection
   ...
```
`get_source_dsn()` runs `SHOW REPLICA/SLAVE STATUS` and, if your server is itself a replica of some upstream master, builds a DSN pointing at that master's host/port and immediately opens a second connection to it — to check whether replication is safely STATEMENT-based.

This breaks two scenarios:

`--recursion-method=none`: that flag only ever gated downstream replica discovery. This new check ignores it completely, so even though you explicitly said "don't go looking at other servers," it still does.
**Unix socket auth**: your first connection authenticates via the local socket with no `-u`/`-p` (OS-user trust, local only). That trust can't extend to a second, remote TCP connection to the upstream master's hostname — so it tries with no credentials and MySQL/MariaDB correctly reports `Access denied ... using password: NO`. Since `$make_cxn` dies on connection failure, the whole run aborts.

In 3.7.0 this second connection simply didn't exist, which is why it worked.

**The fix**

Skip this check when `--recursion-method=none` is explicitly set (consistent with how the rest of the tool already treats that flag), and make a failed connection to the discovered source non-fatal — warn and skip the safety check instead of killing the whole run, mirroring the existing "don't die on tunnel/port-redirection" handling right below it in the same block.
