### PR TITLE
Auto-approval for Dependabot

### DIFF
--- a/.github/workflows/dependabot_auto_approve.yaml
+++ b/.github/workflows/dependabot_auto_approve.yaml
@@ -4,7 +4,7 @@
 # documentation.
 name: Dependabot auto-approve
 on:
-  pull_request:
+  pull_request_target:
     branches: [ "3.x" ]
 
 permissions:

--- a/.github/workflows/dependabot_auto_approve.yaml
+++ b/.github/workflows/dependabot_auto_approve.yaml
@@ -13,14 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'percona/percona-toolkit'
     steps:
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dependabot_auto_approve.yaml
+++ b/.github/workflows/dependabot_auto_approve.yaml
@@ -15,9 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'percona/percona-toolkit'
     steps:
-      - name: Approve a PR
-        run: gh pr review --approve "$PR_URL"
+      - name: Approve PR (if not already approved)
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          existing=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --jq '[.[] | select(.user.login=="github-actions[bot]" and .state=="APPROVED")] | length')
+          if [ "$existing" -eq 0 ]; then
+            gh pr review --repo "$REPO" --approve "$PR_NUMBER"
+          else
+            echo "Already approved by github-actions[bot]; skipping."
+          fi
 

--- a/.github/workflows/dependabot_auto_approve.yaml
+++ b/.github/workflows/dependabot_auto_approve.yaml
@@ -1,0 +1,26 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+name: Dependabot auto-approve
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'percona/percona-toolkit'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+

--- a/.github/workflows/dependabot_auto_approve.yaml
+++ b/.github/workflows/dependabot_auto_approve.yaml
@@ -3,7 +3,9 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 name: Dependabot auto-approve
-on: pull_request
+on:
+  pull_request:
+    branches: [ "3.x" ]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/dependabot_auto_approve.yaml
+++ b/.github/workflows/dependabot_auto_approve.yaml
@@ -1,7 +1,3 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
 name: Dependabot auto-approve
 on: pull_request
 


### PR DESCRIPTION
- Added auto-approval rule, so Dependabot PRs require single approver. Used GitHub documentation as example: https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/automate-dependabot-with-actions#automatically-approving-a-pull-request

- [x] The contributed code is licensed under GPL v2.0
- [x] Contributor Licence Agreement (CLA) is signed
- [ ] util/update-modules has been ran
- [ ] Documentation updated
- [ ] Test suite update
