### PR TITLE
PT-1923: Replace offensive terminology (master/slave → primary/replica) in pt-pg-summary

### DIFF
--- a/src/go/lib/pginfo/pginfo.go
+++ b/src/go/lib/pginfo/pginfo.go
@@ -40,8 +40,8 @@ type PGInfo struct {
 	AllDatabases       []*models.Databases
 	GlobalWaitEvents   []*models.GlobalWaitEvents
 	PortAndDatadir     *models.PortAndDatadir
-	SlaveHosts96       []*models.SlaveHosts96
-	SlaveHosts10       []*models.SlaveHosts10
+	ReplicaHosts96     []*models.ReplicaHosts96
+	ReplicaHosts10     []*models.ReplicaHosts10
 	Tablespaces        []*models.Tablespaces
 	Settings           []*models.Setting
 	Counters           map[models.Name][]*models.Counters    // Counters per database
@@ -205,16 +205,16 @@ func (i *PGInfo) CollectGlobalInfo(db models.XODB) []error {
 	}
 
 	if i.ServerVersion.LessThan(version10) {
-		i.logger.Info("Collecting Slave Hosts (PostgreSQL < 10)")
-		if i.SlaveHosts96, err = models.GetSlaveHosts96s(db); err != nil {
-			errs = append(errs, errors.Wrap(err, "Cannot get slave hosts on Postgre < 10"))
+		i.logger.Info("Collecting Replica Hosts (PostgreSQL < 10)")
+		if i.ReplicaHosts96, err = models.GetReplicaHosts96s(db); err != nil {
+			errs = append(errs, errors.Wrap(err, "Cannot get replica hosts on Postgre < 10"))
 		}
 	}
 
 	if i.ServerVersion.GreaterThanOrEqual(version10) {
-		i.logger.Info("Collecting Slave Hosts (PostgreSQL 10+)")
-		if i.SlaveHosts10, err = models.GetSlaveHosts10s(db); err != nil {
-			errs = append(errs, errors.Wrap(err, "Cannot get slave hosts in Postgre 10+"))
+		i.logger.Info("Collecting Replica Hosts (PostgreSQL 10+)")
+		if i.ReplicaHosts10, err = models.GetReplicaHosts10s(db); err != nil {
+			errs = append(errs, errors.Wrap(err, "Cannot get replica hosts in Postgre 10+"))
 		}
 	}
 

--- a/src/go/pt-pg-summary/README.rst
+++ b/src/go/pt-pg-summary/README.rst
@@ -106,7 +106,7 @@ Output example
      Client Hostname:
      Version        : PostgreSQL 9.6.17 on x86_64-pc-linux-gnu (Debian 9.6.17-2.pgdg90+1), compiled by
      Started        : 2020-04-21 13:36:59.909175 +0000 UTC
-     Is Slave       : false
+     Is Replica     : false
     +------------------------------------------------------------------------------------------------------+
 
     ##### --- Databases --- ####
@@ -489,11 +489,11 @@ Output is separated into the following sections:
     
   Selects ``name`` and ``setting`` from ``pg_settings``.
 
-* **SlaveHosts10**
+* **ReplicaHosts10**
     
   Selects information for PostgreSQL version 10.
 
-* **SlaveHosts96**
+* **ReplicaHosts96**
     
   Selects information for PostgreSQL version 9.6.
 

--- a/src/go/pt-pg-summary/main.go
+++ b/src/go/pt-pg-summary/main.go
@@ -121,12 +121,12 @@ func main() {
 		conn.Close()
 	}
 
-	masterTmpl, err := template.New("master").Funcs(funcsMap()).Parse(templates.TPL)
+	reportTmpl, err := template.New("report").Funcs(funcsMap()).Parse(templates.TPL)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	if err := masterTmpl.ExecuteTemplate(os.Stdout, "report", info); err != nil {
+	if err := reportTmpl.ExecuteTemplate(os.Stdout, "report", info); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/src/go/pt-pg-summary/models/clusterinfo.xo.go
+++ b/src/go/pt-pg-summary/models/clusterinfo.xo.go
@@ -29,7 +29,7 @@ type ClusterInfo struct {
 	ClientHostname sql.NullString // client_hostname
 	Version        string         // version
 	Started        time.Time      // started
-	IsSlave        bool           // is_slave
+	IsReplica      bool           // is_replica
 }
 
 // GetClusterInfos runs a custom query, returning results as ClusterInfo.
@@ -42,7 +42,7 @@ func GetClusterInfos(db XODB) ([]*ClusterInfo, error) {
 		`client_hostname, ` +
 		`version() AS version, ` +
 		`pg_postmaster_start_time() AS Started, ` +
-		`pg_is_in_recovery() AS "Is_Slave" ` +
+		`pg_is_in_recovery() AS "Is_Replica" ` +
 		`FROM pg_stat_activity ` +
 		`WHERE pid = pg_backend_pid()`
 
@@ -60,7 +60,7 @@ func GetClusterInfos(db XODB) ([]*ClusterInfo, error) {
 		ci := ClusterInfo{}
 
 		// scan
-		err = q.Scan(&ci.Usename, &ci.Time, &ci.ClientAddr, &ci.ClientHostname, &ci.Version, &ci.Started, &ci.IsSlave)
+		err = q.Scan(&ci.Usename, &ci.Time, &ci.ClientAddr, &ci.ClientHostname, &ci.Version, &ci.Started, &ci.IsReplica)
 		if err != nil {
 			return nil, err
 		}

--- a/src/go/pt-pg-summary/models/gen.sh
+++ b/src/go/pt-pg-summary/models/gen.sh
@@ -54,7 +54,7 @@ xo pgsql://${USERNAME}:${PASSWORD}@127.0.0.1:${PORT9}/?sslmode=disable \
 ORDER BY 1
 ENDSQL
 
-FIELDS='Usename string,Time time.Time,ClientAddr sql.NullString,ClientHostname sql.NullString,Version string,Started time.Time,IsSlave bool'
+FIELDS='Usename string,Time time.Time,ClientAddr sql.NullString,ClientHostname sql.NullString,Version string,Started time.Time,IsReplica bool'
 COMMENT='Cluster info'
 xo pgsql://${USERNAME}:${PASSWORD}@127.0.0.1:${PORT9}/?sslmode=disable \
     --query-mode \
@@ -72,7 +72,7 @@ SELECT usename, now() AS "Time",
        client_hostname,
        version() AS version,
        pg_postmaster_start_time() AS Started,
-       pg_is_in_recovery() AS "Is_Slave"
+       pg_is_in_recovery() AS "Is_Replica"
   FROM pg_stat_activity
  WHERE pid = pg_backend_pid()
 ENDSQL
@@ -235,7 +235,7 @@ ENDSQL
 xo pgsql://${USERNAME}:${PASSWORD}@127.0.0.1:${PORT9}/?sslmode=disable \
     --query-mode \
     --query-trim  \
-    --query-type SlaveHosts96 \
+    --query-type ReplicaHosts96 \
     --query-interpolate \
     --query-allow-nulls \
     --package models \
@@ -255,7 +255,7 @@ xo pgsql://${USERNAME}:${PASSWORD}@127.0.0.1:${PORT10}/?sslmode=disable \
     --query-trim \
     --query-interpolate \
     --query-allow-nulls \
-    --query-type SlaveHosts10 \
+    --query-type ReplicaHosts10 \
     --package models \
     --out ./ << ENDSQL
 SELECT application_name, client_addr, state, sent_offset - (replay_offset - (sent_lsn - replay_lsn) * 255 * 16 ^ 6 ) AS byte_lag

--- a/src/go/pt-pg-summary/models/replicahosts10.xo.go
+++ b/src/go/pt-pg-summary/models/replicahosts10.xo.go
@@ -20,25 +20,25 @@ import (
 	"database/sql"
 )
 
-// SlaveHosts96 represents a row from '[custom slave_hosts96]'.
-type SlaveHosts96 struct {
+// ReplicaHosts10 represents a row from '[custom replica_hosts10]'.
+type ReplicaHosts10 struct {
 	ApplicationName sql.NullString  // application_name
 	ClientAddr      sql.NullString  // client_addr
 	State           sql.NullString  // state
 	ByteLag         sql.NullFloat64 // byte_lag
 }
 
-// GetSlaveHosts96s runs a custom query, returning results as SlaveHosts96.
-func GetSlaveHosts96s(db XODB) ([]*SlaveHosts96, error) {
+// GetReplicaHosts10s runs a custom query, returning results as ReplicaHosts10.
+func GetReplicaHosts10s(db XODB) ([]*ReplicaHosts10, error) {
 	var err error
 
 	// sql query
-	sqlstr := `SELECT application_name, client_addr, state, sent_offset - (replay_offset - (sent_xlog - replay_xlog) * 255 * 16 ^ 6 ) AS byte_lag ` +
+	sqlstr := `SELECT application_name, client_addr, state, sent_offset - (replay_offset - (sent_lsn - replay_lsn) * 255 * 16 ^ 6 ) AS byte_lag ` +
 		`FROM ( SELECT application_name, client_addr, client_hostname, state, ` +
-		`('x' || lpad(split_part(sent_location::TEXT,   '/', 1), 8, '0'))::bit(32)::bigint AS sent_xlog, ` +
-		`('x' || lpad(split_part(replay_location::TEXT, '/', 1), 8, '0'))::bit(32)::bigint AS replay_xlog, ` +
-		`('x' || lpad(split_part(sent_location::TEXT,   '/', 2), 8, '0'))::bit(32)::bigint AS sent_offset, ` +
-		`('x' || lpad(split_part(replay_location::TEXT, '/', 2), 8, '0'))::bit(32)::bigint AS replay_offset ` +
+		`('x' || lpad(split_part(sent_lsn::TEXT,   '/', 1), 8, '0'))::bit(32)::bigint AS sent_lsn, ` +
+		`('x' || lpad(split_part(replay_lsn::TEXT, '/', 1), 8, '0'))::bit(32)::bigint AS replay_lsn, ` +
+		`('x' || lpad(split_part(sent_lsn::TEXT,   '/', 2), 8, '0'))::bit(32)::bigint AS sent_offset, ` +
+		`('x' || lpad(split_part(replay_lsn::TEXT, '/', 2), 8, '0'))::bit(32)::bigint AS replay_offset ` +
 		`FROM pg_stat_replication ) AS s`
 
 	// run query
@@ -50,9 +50,9 @@ func GetSlaveHosts96s(db XODB) ([]*SlaveHosts96, error) {
 	defer q.Close()
 
 	// load results
-	res := []*SlaveHosts96{}
+	res := []*ReplicaHosts10{}
 	for q.Next() {
-		sh := SlaveHosts96{}
+		sh := ReplicaHosts10{}
 
 		// scan
 		err = q.Scan(&sh.ApplicationName, &sh.ClientAddr, &sh.State, &sh.ByteLag)

--- a/src/go/pt-pg-summary/models/replicahosts96.xo.go
+++ b/src/go/pt-pg-summary/models/replicahosts96.xo.go
@@ -20,25 +20,25 @@ import (
 	"database/sql"
 )
 
-// SlaveHosts10 represents a row from '[custom slave_hosts10]'.
-type SlaveHosts10 struct {
+// ReplicaHosts96 represents a row from '[custom replica_hosts96]'.
+type ReplicaHosts96 struct {
 	ApplicationName sql.NullString  // application_name
 	ClientAddr      sql.NullString  // client_addr
 	State           sql.NullString  // state
 	ByteLag         sql.NullFloat64 // byte_lag
 }
 
-// GetSlaveHosts10s runs a custom query, returning results as SlaveHosts10.
-func GetSlaveHosts10s(db XODB) ([]*SlaveHosts10, error) {
+// GetReplicaHosts96s runs a custom query, returning results as ReplicaHosts96.
+func GetReplicaHosts96s(db XODB) ([]*ReplicaHosts96, error) {
 	var err error
 
 	// sql query
-	sqlstr := `SELECT application_name, client_addr, state, sent_offset - (replay_offset - (sent_lsn - replay_lsn) * 255 * 16 ^ 6 ) AS byte_lag ` +
+	sqlstr := `SELECT application_name, client_addr, state, sent_offset - (replay_offset - (sent_xlog - replay_xlog) * 255 * 16 ^ 6 ) AS byte_lag ` +
 		`FROM ( SELECT application_name, client_addr, client_hostname, state, ` +
-		`('x' || lpad(split_part(sent_lsn::TEXT,   '/', 1), 8, '0'))::bit(32)::bigint AS sent_lsn, ` +
-		`('x' || lpad(split_part(replay_lsn::TEXT, '/', 1), 8, '0'))::bit(32)::bigint AS replay_lsn, ` +
-		`('x' || lpad(split_part(sent_lsn::TEXT,   '/', 2), 8, '0'))::bit(32)::bigint AS sent_offset, ` +
-		`('x' || lpad(split_part(replay_lsn::TEXT, '/', 2), 8, '0'))::bit(32)::bigint AS replay_offset ` +
+		`('x' || lpad(split_part(sent_location::TEXT,   '/', 1), 8, '0'))::bit(32)::bigint AS sent_xlog, ` +
+		`('x' || lpad(split_part(replay_location::TEXT, '/', 1), 8, '0'))::bit(32)::bigint AS replay_xlog, ` +
+		`('x' || lpad(split_part(sent_location::TEXT,   '/', 2), 8, '0'))::bit(32)::bigint AS sent_offset, ` +
+		`('x' || lpad(split_part(replay_location::TEXT, '/', 2), 8, '0'))::bit(32)::bigint AS replay_offset ` +
 		`FROM pg_stat_replication ) AS s`
 
 	// run query
@@ -50,9 +50,9 @@ func GetSlaveHosts10s(db XODB) ([]*SlaveHosts10, error) {
 	defer q.Close()
 
 	// load results
-	res := []*SlaveHosts10{}
+	res := []*ReplicaHosts96{}
 	for q.Next() {
-		sh := SlaveHosts10{}
+		sh := ReplicaHosts96{}
 
 		// scan
 		err = q.Scan(&sh.ApplicationName, &sh.ClientAddr, &sh.State, &sh.ByteLag)

--- a/src/go/pt-pg-summary/templates/templates.go
+++ b/src/go/pt-pg-summary/templates/templates.go
@@ -16,12 +16,12 @@ package templates
 var TPL = `{{define "report"}}
 {{ template "port_and_datadir" .PortAndDatadir }}
 {{ template "tablespaces" .Tablespaces }}
-{{ if .SlaveHosts96 -}}
-  {{ template "slaves_and_lag" .SlaveHosts96 }}
-{{- else if .SlaveHosts10 -}}
-  {{ template "slaves_and_lag" .SlaveHosts10 }}
+{{ if .ReplicaHosts96 -}}
+  {{ template "replicas_and_lag" .ReplicaHosts96 }}
+{{- else if .ReplicaHosts10 -}}
+  {{ template "replicas_and_lag" .ReplicaHosts10 }}
 {{- else -}}
-  {{ template "slaves_and_log_none" }}
+  {{ template "replicas_and_lag_none" }}
 {{- end }}
 {{ template "cluster" .ClusterInfo }}
 {{ template "databases" .AllDatabases }}
@@ -56,8 +56,8 @@ var TPL = `{{define "report"}}
 +----------------------+----------------------+----------------------------------------------------+
 {{ end -}} {{/* end define */}}
 ` +
-	`{{ define "slaves_and_lag" -}}
-##### --- Slave and the lag with Master --- ####
+	`{{ define "replicas_and_lag" -}}
+##### --- Replicas and the lag with Primary --- ####
 +----------------------+----------------------+--------------------------------+-------------------+
 |  Application Name    |    Client Address    |           State                |      Lag          |
 +----------------------+----------------------+--------------------------------+-------------------+
@@ -70,9 +70,9 @@ var TPL = `{{define "report"}}
 +----------------------+----------------------+----------------------------------------------------+
 {{ end -}} {{/* end define */}}
 ` +
-	`{{- define "slaves_and_log_none" -}}
-##### --- Slave and the lag with Master --- ####
-There are no slave hosts
+	`{{- define "replicas_and_lag_none" -}}
+##### --- Replicas and the lag with Primary --- ####
+There are no replica hosts
 {{ end -}} {{/* end define */}}
 ` +
 	`{{ define "cluster" -}}
@@ -86,7 +86,7 @@ There are no slave hosts
  Client Hostname: {{ convertnullstring .ClientHostname | trim 90 }}
  Version        : {{ trim 90 .Version }}
  Started        : {{ printf "%v" .Started }}
- Is Slave       : {{ .IsSlave }}
+ Is Replica     : {{ .IsReplica }}
 +------------------------------------------------------------------------------------------------------+
 {{ end -}}
 {{ else -}}


### PR DESCRIPTION
## PT-1923: Offensive terminology elimination (Group 3, PostgreSQL)

Replaces `master`/`slave` with `primary`/`replica` across `pt-pg-summary`,
the only PostgreSQL-specific tool in the toolkit. All occurrences were the
tool's own naming — PostgreSQL itself never uses these terms; the SQL simply
aliased `pg_is_in_recovery()` as `Is_Slave` and read from `pg_stat_replication`.

**Changes**
- Report output: `Replicas and the lag with Primary`, `There are no replica hosts`, `Is Replica`
- `lib/pginfo`: `ReplicaHosts96/10` fields, log/error strings
- `models/`: `IsReplica`, SQL alias `Is_Replica`, `slavehosts{10,96}.xo.go` → `replicahosts{10,96}.xo.go`
- `models/gen.sh` updated so `xo` regeneration reproduces the new names
- Docs (`README.rst`, symlinked as `docs/pt-pg-summary.rst`)

No functional change. Verified: `gofmt` clean, `go build`, `go vet` pass.
