### PR TITLE
Add a new option to support MariaDB Server syntax

### DIFF
--- a/bin/pt-show-grants
+++ b/bin/pt-show-grants
@@ -2094,7 +2094,16 @@ sub main {
                $create =~ s/IDENTIFIED AS/IDENTIFIED WITH mysql_native_password AS/;
             }
 
-            @create_user = ( $create, $alter );
+            # Or the other way around: port a MySQL CREATE/ALTER USER
+            # statement to MariaDB's syntax.
+            if ( ($version !~ m/MariaDB/) && $o->get('convert-to-MariaDB')){
+               my @alter_stmts = convert_to_mariadb($alter, $u->{User}, $u->{Host});
+               ($create) = convert_to_mariadb($create);
+               @create_user = ( $create, @alter_stmts );
+            }
+            else {
+               @create_user = ( $create, $alter );
+            }
             PTDEBUG && _d('Adjusted CREATE USER:', Dumper(\@create_user));
          }
       }
@@ -2270,6 +2279,100 @@ sub is_role {
         }
     }
     return 0;
+}
+
+# Plugins MariaDB has no auth-compatible equivalent for, but whose exact
+# on-disk hash format it can still verify -- provided the hash is written
+# straight into mysql.global_priv instead of through ALTER USER, whose
+# grammar only accepts a quoted string literal (not UNHEX() or a 0x...
+# literal) for the auth string, and these plugins' hashes contain binary
+# bytes that don't survive being quoted as plain SQL text.
+my %RAW_HASH_PLUGIN = map { $_ => 1 } qw(caching_sha2_password);
+
+sub convert_to_mariadb {
+   my ($stmt, $user, $host) = @_;
+   return () unless defined $stmt;
+   return ($stmt) unless length $stmt;
+
+   # These MySQL 8.0 password-management clauses have no MariaDB
+   # equivalent.  Left in place they cause a syntax error, so strip
+   # them out entirely.
+   $stmt =~ s/\s*PASSWORD HISTORY (?:DEFAULT|\d+)//;
+   $stmt =~ s/\s*PASSWORD REUSE INTERVAL (?:DEFAULT|\d+ DAY)//;
+   $stmt =~ s/\s*PASSWORD REQUIRE CURRENT(?: DEFAULT| OPTIONAL)?//;
+
+   # Nothing more to translate if there's no auth clause.
+   return ($stmt) unless $stmt =~ /IDENTIFIED\s+WITH/;
+
+   # MySQL's "IDENTIFIED WITH 'plugin' AS 'auth_string'" must become
+   # MariaDB's "IDENTIFIED VIA plugin USING 'auth_string'".  A few
+   # plugin names also need translating to their MariaDB equivalent.
+   # The auth string is normally a quoted string, but MySQL prints it
+   # as a 0x<hex> literal (print_identified_with_as_hex) whenever it
+   # contains bytes that aren't safe inside quotes -- which is always
+   # the case for the %RAW_HASH_PLUGIN plugins below.
+   my %plugin_map = (
+      mysql_native_password => 'mysql_native_password',
+      auth_socket            => 'unix_socket',
+   );
+
+   # Statements that must run after $stmt, once the account exists, to
+   # write the real hash for a %RAW_HASH_PLUGIN plugin.
+   my @after;
+   $stmt =~ s{
+      IDENTIFIED \s+ WITH \s+ '?([\w.]+)'?
+      (?:\s+ AS \s+ (0x[0-9A-Fa-f]+ | '(?:[^'\\]|\\.)*'))?
+   }{
+      my ($plugin, $auth_string) = ($1, $2);
+
+      if ( $RAW_HASH_PLUGIN{$plugin} ) {
+         if ( $auth_string && $auth_string =~ /^0x[0-9A-Fa-f]+$/ && $user && $host ) {
+            # Write the plugin name and the hash straight into
+            # mysql.global_priv instead of through ALTER USER, which
+            # would need the plugin installed and active on the target
+            # server just to accept it. Whether logins actually work
+            # is up to the server having a plugin installed (e.g.
+            # MariaDB's own auth_mysql_sha2, registered under the name
+            # caching_sha2_password) that understands this hash format.
+            push @after,
+               "UPDATE mysql.global_priv SET Priv = JSON_SET(Priv, "
+               . "'\$.plugin', " . _sql_quote($plugin) . ", "
+               . "'\$.authentication_string', UNHEX('"
+               . substr($auth_string, 2) . "')) WHERE User = "
+               . _sql_quote($user) . " AND Host = " . _sql_quote($host);
+            push @after, "FLUSH PRIVILEGES";
+         }
+         else {
+            warn "pt-show-grants: authentication plugin '$plugin' has no "
+               . "usable hex-encoded auth string to write into "
+               . "mysql.global_priv; the account will need its password "
+               . "set manually.\n";
+         }
+         ''; # Drop the clause; the plugin/hash are set via the UPDATE above.
+      }
+      else {
+         if ( !$plugin_map{$plugin} ) {
+            warn "pt-show-grants: authentication plugin '$plugin' has no "
+               . "direct MariaDB equivalent; the converted statement may "
+               . "need manual adjustment.\n";
+         }
+         my $mdb_plugin = $plugin_map{$plugin} || $plugin;
+         $auth_string ? "IDENTIFIED VIA $mdb_plugin USING $auth_string"
+                      : "IDENTIFIED VIA $mdb_plugin";
+      }
+   }xe;
+
+   $stmt =~ s/\s{2,}/ /g;
+   $stmt =~ s/\s+$//;
+   return ($stmt, @after);
+}
+
+# Quotes a value (an identifier's worth of text, e.g. a username or
+# hostname) as a single-quoted SQL string literal.
+sub _sql_quote {
+   my ($val) = @_;
+   $val =~ s/([\\'])/\\$1/g;
+   return "'$val'";
 }
 
 sub split_grants {
@@ -2503,6 +2606,44 @@ Only show grants for this comma-separated list of users.
 =item --convert-MariaDB
 
 Convert proprietary MariaDB syntax into valid MySQL form
+
+=item --convert-to-MariaDB
+
+Convert a MySQL CREATE/ALTER USER statement into valid MariaDB syntax.
+
+MySQL 8.0 added several C<CREATE USER>/C<ALTER USER> clauses (such as
+C<PASSWORD HISTORY>, C<PASSWORD REUSE INTERVAL> and C<PASSWORD REQUIRE
+CURRENT>) that MariaDB does not understand, and it also quotes the
+authentication plugin name differently (C<IDENTIFIED WITH 'plugin' AS
+'auth_string'> instead of MariaDB's C<IDENTIFIED VIA plugin USING
+'auth_string'>).  When this option is used against a MySQL server, those
+clauses are stripped or rewritten so the resulting statement can be
+replayed on a MariaDB server.
+
+C<mysql_native_password> and C<auth_socket> accounts convert to a plain
+C<ALTER USER ... IDENTIFIED VIA ...> statement.  C<caching_sha2_password>
+accounts (MySQL 8's default) need more: MariaDB has no plugin active by
+default that understands MySQL's hash for that plugin, and C<ALTER
+USER>'s grammar only accepts a quoted string literal, not an
+expression, for the auth string -- while the hash itself contains
+binary bytes that aren't safe to quote as plain text (which is exactly
+why MySQL prints it as a C<0x>-prefixed hex literal in the first
+place). So for these accounts the C<IDENTIFIED WITH ...> clause is
+dropped from the C<ALTER USER> entirely, and instead the tool emits an
+C<UPDATE mysql.global_priv> that sets both the plugin name and the
+real hash directly, via C<JSON_SET(..., UNHEX(...))>, followed by
+C<FLUSH PRIVILEGES>. This writes the account's authentication data
+correctly, but the account still won't be able to log in until the
+target server has a plugin that understands
+C<caching_sha2_password>-formatted hashes installed and active (e.g.
+MariaDB's own C<auth_mysql_sha2>, registered under the plugin name
+C<caching_sha2_password>, via C<INSTALL SONAME 'auth_mysql_sha2'> --
+this tool does not do that for you). Other authentication plugins with
+no MariaDB equivalent (e.g. C<sha256_password>) only get their syntax
+rewritten, with a warning that the password will need to be reset
+manually.
+
+This option has no effect when the source server is MariaDB.
 
 =item --password
 

--- a/bin/pt-show-grants
+++ b/bin/pt-show-grants
@@ -2371,7 +2371,7 @@ sub convert_to_mariadb {
 # hostname) as a single-quoted SQL string literal.
 sub _sql_quote {
    my ($val) = @_;
-   $val =~ s/([\\'])/\\$1/g;
+   $val =~ s/'/''/g;
    return "'$val'";
 }
 

--- a/t/pt-show-grants/convert_to_mariadb.t
+++ b/t/pt-show-grants/convert_to_mariadb.t
@@ -1,0 +1,131 @@
+#!/usr/bin/env perl
+
+BEGIN {
+   die "The PERCONA_TOOLKIT_BRANCH environment variable is not set.\n"
+      unless $ENV{PERCONA_TOOLKIT_BRANCH} && -d $ENV{PERCONA_TOOLKIT_BRANCH};
+   unshift @INC, "$ENV{PERCONA_TOOLKIT_BRANCH}/lib";
+};
+
+use strict;
+use warnings FATAL => 'all';
+use English qw(-no_match_vars);
+use Test::More;
+
+use PerconaTest;
+require "$trunk/bin/pt-show-grants";
+
+# This exercises pt_show_grants::convert_to_mariadb() directly, so it
+# needs no database connection: it's the pure string-rewriting half of
+# --convert-to-MariaDB.  The sub returns a LIST of statements (usually
+# just one), so every call below is made in list context.
+
+# The exact statement from PT-2547: a MySQL 8.0 ALTER USER with the
+# password-management clauses MariaDB doesn't understand.
+is_deeply(
+   [ pt_show_grants::convert_to_mariadb(
+      q{ALTER USER `wp_lefred`@`127.0.0.1` IDENTIFIED WITH 'mysql_native_password' AS '*FBA161068101DB224E8BE9350119DBF34A897DA4' REQUIRE NONE PASSWORD EXPIRE DEFAULT ACCOUNT UNLOCK PASSWORD HISTORY DEFAULT PASSWORD REUSE INTERVAL DEFAULT PASSWORD REQUIRE CURRENT DEFAULT}
+   ) ],
+   [ q{ALTER USER `wp_lefred`@`127.0.0.1` IDENTIFIED VIA mysql_native_password USING '*FBA161068101DB224E8BE9350119DBF34A897DA4' REQUIRE NONE PASSWORD EXPIRE DEFAULT ACCOUNT UNLOCK} ],
+   'Converts the PT-2547 ALTER USER statement to valid MariaDB syntax',
+);
+
+# auth_socket becomes MariaDB's unix_socket, with no USING clause.
+is_deeply(
+   [ pt_show_grants::convert_to_mariadb(
+      q{ALTER USER `root`@`localhost` IDENTIFIED WITH 'auth_socket' REQUIRE NONE PASSWORD EXPIRE DEFAULT ACCOUNT UNLOCK}
+   ) ],
+   [ q{ALTER USER `root`@`localhost` IDENTIFIED VIA unix_socket REQUIRE NONE PASSWORD EXPIRE DEFAULT ACCOUNT UNLOCK} ],
+   'Converts auth_socket to unix_socket',
+);
+
+# PASSWORD REQUIRE CURRENT can appear without a trailing DEFAULT/OPTIONAL.
+is_deeply(
+   [ pt_show_grants::convert_to_mariadb(
+      q{ALTER USER `u`@`%` IDENTIFIED WITH 'mysql_native_password' AS 'hash' PASSWORD REQUIRE CURRENT ACCOUNT LOCK}
+   ) ],
+   [ q{ALTER USER `u`@`%` IDENTIFIED VIA mysql_native_password USING 'hash' ACCOUNT LOCK} ],
+   'Strips a bare PASSWORD REQUIRE CURRENT clause',
+);
+
+# A statement with no IDENTIFIED clause, or nothing to convert, passes
+# through untouched (aside from stripped MySQL-8-only clauses).
+is_deeply(
+   [ pt_show_grants::convert_to_mariadb(
+      q{CREATE USER IF NOT EXISTS `sally`@`%`}
+   ) ],
+   [ q{CREATE USER IF NOT EXISTS `sally`@`%`} ],
+   'Leaves a statement with no IDENTIFIED clause unchanged',
+);
+
+is_deeply(
+   [ pt_show_grants::convert_to_mariadb(undef) ],
+   [],
+   'Handles undef input gracefully',
+);
+
+# An unmapped plugin with a plain quoted auth string (e.g.
+# sha256_password) still gets its syntax rewritten, and a warning is
+# issued -- there's no way to make the password actually work, but the
+# statement at least becomes valid SQL.
+{
+   my $warning;
+   local $SIG{__WARN__} = sub { $warning = $_[0]; };
+   is_deeply(
+      [ pt_show_grants::convert_to_mariadb(
+         q{ALTER USER `x`@`%` IDENTIFIED WITH 'sha256_password' AS '$5$somehash'}
+      ) ],
+      [ q{ALTER USER `x`@`%` IDENTIFIED VIA sha256_password USING '$5$somehash'} ],
+      'Rewrites the syntax even for a plugin with no MariaDB equivalent',
+   );
+   like(
+      $warning,
+      qr/sha256_password.*no direct MariaDB equivalent/,
+      'Warns about the unmapped plugin',
+   );
+}
+
+# caching_sha2_password has no MariaDB-compatible ALTER USER path (its
+# grammar only accepts a quoted string literal for the auth string, and
+# this plugin's hash is binary, which is why MySQL prints it as a 0x...
+# hex literal in the first place). The IDENTIFIED clause is dropped
+# from the ALTER USER entirely -- the tool does not install any plugin
+# -- and instead the plugin name and the unhexed hash are written
+# straight into mysql.global_priv, followed by a flush so the change
+# actually takes effect. Verified against a live MariaDB 11.4 server;
+# actually logging in still requires a compatible plugin (e.g.
+# MariaDB's own auth_mysql_sha2) to be installed and active on the
+# target server -- this tool leaves that to the DBA.
+is_deeply(
+   [ pt_show_grants::convert_to_mariadb(
+      q{ALTER USER `lefred`@`%` IDENTIFIED WITH caching_sha2_password AS 0x2441 REQUIRE NONE PASSWORD EXPIRE DEFAULT ACCOUNT UNLOCK},
+      'lefred', '%',
+   ) ],
+   [
+      q{ALTER USER `lefred`@`%` REQUIRE NONE PASSWORD EXPIRE DEFAULT ACCOUNT UNLOCK},
+      q{UPDATE mysql.global_priv SET Priv = JSON_SET(Priv, '$.plugin', 'caching_sha2_password', '$.authentication_string', UNHEX('2441')) WHERE User = 'lefred' AND Host = '%'},
+      q{FLUSH PRIVILEGES},
+   ],
+   'Converts a caching_sha2_password ALTER USER into the stripped ALTER USER plus a raw global_priv update, with no INSTALL SONAME',
+);
+
+# Without a user/host to target, there's nothing safe to UPDATE, so it
+# just warns instead of guessing -- but the IDENTIFIED clause is still
+# dropped, since it wouldn't work against MariaDB either way.
+{
+   my $warning;
+   local $SIG{__WARN__} = sub { $warning = $_[0]; };
+   is_deeply(
+      [ pt_show_grants::convert_to_mariadb(
+         q{ALTER USER `lefred`@`%` IDENTIFIED WITH caching_sha2_password AS 0x2441}
+      ) ],
+      [ q{ALTER USER `lefred`@`%`} ],
+      'Still drops the IDENTIFIED clause when no user/host is given',
+   );
+   like(
+      $warning,
+      qr/caching_sha2_password.*usable hex-encoded auth string/,
+      'Warns when it cannot target a global_priv update',
+   );
+}
+
+done_testing;


### PR DESCRIPTION
and allow user migration from MySQL to MariaDB
when using caching_sha2_password.

See https://lefred.be/content/dealing-with-caching_sha2_password-as-authentication-method-in-mariadb-server/

- [X] The contributed code is licensed under GPL v2.0
- [X] Contributor Licence Agreement (CLA) is signed
- [X] util/update-modules has been ran
- [ ] Documentation updated
- [X] Test suite update
